### PR TITLE
logind: doesn't monitor seats if started with VT

### DIFF
--- a/src/kmscon_main.c
+++ b/src/kmscon_main.c
@@ -522,6 +522,7 @@ static void destroy_app(struct kmscon_app *app)
 static int setup_app(struct kmscon_app *app)
 {
 	int ret;
+	bool use_vt = (app->conf->vt != 0);
 
 	shl_dlist_init(&app->seats);
 
@@ -555,7 +556,7 @@ static int setup_app(struct kmscon_app *app)
 		goto err_app;
 	}
 
-	ret = uterm_monitor_new(&app->mon, app->eloop, app_monitor_event, app);
+	ret = uterm_monitor_new(&app->mon, app->eloop, app_monitor_event, use_vt, app);
 	if (ret) {
 		log_error("cannot create device monitor: %d", ret);
 		goto err_app;

--- a/src/uterm_monitor.c
+++ b/src/uterm_monitor.c
@@ -744,7 +744,7 @@ static void monitor_udev_event(struct ev_fd *fd, int mask, void *data)
 
 SHL_EXPORT
 int uterm_monitor_new(struct uterm_monitor **out, struct ev_eloop *eloop, uterm_monitor_cb cb,
-		      void *data)
+		      bool vt, void *data)
 {
 	struct uterm_monitor *mon;
 	int ret, ufd, set;
@@ -762,9 +762,12 @@ int uterm_monitor_new(struct uterm_monitor **out, struct ev_eloop *eloop, uterm_
 	mon->data = data;
 	shl_dlist_init(&mon->seats);
 
-	ret = monitor_sd_init(mon);
-	if (ret)
-		goto err_free;
+	/* Monitor seats if VT is disabled */
+	if (!vt) {
+		ret = monitor_sd_init(mon);
+		if (ret)
+			goto err_free;
+	}
 
 	mon->udev = udev_new();
 	if (!mon->udev) {

--- a/src/uterm_monitor.h
+++ b/src/uterm_monitor.h
@@ -79,7 +79,7 @@ typedef void (*uterm_monitor_cb)(struct uterm_monitor *mon, struct uterm_monitor
 				 void *data);
 
 int uterm_monitor_new(struct uterm_monitor **out, struct ev_eloop *eloop, uterm_monitor_cb cb,
-		      void *data);
+		      bool vt, void *data);
 void uterm_monitor_ref(struct uterm_monitor *mon);
 void uterm_monitor_unref(struct uterm_monitor *mon);
 void uterm_monitor_scan(struct uterm_monitor *mon);

--- a/tests/test_input.c
+++ b/tests/test_input.c
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
 		goto err_exit;
 	}
 
-	ret = uterm_monitor_new(&mon, eloop, monitor_event, NULL);
+	ret = uterm_monitor_new(&mon, eloop, monitor_event, true, NULL);
 	if (ret)
 		goto err_exit;
 


### PR DESCRIPTION
multiple seats doesn't work when VT are enabled, so don't try to monitor seats in this case.

This fixes the following error when starting sway from kmscon:

```
$ /usr/bin/kmscon-launch-gui /usr/bin/sway
00:00:00.001 [ERROR] [wlr] [libseat] [libseat/libseat.c:79] No backend was able to open a seat 
00:00:00.001 [ERROR] [wlr] [backend/session/session.c:83] Unable to create seat: Function not implemented 
00:00:00.001 [ERROR] [wlr] [backend/session/session.c:248] Failed to load session backend 
00:00:00.001 [ERROR] [wlr] [backend/backend.c:79] Failed to start a session 
00:00:00.001 [ERROR] [wlr] [backend/backend.c:407] Failed to start a DRM session 
00:00:00.001 [ERROR] [sway/server.c:228] Unable to create backend
```