### PR TITLE
Installation instructions were incorrect

### DIFF
--- a/README
+++ b/README
@@ -41,7 +41,8 @@ Released tarballs can be found at:
 == Install ==
 
   To compile the kmscon binary, run the standard autotools commands:
-    $ test -f ./configure || NOCONFIGURE=1 ./autogen.sh
+    $ test -f ./configure || NOCONFIGURE=1 
+    $ ./autogen.sh
     $ ./configure
     $ make
     $ make install


### PR DESCRIPTION
installation instructions were not working, at least 
if you already configured the project previously...
