### PR TITLE
Fixes a rendering problem of certain CJK fonts

### DIFF
--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -199,7 +199,7 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out,
 	bitmap.pixel_mode = FT_PIXEL_MODE_GRAY;
 	bitmap.buffer = glyph->buf.data;
 
-	pango_ft2_render_layout_line(&bitmap, line, -rec.x, -rec.y);
+	pango_ft2_render_layout_line(&bitmap, line, -rec.x, face->baseline);
 
 	pthread_mutex_lock(&face->glyph_lock);
 	ret = shl_hashtable_insert(face->glyphs, (void*)(long)id, glyph);


### PR DESCRIPTION
I recently switched to a new Chinese font on my computer and noticed
that it is not rendered correctly. The glyphs seemed to have been shifted downward.

Before this patch was applied:
![before](https://f.cloud.github.com/assets/3608694/231924/21e7e4be-871a-11e2-9f86-5b32b83b923e.png)
If you look closely enough you will find that the Chinese line appeared to be
shifted down some pixels.

After this patch was applied:
![after](https://f.cloud.github.com/assets/3608694/231926/425229d0-871a-11e2-9915-eb5277ba01ec.png)
Now the Chinese characters are rendered correctly.

I tested other fonts (CJK and Latin) I have on my computer and this patch solved the
rendering problem while not causing regressions (Latin glyphs continue to appear normal).
