### PR TITLE
text: add default attribute to prepare()

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -158,17 +158,15 @@ static void coord_to_cell(struct kmscon_terminal *term, int32_t x, int32_t y, un
 
 static void draw_pointer(struct screen *scr)
 {
-	struct tsm_screen_attr attr;
-
 	if (!scr->term->pointer.visible)
 		return;
 
-	tsm_vte_get_def_attr(scr->term->vte, &attr);
-	kmscon_text_draw_pointer(scr->txt, scr->term->pointer.x, scr->term->pointer.y, &attr);
+	kmscon_text_draw_pointer(scr->txt, scr->term->pointer.x, scr->term->pointer.y);
 }
 
 static void do_redraw_screen(struct screen *scr)
 {
+	struct tsm_screen_attr attr;
 	int ret;
 
 	if (!scr->term->awake || !kmscon_session_get_foreground(scr->term->session))
@@ -177,7 +175,8 @@ static void do_redraw_screen(struct screen *scr)
 	scr->pending = false;
 	do_clear_margins(scr);
 
-	kmscon_text_prepare(scr->txt);
+	tsm_vte_get_def_attr(scr->term->vte, &attr);
+	kmscon_text_prepare(scr->txt, &attr);
 	tsm_screen_draw(scr->term->console, kmscon_text_draw_cb, scr->txt);
 	draw_pointer(scr);
 	kmscon_text_render(scr->txt);

--- a/src/text.c
+++ b/src/text.c
@@ -394,6 +394,7 @@ int kmscon_text_rotate(struct kmscon_text *txt, enum Orientation orientation)
 /**
  * kmscon_text_prepare:
  * @txt: valid text renderer
+ * @attr: glyph attributes
  *
  * This starts a rendering-round. When rendering a console via a text renderer,
  * you have to call this first, then render all your glyphs via
@@ -404,7 +405,7 @@ int kmscon_text_rotate(struct kmscon_text *txt, enum Orientation orientation)
  *
  * Returns: 0 on success, negative error code on failure.
  */
-int kmscon_text_prepare(struct kmscon_text *txt)
+int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr)
 {
 	int ret = 0;
 
@@ -413,7 +414,7 @@ int kmscon_text_prepare(struct kmscon_text *txt)
 
 	txt->rendering = true;
 	if (txt->ops->prepare)
-		ret = txt->ops->prepare(txt);
+		ret = txt->ops->prepare(txt, attr);
 	if (ret)
 		txt->rendering = false;
 
@@ -455,7 +456,6 @@ int kmscon_text_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, s
  * @txt: valid text renderer
  * @x: X-position of the center of the pointer in pixel
  * @y: Y-position of the center of the pointer in pixel
- * @attr: glyph attributes
  *
  * This draws a single I glyph at the requested position. The position is a
  * a pixel position! You must precede this call with kmscon_text_prepare().
@@ -464,13 +464,12 @@ int kmscon_text_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, s
  *
  * Returns: 0 on success or negative error code if it couldn't be drawn.
  */
-int kmscon_text_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned int y,
-			     const struct tsm_screen_attr *attr)
+int kmscon_text_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned int y)
 {
 	if (!txt || !txt->rendering || !txt->ops->draw_pointer)
 		return -EINVAL;
 
-	return txt->ops->draw_pointer(txt, x, y, attr);
+	return txt->ops->draw_pointer(txt, x, y);
 }
 
 /**

--- a/src/text.h
+++ b/src/text.h
@@ -76,12 +76,11 @@ struct kmscon_text_ops {
 	int (*set)(struct kmscon_text *txt);
 	void (*unset)(struct kmscon_text *txt);
 	int (*rotate)(struct kmscon_text *txt, enum Orientation orientation);
-	int (*prepare)(struct kmscon_text *txt);
+	int (*prepare)(struct kmscon_text *txt, struct tsm_screen_attr *attr);
 	int (*draw)(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, size_t len,
 		    unsigned int width, unsigned int posx, unsigned int posy,
 		    const struct tsm_screen_attr *attr);
-	int (*draw_pointer)(struct kmscon_text *txt, unsigned int x, unsigned int y,
-			    const struct tsm_screen_attr *attr);
+	int (*draw_pointer)(struct kmscon_text *txt, unsigned int x, unsigned int y);
 	int (*render)(struct kmscon_text *txt);
 	void (*abort)(struct kmscon_text *txt);
 };
@@ -105,12 +104,11 @@ unsigned int kmscon_text_get_rows(struct kmscon_text *txt);
 enum Orientation kmscon_text_get_orientation(struct kmscon_text *txt);
 int kmscon_text_rotate(struct kmscon_text *txt, enum Orientation orientation);
 
-int kmscon_text_prepare(struct kmscon_text *txt);
+int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr);
 int kmscon_text_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, size_t len,
 		     unsigned int width, unsigned int posx, unsigned int posy,
 		     const struct tsm_screen_attr *attr);
-int kmscon_text_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned int y,
-			     const struct tsm_screen_attr *attr);
+int kmscon_text_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned int y);
 int kmscon_text_render(struct kmscon_text *txt);
 void kmscon_text_abort(struct kmscon_text *txt);
 

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -64,6 +64,7 @@ struct bbulk {
 	struct uterm_video_blend_req *reqs;
 	unsigned int req_len;
 	unsigned int req_total_len;
+	struct tsm_screen_attr attr;
 	struct shl_hashtable *glyphs;
 	struct shl_hashtable *bold_glyphs;
 	struct bbcell *prev;
@@ -447,7 +448,7 @@ static void set_pointer_coordinate(struct bbulk *bb, struct kmscon_text *txt,
 }
 
 static int bblit_draw_pointer(struct kmscon_text *txt, unsigned int pointer_x,
-			      unsigned int pointer_y, const struct tsm_screen_attr *attr)
+			      unsigned int pointer_y)
 {
 	struct bbulk *bb = txt->data;
 	struct uterm_video_blend_req *req;
@@ -463,19 +464,19 @@ static int bblit_draw_pointer(struct kmscon_text *txt, unsigned int pointer_x,
 	req = &bb->reqs[bb->req_len++];
 	mark_damaged(txt, bb, pointer_x, pointer_y);
 
-	ret = find_glyph(txt, &bb_glyph, id, &ch, 1, attr);
+	ret = find_glyph(txt, &bb_glyph, id, &ch, 1, &bb->attr);
 	if (ret)
 		return ret;
 
 	req->buf = &bb_glyph->buf;
 	set_pointer_coordinate(bb, txt, req, pointer_x, pointer_y);
 
-	req->fr = attr->fr;
-	req->fg = attr->fg;
-	req->fb = attr->fb;
-	req->br = attr->br;
-	req->bg = attr->bg;
-	req->bb = attr->bb;
+	req->fr = bb->attr.fr;
+	req->fg = bb->attr.fg;
+	req->fb = bb->attr.fb;
+	req->br = bb->attr.br;
+	req->bg = bb->attr.bg;
+	req->bb = bb->attr.bb;
 	return 0;
 }
 
@@ -489,7 +490,7 @@ static int bbulk_render(struct kmscon_text *txt)
 	return ret;
 }
 
-static int bbulk_prepare(struct kmscon_text *txt)
+static int bbulk_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr)
 {
 	struct bbulk *bb = txt->data;
 	int i;
@@ -499,6 +500,8 @@ static int bbulk_prepare(struct kmscon_text *txt)
 		bb->reqs[i].buf = NULL;
 
 	bb->req_len = 0;
+	bb->attr = *attr;
+
 	return 0;
 }
 

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -118,6 +118,8 @@ struct gltex {
 
 	GLfloat cos;
 	GLfloat sin;
+
+	struct tsm_screen_attr attr;
 };
 
 static int gltex_init(struct kmscon_text *txt)
@@ -546,7 +548,7 @@ static int gltex_rotate(struct kmscon_text *txt, enum Orientation orientation)
 	return 0;
 }
 
-static int gltex_prepare(struct kmscon_text *txt)
+static int gltex_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr)
 {
 	struct gltex *gt = txt->data;
 	struct atlas *atlas;
@@ -573,6 +575,8 @@ static int gltex_prepare(struct kmscon_text *txt)
 		gt->advance_y = 2.0 / gt->sh * FONT_HEIGHT(txt) * (1. / aspect);
 	}
 	gltex_set_rotate(gt, txt->orientation);
+
+	gt->attr = *attr;
 
 	return 0;
 }
@@ -667,8 +671,7 @@ static int gltex_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 	return 0;
 }
 
-static int gltex_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned int y,
-			      const struct tsm_screen_attr *attr)
+static int gltex_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned int y)
 {
 	struct gltex *gt = txt->data;
 	struct atlas *atlas;
@@ -679,7 +682,7 @@ static int gltex_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned 
 	uint32_t ch = 'I';
 	uint64_t id = ch;
 
-	ret = find_glyph(txt, &glyph, id, &ch, 1, attr);
+	ret = find_glyph(txt, &glyph, id, &ch, 1, &gt->attr);
 	if (ret)
 		return ret;
 
@@ -739,12 +742,12 @@ static int gltex_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned 
 
 	for (i = 0; i < 6; ++i) {
 		idx = atlas->cache_num * 3 * 6 + i * 3;
-		atlas->cache_fgcol[idx + 0] = attr->fr / 255.0;
-		atlas->cache_fgcol[idx + 1] = attr->fg / 255.0;
-		atlas->cache_fgcol[idx + 2] = attr->fb / 255.0;
-		atlas->cache_bgcol[idx + 0] = attr->br / 255.0;
-		atlas->cache_bgcol[idx + 1] = attr->bg / 255.0;
-		atlas->cache_bgcol[idx + 2] = attr->bb / 255.0;
+		atlas->cache_fgcol[idx + 0] = gt->attr.fr / 255.0;
+		atlas->cache_fgcol[idx + 1] = gt->attr.fg / 255.0;
+		atlas->cache_fgcol[idx + 2] = gt->attr.fb / 255.0;
+		atlas->cache_bgcol[idx + 0] = gt->attr.br / 255.0;
+		atlas->cache_bgcol[idx + 1] = gt->attr.bg / 255.0;
+		atlas->cache_bgcol[idx + 2] = gt->attr.bb / 255.0;
 	}
 
 	++atlas->cache_num;


### PR DESCRIPTION
So we can use it later to draw the margins.
Also re-use it for the pointer, so there is no need to pass it to the pointer anymore.