### PR TITLE
ring: fix is_empty

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -85,7 +85,7 @@ bool kmscon_ring_is_empty(struct kmscon_ring *ring)
 	if (!ring)
 		return false;
 
-	return ring->first;
+	return ring->first == NULL;
 }
 
 int kmscon_ring_write(struct kmscon_ring *ring, const char *val, size_t len)


### PR DESCRIPTION
Hi,
Without this patch the first key stroke never does anything. But maybe I'm just confused...
Also I'm not sure returning 'false' when the argument is NULL is the right thing to do but I didn't change that.
