### PR TITLE
Remove bashism in kmscon-launch-gui.sh

### DIFF
--- a/scripts/kmscon-launch-gui.sh
+++ b/scripts/kmscon-launch-gui.sh
@@ -11,7 +11,7 @@ if [ -d /sys/class/tty/tty0 ]; then
 fi
 
 if [ "${TERM_PROGRAM}" != "tmux" ]; then
-    printf "\x1B]setBackground\a"
+    printf "\033]setBackground\a"
 else
     printf "\033Ptmux;\033\033]setBackground\a\033\\"
 fi
@@ -26,7 +26,7 @@ if [ -n "${kms_tty}" ]; then
 fi
 
 if [ "${TERM_PROGRAM}" != "tmux" ]; then
-    printf "\x1B]setForeground\a"
+    printf "\033]setForeground\a"
 else
     printf "\033Ptmux;\033\033]setForeground\a\033\\"
 fi


### PR DESCRIPTION
\x1B] is not recognized by sh or dash, but should be \033] instead.
It makes this script to fail to run a GUI with dash or sh.

Example:
```
> dash
$ printf "\x1B]setBackground\a"
\x1B]setBackground$
$ printf "\033]setBackground\a"
$
```