### PR TITLE
Add grab-reboot option to example config file

### DIFF
--- a/scripts/etc/kmscon.conf
+++ b/scripts/etc/kmscon.conf
@@ -71,6 +71,8 @@
 #grab-terminal-new=<Ctrl><Logo>Return
 #grab-rotate-cw=<Logo>Plus
 #grab-rotate-ccw=<Logo>Minus
+## Reboot system (disabled by default, use with caution - immediate reboot without confirmation)
+#grab-reboot=<Ctrl><Alt>Delete
 
 ## Enable mouse
 #mouse


### PR DESCRIPTION
Document the grab-reboot keyboard shortcut in the example configuration file.

The grab-reboot feature allows users to configure a keyboard shortcut (e.g., Ctrl+Alt+Delete) to trigger an immediate system reboot. This option is already fully implemented in kmscon with:
- Code implementation in src/kmscon_seat.c
- CLI option --grab-reboot documented in --help
- Man pages documentation (kmscon.1 and kmscon.conf.1)

This PR adds the missing commented example line in scripts/etc/kmscon.conf to help users discover and configure this feature. The option is disabled by default for security reasons, and includes an appropriate warning about the immediate reboot without confirmation.