### PR TITLE
Forward mouse wheel events to applications in mouse tracking mode

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -683,6 +683,9 @@ static void forward_pointer_event(struct kmscon_terminal *term,
 				  struct uterm_input_pointer_event *ev)
 {
 	unsigned int event;
+	unsigned int button;
+
+	button = ev->button;
 
 	switch (ev->event) {
 	case UTERM_MOVED:
@@ -694,11 +697,19 @@ static void forward_pointer_event(struct kmscon_terminal *term,
 		else
 			event = TSM_MOUSE_EVENT_RELEASED;
 		break;
+	case UTERM_WHEEL:
+		/* Convert wheel events to button 4 (scroll up) or 5 (scroll down) */
+		event = TSM_MOUSE_EVENT_PRESSED;
+		if (ev->wheel > 0)
+			button = 4; /* Scroll up */
+		else
+			button = 5; /* Scroll down */
+		break;
 	default:
 		return;
 	}
 	tsm_vte_handle_mouse(term->vte, term->pointer.posx, term->pointer.posy, term->pointer.x,
-			     term->pointer.y, ev->button, event, 0);
+			     term->pointer.y, button, event, 0);
 }
 
 static void handle_pointer_button(struct kmscon_terminal *term,


### PR DESCRIPTION
Fixes mouse wheel support in applications that use mouse tracking mode (e.g., vim, less, tmux).

## Problem
When an application enables mouse tracking (like vim with ), kmscon was not forwarding mouse wheel events to the application. The wheel events were only used for scrolling kmscon's own terminal history, even when the application explicitly requested mouse input.

## Solution
This PR adds support for forwarding mouse wheel events to applications by converting them to button events following the xterm mouse protocol:
- Wheel up → button 4
- Wheel down → button 5

## Behavior
- **With mouse tracking enabled** (vim , less, etc.): Mouse wheel scrolls the application content
- **Without mouse tracking** (shell prompt): Mouse wheel scrolls kmscon terminal history (existing behavior preserved)

## Changes
- Modified  in :
  - Added  case to handle wheel events
  - Convert wheel direction to button 4/5 according to xterm protocol
  - Added local  variable to allow modification before forwarding

## Testing
- Tested with vim (): wheel scrolls vim content ✓
- Tested with bash: wheel scrolls terminal history ✓
- Tested with less: wheel scrolls less content ✓

This fix brings kmscon's mouse wheel behavior in line with other terminal emulators like xterm, urxvt, and gnome-terminal.