### PR TITLE
tsm: support background color lightening via blink attribute

### DIFF
--- a/src/tsm_screen.h
+++ b/src/tsm_screen.h
@@ -90,6 +90,7 @@ struct tsm_screen_attr {
 	unsigned int underline : 1;	/* underlined character */
 	unsigned int inverse : 1;	/* inverse colors */
 	unsigned int protect : 1;	/* cannot be erased */
+  unsigned int blink : 1;		/* blinking character */
 };
 
 typedef int (*tsm_screen_prepare_cb) (struct tsm_screen *con,

--- a/src/tsm_vte.c
+++ b/src/tsm_vte.c
@@ -335,6 +335,9 @@ static void to_rgb(struct tsm_vte *vte, struct tsm_screen_attr *attr)
 
 	code = attr->bccode;
 	if (code >= 0) {
+		/* blink causes light colors */
+		if (attr->blink && code < 8)
+			code += 8;
 		if (code >= COLOR_NUM)
 			code = COLOR_BACKGROUND;
 
@@ -550,6 +553,7 @@ static void reset_state(struct tsm_vte *vte)
 	vte->saved_state.cattr.underline = 0;
 	vte->saved_state.cattr.inverse = 0;
 	vte->saved_state.cattr.protect = 0;
+  vte->saved_state.cattr.blink = 0;
 }
 
 static void save_state(struct tsm_vte *vte)
@@ -1039,12 +1043,16 @@ static void csi_attribute(struct tsm_vte *vte)
 			vte->cattr.bold = 0;
 			vte->cattr.underline = 0;
 			vte->cattr.inverse = 0;
+      vte->cattr.blink = 0;
 			break;
 		case 1:
 			vte->cattr.bold = 1;
 			break;
 		case 4:
 			vte->cattr.underline = 1;
+			break;
+		case 5:
+			vte->cattr.blink = 1;
 			break;
 		case 7:
 			vte->cattr.inverse = 1;
@@ -1054,6 +1062,9 @@ static void csi_attribute(struct tsm_vte *vte)
 			break;
 		case 24:
 			vte->cattr.underline = 0;
+			break;
+		case 25:
+			vte->cattr.blink = 0;
 			break;
 		case 27:
 			vte->cattr.inverse = 0;


### PR DESCRIPTION
According to http://misc.flogisoft.com/bash/tip_colors_and_formatting#terminals_compatibility several terminal emulators (Linux TTY included) use blink to set high-intensity background color. Rxvt doc states it as well: https://github.com/exg/rxvt-unicode/blob/master/README.FAQ#L319-L324
