### PR TITLE
Fix typo in kmscon.1

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -188,7 +188,7 @@
         <term><option>--session-control</option></term>
         <listitem>
           <para>Allow keyboard-shortcuts to control the session manager. This
-                allows the use to create new sessions, kill sessions and switch
+                allows the user to create new sessions, kill sessions and switch
                 sessions via keyboard input. (default: off)</para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
Originally reported at https://bugs.debian.org/1098993 .