### PR TITLE
More extensive kmscon-launch-gui.sh tweaks, inotifywait

### DIFF
--- a/scripts/kmscon-launch-gui.sh
+++ b/scripts/kmscon-launch-gui.sh
@@ -13,8 +13,8 @@ if [ -f "$active_tty_file" ]; then
 fi
 
 case "${TERM_PROGRAM}" in
-tmux) printf "\033Ptmux;\033\033]setBackground\a\033\\" ;;
-*) printf "\033]setBackground\a" ;;
+tmux) printf '\033Ptmux;\033\033]setBackground\a\033\\' ;;
+*) printf '\033]setBackground\a' ;;
 esac
 
 "$@"
@@ -34,6 +34,6 @@ if [ -n "${kms_tty}" ]; then
 fi
 
 case "${TERM_PROGRAM}" in
-tmux) printf "\033Ptmux;\033\033]setForeground\a\033\\" ;;
-*) printf "\033]setForeground\a" ;;
+tmux) printf '\033Ptmux;\033\033]setForeground\a\033\\' ;;
+*) printf '\033]setForeground\a' ;;
 esac


### PR DESCRIPTION
Continuation of #162 

Use `inotifywait` to monitor foreground console change, if available, otherwise fallback to sleep.

Use `case` for control sequence selectors as it is more compact, elegant, and handy for potential future variant additions.

apply `shfmt -s -sr` formatting.