### PR TITLE
Portable printf

### DIFF
--- a/scripts/kmscon-launch-gui.sh
+++ b/scripts/kmscon-launch-gui.sh
@@ -9,7 +9,7 @@ fi
 kms_tty=
 active_tty_file=/sys/class/tty/tty0/active
 if [ -f "$active_tty_file" ]; then
-    read -r kms_tty < /sys/class/tty/tty0/active
+    read -r kms_tty < "$active_tty_file"
 fi
 
 if [ "${TERM_PROGRAM}" != "tmux" ]; then


### PR DESCRIPTION
`printf '\x1B...` is not portable. For example it does not work if `sh` is `dash`. This change uses portable `printf '%b' '\033...` form.

Also removed useless `cat`s, read file directly.