### PR TITLE
Bbulk damage

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -439,21 +439,3 @@ int kmscon_font_render_inval(struct kmscon_font *font, const struct kmscon_glyph
 
 	return font->ops->render_inval(font, out);
 }
-
-/**
- * kmscon_font_render:
- * @font: Valid font object
- * @ch: Symbol to find a glyph for
- * @len: Length of @ch
- *
- * Detects if the given character would overflow into the next cell.
- *
- * Returns: true when overflow needed, false when no overflow needed or on error
- */
-bool kmscon_font_get_overflow(struct kmscon_font *font, uint64_t id, const uint32_t *ch, size_t len)
-{
-	if (!font || !font->ops->get_overflow)
-		return false;
-
-	return font->ops->get_overflow(font, id, ch, len);
-}

--- a/src/font.h
+++ b/src/font.h
@@ -83,7 +83,6 @@ struct kmscon_font_ops {
 		      const struct kmscon_glyph **out);
 	int (*render_empty)(struct kmscon_font *font, const struct kmscon_glyph **out);
 	int (*render_inval)(struct kmscon_font *font, const struct kmscon_glyph **out);
-	bool (*get_overflow)(struct kmscon_font *font, uint64_t id, const uint32_t *ch, size_t len);
 };
 
 int kmscon_font_register(const struct kmscon_font_ops *ops);
@@ -98,8 +97,6 @@ int kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch
 		       const struct kmscon_glyph **out);
 int kmscon_font_render_empty(struct kmscon_font *font, const struct kmscon_glyph **out);
 int kmscon_font_render_inval(struct kmscon_font *font, const struct kmscon_glyph **out);
-bool kmscon_font_get_overflow(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
-			      size_t len);
 
 /* modularized backends */
 

--- a/src/font_8x16.c
+++ b/src/font_8x16.c
@@ -109,7 +109,6 @@ struct kmscon_font_ops kmscon_font_8x16_ops = {
 	.render = kmscon_font_8x16_render,
 	.render_empty = kmscon_font_8x16_render_empty,
 	.render_inval = kmscon_font_8x16_render_inval,
-	.get_overflow = NULL,
 };
 
 static const struct kmscon_glyph kmscon_font_8x16_glyphs[256] = {

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -459,20 +459,6 @@ static int kmscon_font_pango_render_inval(struct kmscon_font *font, const struct
 	return kmscon_font_pango_render(font, question_mark, &question_mark, 1, out);
 }
 
-static bool kmscon_font_pango_get_overflow(struct kmscon_font *font, uint64_t id,
-					   const uint32_t *ch, size_t len)
-{
-	struct face *face = font->data;
-	unsigned int cwidth;
-	struct kmscon_glyph *glyph;
-
-	if (get_glyph(face, &glyph, id, ch, len, &font->attr) < 0)
-		return false;
-
-	cwidth = tsm_ucs4_get_width(*ch);
-	return (glyph->width == 2 && cwidth == 1);
-}
-
 struct kmscon_font_ops kmscon_font_pango_ops = {
 	.name = "pango",
 	.owner = NULL,
@@ -481,5 +467,4 @@ struct kmscon_font_ops kmscon_font_pango_ops = {
 	.render = kmscon_font_pango_render,
 	.render_empty = kmscon_font_pango_render_empty,
 	.render_inval = kmscon_font_pango_render_inval,
-	.get_overflow = kmscon_font_pango_get_overflow,
 };

--- a/src/font_rotate.c
+++ b/src/font_rotate.c
@@ -50,7 +50,7 @@ void kmscon_rotate_free_tables(struct shl_hashtable *normal, struct shl_hashtabl
 }
 
 SHL_EXPORT
-int kmscon_rotate_glyph(struct uterm_video_buffer *vb, const struct kmscon_glyph *glyph,
+int kmscon_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyph,
 			enum Orientation orientation, uint8_t align)
 {
 	int width;
@@ -69,13 +69,13 @@ int kmscon_rotate_glyph(struct uterm_video_buffer *vb, const struct kmscon_glyph
 	}
 
 	stride = align * ((width + (align - 1)) / align);
-	vb->data = malloc(stride * height);
+	vb->buf.data = malloc(stride * height);
 
-	if (!vb->data)
+	if (!vb->buf.data)
 		return -ENOMEM;
 
 	src = buf->data;
-	dst = vb->data;
+	dst = vb->buf.data;
 
 	switch (orientation) {
 	default:
@@ -111,9 +111,10 @@ int kmscon_rotate_glyph(struct uterm_video_buffer *vb, const struct kmscon_glyph
 			src += buf->stride;
 		}
 	}
-	vb->width = width;
-	vb->height = height;
-	vb->stride = stride;
-	vb->format = buf->format;
+	vb->buf.width = width;
+	vb->buf.height = height;
+	vb->buf.stride = stride;
+	vb->buf.format = buf->format;
+	vb->width = glyph->width;
 	return 0;
 }

--- a/src/font_rotate.h
+++ b/src/font_rotate.h
@@ -29,5 +29,5 @@
 int kmscon_rotate_create_tables(struct shl_hashtable **normal, struct shl_hashtable **bold,
 				shl_free_cb free_glyph);
 void kmscon_rotate_free_tables(struct shl_hashtable *normal, struct shl_hashtable *bold);
-int kmscon_rotate_glyph(struct uterm_video_buffer *vb, const struct kmscon_glyph *glyph,
+int kmscon_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyph,
 			enum Orientation orientation, uint8_t align);

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -261,5 +261,4 @@ struct kmscon_font_ops kmscon_font_unifont_ops = {
 	.render = kmscon_font_unifont_render,
 	.render_empty = kmscon_font_unifont_render_empty,
 	.render_inval = kmscon_font_unifont_render_inval,
-	.get_overflow = NULL,
 };

--- a/src/text.c
+++ b/src/text.c
@@ -442,17 +442,10 @@ int kmscon_text_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, s
 		     unsigned int width, unsigned int posx, unsigned int posy,
 		     const struct tsm_screen_attr *attr)
 {
-	bool previous_overflow;
-
 	if (!txt || !txt->rendering)
 		return -EINVAL;
 	if (posx >= txt->cols || posy >= txt->rows || !attr)
 		return -EINVAL;
-
-	previous_overflow = txt->overflow_next;
-	txt->overflow_next = kmscon_font_get_overflow(txt->font, id, ch, len);
-	if (previous_overflow && !len && posx && !attr->inverse)
-		return 0;
 
 	return txt->ops->draw(txt, id, ch, len, width, posx, posy, attr);
 }


### PR DESCRIPTION
bbulk: Add damage support

Only redraw the part of the frame that changed.
Instead of repainting the whole buffer.
This improve performances, particularly when moving the mouse cursor.

To be really efficient, it needs to send the damage rectangle to the
drm device, but this will be done in a later patch.