### PR TITLE
A small fix to be able to get rid of debug messages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,10 +47,9 @@ AC_SUBST(PANGO_LIBS)
 
 AC_MSG_CHECKING([whether to build with debugging on])
 AC_ARG_ENABLE([debug],
-              [AS_HELP_STRING([--enable-debug],
-                              [whether to build with debugging on)])],
-                              [debug="$enableval"; AC_DEFINE([DEBUG], [0], [Debug])],
-                              [debug=no])
+              [AS_HELP_STRING([--enable-debug], [whether to build with debugging on)])],
+              [debug="$enableval"],
+              [debug=no; AC_DEFINE([NDEBUG], [1], [No Debug])])
 AM_CONDITIONAL([DEBUG], [test x$debug = xyes])
 AC_MSG_RESULT([$debug])
 

--- a/src/log.h
+++ b/src/log.h
@@ -38,6 +38,8 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
+#include "config.h"
+
 /* LOG_EMERG and LOG_ALERT do not make sense for this application */
 #define LOG_CRIT	"<2>" /* error that cannot be handled correctly */
 #define LOG_ERR		"<3>" /* error detected */


### PR DESCRIPTION
I personally prefer DEBUG, because I like to keep asserts on even in production. However, we don't use them here, so it hardly matters.
