### PR TITLE
Convert backspace delete to a runtime option, and enable it.

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -246,6 +246,14 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--backspace-delete</option></term>
+        <listitem>
+          <para>Send delete character when backspace is pressed.
+                (default: on)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--sb-size {size}</option></term>
         <listitem>
           <para>Specify the size of the scrollback buffer (in lines). (default: 1000)</para>

--- a/docs/man/kmscon.conf.1.xml.in
+++ b/docs/man/kmscon.conf.1.xml.in
@@ -200,6 +200,13 @@ font-name=Ubuntu Mono
       </varlistentry>
 
       <varlistentry>
+        <term><option>backspace-delete</option></term>
+        <listitem>
+          <para>Send delete character when backspace is pressed. (default: on)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>palette</option></term>
         <listitem>
           <para>Select the used color palette. (default: default)</para>

--- a/meson.build
+++ b/meson.build
@@ -121,7 +121,6 @@ endforeach
 config.set('BUILD_ENABLE_DEBUG', get_option('extra_debug'))
 config.set_quoted('BUILD_MODULE_DIR', prefix / moduledir)
 config.set_quoted('BUILD_CONFIG_DIR', prefix / sysconfdir)
-config.set10('BUILD_BACKSPACE_SENDS_DELETE', get_option('backspace_sends_delete'))
 
 # Make all files include "config.h" by default. This shouldn't cause any
 # problems and we cannot forget to include it anymore.
@@ -161,7 +160,6 @@ summary({
   'extra_debug': get_option('extra_debug'),
   'tests': get_option('tests'),
   'docs': enable_docs,
-  'backspace_sends_delete': get_option('backspace_sends_delete'),
 }, section: 'Miscellaneous')
 
 #

--- a/meson.options
+++ b/meson.options
@@ -34,7 +34,3 @@ option('session_dummy', type: 'feature', value: 'auto',
   description: 'dummy session')
 option('session_terminal', type: 'feature', value: 'auto',
   description: 'terminal session')
-
-# terminal options
-option('backspace_sends_delete', type: 'boolean', value: false,
-  description: 'backspace sends ASCII delete (0177) instead of ASCII backspace (010)')

--- a/scripts/etc/kmscon.conf
+++ b/scripts/etc/kmscon.conf
@@ -79,6 +79,12 @@
 ## value of the $TERM variable
 #term=kmscon
 
+## Reset environment [on]
+#reset-env
+
+## Send delete when backspace is pressed [on]
+#backspace-delete
+
 ## Scrollback buffer size, in lines
 #sb-size=10000
 

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -94,6 +94,9 @@ static void print_help()
 		"\t    --reset-env             [on]\n"
 		"\t                              Reset environment before running child\n"
 		"\t                              process\n"
+		"\t    --backspace-delete      [on]\n"
+		"\t                              Send delete character when backspace is\n"
+		"\t                              pressed\n"
 		"\t    --sb-size <num>         [1000]\n"
 		"\t                              Size of the scrollback-buffer in lines\n"
 		"\n"
@@ -708,6 +711,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 			    &conf->login, false),
 		CONF_OPTION_STRING('t', "term", &conf->term, "xterm-256color"),
 		CONF_OPTION_BOOL(0, "reset-env", &conf->reset_env, true),
+		CONF_OPTION_BOOL(0, "backspace-delete", &conf->backspace_delete, true),
 		CONF_OPTION_UINT(0, "sb-size", &conf->sb_size, 1000),
 
 		/* Input Options */

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -91,6 +91,8 @@ struct kmscon_conf_t {
 	char *term;
 	/* reset environment */
 	bool reset_env;
+	/* Send delete when backspace is pressed */
+	bool backspace_delete;
 	/* terminal scroll-back buffer size */
 	unsigned int sb_size;
 

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -935,7 +935,7 @@ int kmscon_terminal_register(struct kmscon_session **out, struct kmscon_seat *se
 	if (ret)
 		goto err_con;
 
-	tsm_vte_set_backspace_sends_delete(term->vte, BUILD_BACKSPACE_SENDS_DELETE);
+	tsm_vte_set_backspace_sends_delete(term->vte, term->conf->backspace_delete);
 
 	tsm_vte_set_osc_cb(term->vte, osc_event, (void *)term);
 	tsm_vte_set_mouse_cb(term->vte, mouse_event, (void *)term);
@@ -957,7 +957,8 @@ int kmscon_terminal_register(struct kmscon_session **out, struct kmscon_seat *se
 		goto err_font;
 
 	ret = kmscon_pty_set_conf(term->pty, term->conf->term, "kmscon", term->conf->argv,
-				  kmscon_seat_get_name(seat), term->conf->reset_env);
+				  kmscon_seat_get_name(seat), term->conf->reset_env,
+				  term->conf->backspace_delete);
 	if (ret)
 		goto err_pty;
 

--- a/src/pty.h
+++ b/src/pty.h
@@ -53,7 +53,7 @@ int kmscon_pty_new(struct kmscon_pty **out, kmscon_pty_input_cb input_cb, void *
 void kmscon_pty_ref(struct kmscon_pty *pty);
 void kmscon_pty_unref(struct kmscon_pty *pty);
 int kmscon_pty_set_conf(struct kmscon_pty *pty, const char *term, const char *colorterm,
-			char **argv, const char *seat, bool do_reset);
+			char **argv, const char *seat, bool do_reset, bool backspace);
 
 int kmscon_pty_get_fd(struct kmscon_pty *pty);
 void kmscon_pty_dispatch(struct kmscon_pty *pty);


### PR DESCRIPTION
So it's easier to configure, and do that by default, as is it's the default in xterm.