### PR TITLE
build: a few fixes to configure script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,13 +5,14 @@ check_PROGRAMS = test_console test_output test_vt
 noinst_LTLIBRARIES = libkmscon-core.la
 
 AM_CFLAGS = \
-	-Wall \
+	-Wall
+AM_CPPFLAGS = \
 	-I $(srcdir)/src
 AM_LDFLAGS = \
 	-Wl,--as-needed
 
 if DEBUG
-AM_CFLAGS += -g
+AM_CFLAGS += -O0 -g
 endif
 
 libkmscon_core_la_SOURCES = \
@@ -23,14 +24,16 @@ libkmscon_core_la_SOURCES = \
 	src/eloop.c src/eloop.h \
 	src/vt.c src/vt.h
 
-libkmscon_core_la_CFLAGS = \
-	$(AM_CFLAGS) \
+libkmscon_core_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(DRM_CFLAGS) \
 	$(EGL_CFLAGS) \
 	$(GBM_CFLAGS) \
 	$(OPENGL_CFLAGS) \
 	$(CAIRO_CFLAGS) \
 	$(PANGO_CFLAGS)
 libkmscon_core_la_LIBADD = \
+	$(DRM_LIBS) \
 	$(EGL_LIBS) \
 	$(GBM_LIBS) \
 	$(OPENGL_LIBS) \
@@ -39,24 +42,25 @@ libkmscon_core_la_LIBADD = \
 
 kmscon_SOURCES = src/main.c
 kmscon_LDADD = libkmscon-core.la
-kmscon_CFLAGS = \
-	$(AM_CFLAGS) \
-	$(CAIRO_CFLAGS)
 
 test_console_SOURCES = tests/test_console.c
-test_console_LDADD = libkmscon-core.la \
+test_console_LDADD = \
+	libkmscon-core.la \
 	$(OPENGL_LIBS)
-test_console_CFLAGS = $(kmscon_CFLAGS) \
-	$(OPENGL_CFLAGS)
+test_console_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(OPENGL_CFLAGS) \
+	$(CAIRO_CFLAGS)
 
 test_output_SOURCES = tests/test_output.c
-test_output_LDADD = libkmscon-core.la \
+test_output_LDADD = \
+	libkmscon-core.la \
 	$(OPENGL_LIBS)
-test_output_CPPFLAGS = $(kmscon_CFLAGS) \
+test_output_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
 	$(OPENGL_CFLAGS)
 
 test_vt_SOURCES = tests/test_vt.c
 test_vt_LDADD = libkmscon-core.la
-test_vt_CPPFLAGS = $(kmscon_CFLAGS)
 
 dist_doc_DATA = README TODO

--- a/configure.ac
+++ b/configure.ac
@@ -10,11 +10,20 @@ AC_CONFIG_HEADER(config.h)
 AM_INIT_AUTOMAKE([foreign 1.11 subdir-objects dist-bzip2 no-dist-gzip tar-pax -Wall -Werror])
 AM_SILENT_RULES([yes])
 
+# Don't add a default "-g -O2" if CFLAGS wasn't specified
+: ${CFLAGS=""}
+
+AC_USE_SYSTEM_EXTENSIONS
+AC_PROG_CC
+AC_PROG_CC_C99
+AM_PROG_CC_C_O
+
 LT_PREREQ(2.2)
 LT_INIT
 
-AC_PROG_CC
-AM_PROG_CC_C_O
+PKG_CHECK_MODULES([DRM], [libdrm])
+AC_SUBST(DRM_CFLAGS)
+AC_SUBST(DRM_LIBS)
 
 PKG_CHECK_MODULES([EGL], [egl])
 AC_SUBST(EGL_CFLAGS)


### PR DESCRIPTION
- Use C99 and gnu extensions.
- Explicitly link against libdrm (more strict linkers like gold would
  complain).
- Consistently use *_CPPFLAGS where due.
- Clear the default CFLAGS.

Signed-off-by: Ran Benita ran234@gmail.com
