### PR TITLE
Enable mouse support by default

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -331,7 +331,7 @@
       <varlistentry>
         <term><option>--mouse</option></term>
         <listitem>
-          <para>Enable mouse/touchpad/trackpoint in kmscon (default: off).
+          <para>Enable mouse/touchpad/trackpoint in kmscon (default: on).
                 It allows to select, and copy/paste text with a pointing device,
                 and also to scroll with the mouse wheel.
                 It's still experimental, and may not work with specific devices.

--- a/docs/man/kmscon.conf.1.xml.in
+++ b/docs/man/kmscon.conf.1.xml.in
@@ -266,7 +266,7 @@ font-name=Ubuntu Mono
       <varlistentry>
         <term><option>--mouse</option></term>
         <listitem>
-          <para>Enable mouse/touchpad/trackpoint in kmscon (default: off).
+          <para>Enable mouse/touchpad/trackpoint in kmscon (default: on).
                 It allows to select, and copy/paste text with a pointing device,
                 and also to scroll with the mouse wheel.
                 It's still experimental, and may not work with specific devices.

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -110,8 +110,8 @@ static void print_help()
 		"\t                                 Initial delay for key-repeat in ms\n"
 		"\t    --xkb-repeat-rate <msecs>  [50]\n"
 		"\t                                 Delay between two key repeats in ms\n"
-		"\t    --mouse                    [off]\n"
-		"\t                                 Enable experimental mouse support\n"
+		"\t    --mouse                    [on]\n"
+		"\t                                 Enable mouse support\n"
 		"\n"
 		"Grabs / Keyboard-Shortcuts:\n"
 		"\t    --grab-scroll-up <grab>     [<Shift>Up]\n"
@@ -719,7 +719,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_STRING(0, "xkb-compose-file", &conf->xkb_compose_file, ""),
 		CONF_OPTION_UINT(0, "xkb-repeat-delay", &conf->xkb_repeat_delay, 250),
 		CONF_OPTION_UINT(0, "xkb-repeat-rate", &conf->xkb_repeat_rate, 50),
-		CONF_OPTION_BOOL(0, "mouse", &conf->mouse, false),
+		CONF_OPTION_BOOL(0, "mouse", &conf->mouse, true),
 
 		/* Grabs / Keyboard-Shortcuts */
 		CONF_OPTION_GRAB(0, "grab-scroll-up", &conf->grab_scroll_up, &def_grab_scroll_up),


### PR DESCRIPTION
Mouse support was added in 9.2.0, and there are no issue raised about it, so let's enable it by default.