### PR TITLE
src/genunifont: Avoid format-security compiler warning

### DIFF
--- a/src/genunifont.c
+++ b/src/genunifont.c
@@ -82,10 +82,10 @@ static void print_data_row(FILE *out, char c)
 
 	idx = hex_val(c);
 	if (idx < 16) {
-		fprintf(out, line_map[idx]);
+		fputs(line_map[idx], out);
 	} else {
 		fprintf(stderr, "genunifont: invalid value %c\n", c);
-		fprintf(out, line_map[0]);
+		fputs(line_map[0], out);
 	}
 }
 


### PR DESCRIPTION
Current warning without the patch:
src/genunifont.c: In function 'print_data_row':
src/genunifont.c:85:3: warning: format not a string literal and no format arguments [-Wformat-security]
src/genunifont.c:88:3: warning: format not a string literal and no format arguments [-Wformat-security]
## 

Detlef
