### PR TITLE
Don't print function/file for log_notice

### DIFF
--- a/src/kmscon_main.c
+++ b/src/kmscon_main.c
@@ -609,7 +609,7 @@ int main(int argc, char **argv)
 		goto err_unload;
 
 	if (!app.conf->listen && !app.running_seats) {
-		log_notice("no running seats; exiting");
+		log_notice("no running seats; exiting\n");
 	} else {
 		log_debug("%u running seats after startup", app.running_seats);
 		ev_eloop_run(app.eloop, -1);

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -517,7 +517,7 @@ static int add_display(struct kmscon_terminal *term, struct uterm_display *disp)
 
 	shl_dlist_link(&term->screens, &scr->list);
 
-	log_notice("Using video backend [%s] with text renderer [%s] and font engine [%s]",
+	log_notice("Using video backend [%s] with text renderer [%s] and font engine [%s]\n",
 		   uterm_display_backend_name(disp), scr->txt->ops->name, term->font->ops->name);
 
 	log_debug("added display %p to terminal %p", disp, term);

--- a/src/shl_log.c
+++ b/src/shl_log.c
@@ -448,6 +448,6 @@ void log_print_init(const char *appname)
 {
 	if (!appname)
 		appname = "<unknown>";
-	log_format(LOG_DEFAULT_CONF, NULL, LOG_NOTICE, "%s Revision %s %s %s", appname,
+	log_format(LOG_DEFAULT_CONF, NULL, LOG_NOTICE, "%s Revision %s %s %s\n", appname,
 		   shl_git_head, __DATE__, __TIME__);
 }

--- a/src/uterm_vt.c
+++ b/src/uterm_vt.c
@@ -277,7 +277,7 @@ static int open_tty(const char *dev, int *tty_fd, int *tty_num)
 	if (!dev || !tty_fd || !tty_num)
 		return -EINVAL;
 
-	log_notice("using tty %s", dev);
+	log_notice("using tty %s\n", dev);
 
 	fd = open(dev, O_RDWR | O_NOCTTY | O_CLOEXEC);
 	if (fd < 0) {


### PR DESCRIPTION
Adding \n at the end of the log string remove the function name, and file line.
For generic message, this just clutter the logs.