### PR TITLE
Fix mouse selection can crash kmscon

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -150,10 +150,10 @@ static void coord_to_cell(struct kmscon_terminal *term, int32_t x, int32_t y, un
 	*posy = y / fh;
 
 	if (*posx >= w)
-		*posx = w;
+		*posx = w - 1;
 
 	if (*posy >= h)
-		*posy = h;
+		*posy = h - 1;
 }
 
 static void draw_pointer(struct screen *scr)


### PR DESCRIPTION
Sometime kmscon crashes with the following stack trace:

    Module libxkbcommon.so.0 from rpm libxkbcommon-1.8.1-1.fc42.x86_64
    Stack trace of thread 6732:
    #0  0x00007f8b79de9974 calc_line_len (libtsm.so.4 + 0x3974)
    #1  0x00007f8b79dea153 copy_lines (libtsm.so.4 + 0x4153)
    #2  0x000000000040cd7b copy_selection (/usr/local/libexec/kmscon/kmscon + 0xcd7b)
    #3  0x000000000041d3bd shl_hook_call (/usr/local/libexec/kmscon/kmscon + 0x1d3bd)
    #4  0x000000000041d9f6 pointer_dev_button (/usr/local/libexec/kmscon/kmscon + 0x1d9f6)
    #5  0x000000000041b18d notify_event (/usr/local/libexec/kmscon/kmscon + 0x1b18d)
    #6  0x0000000000411dd7 ev_eloop_dispatch (/usr/local/libexec/kmscon/kmscon + 0x11dd7)
    #7  0x00000000004124e2 ev_eloop_run (/usr/local/libexec/kmscon/kmscon + 0x124e2)
    #8  0x0000000000401688 main (/usr/local/libexec/kmscon/kmscon + 0x1688)
    #9  0x00007f8b79a76575 __libc_start_call_main (libc.so.6 + 0x3575)
    #10 0x00007f8b79a76628 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x3628)
    #11 0x0000000000401a25 _start (/usr/local/libexec/kmscon/kmscon + 0x1a25)

The root cause is a off by one error in coord_to_cell(), so the selected cell can be outside the terminal.