### PR TITLE
Add DPMS screen timeout feature

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -347,6 +347,19 @@
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><option>--dpms-timeout</option></term>
+        <listitem>
+          <para>Set screen timeout in seconds (default: 0 = disabled).
+                When enabled, the screen will automatically turn off (DPMS OFF)
+                after the specified period of keyboard and mouse inactivity.
+                Any keyboard or mouse input will turn the screen back on and
+                reset the timer. This feature is useful for power saving on
+                systems where the screen is not always needed.
+          </para>
+        </listitem>
+      </varlistentry>
+
     </variablelist>
 
     <para>Grabs / Keyboard Shortcuts:</para>

--- a/docs/man/kmscon.conf.1.xml.in
+++ b/docs/man/kmscon.conf.1.xml.in
@@ -69,6 +69,7 @@ xkb-layout=de
 xkb-repeat-delay=200
 xkb-repeat-rate=65
 mouse
+dpms-timeout=0
 
 ### Video Options ###
 drm
@@ -277,6 +278,19 @@ font-name=Ubuntu Mono
                 It allows to select, and copy/paste text with a pointing device,
                 and also to scroll with the mouse wheel.
                 It's still experimental, and may not work with specific devices.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--dpms-timeout</option></term>
+        <listitem>
+          <para>Set screen timeout in seconds (default: 0 = disabled).
+                When enabled, the screen will automatically turn off (DPMS OFF)
+                after the specified period of keyboard and mouse inactivity.
+                Any keyboard or mouse input will turn the screen back on and
+                reset the timer. This feature is useful for power saving on
+                systems where the screen is not always needed.
           </para>
         </listitem>
       </varlistentry>

--- a/scripts/etc/kmscon.conf.example
+++ b/scripts/etc/kmscon.conf.example
@@ -77,6 +77,12 @@
 ## Enable mouse
 #mouse
 
+## Power Management
+## Screen timeout in seconds (0 = disabled)
+## The screen will be turned off (DPMS OFF) after this period of inactivity
+## Any keyboard or mouse input will turn the screen back on
+#dpms-timeout=0
+
 ## Terminal options
 ## value of the $TERM variable
 #term=kmscon

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -115,6 +115,8 @@ static void print_help()
 		"\t                                 Delay between two key repeats in ms\n"
 		"\t    --mouse                    [on]\n"
 		"\t                                 Enable mouse support\n"
+		"\t    --dpms-timeout <secs>      [0]\n"
+		"\t                                 Screen timeout in seconds (0=off)\n"
 		"\n"
 		"Grabs / Keyboard-Shortcuts:\n"
 		"\t    --grab-scroll-up <grab>     [<Shift>Up]\n"
@@ -726,6 +728,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_UINT(0, "xkb-repeat-delay", &conf->xkb_repeat_delay, 250),
 		CONF_OPTION_UINT(0, "xkb-repeat-rate", &conf->xkb_repeat_rate, 50),
 		CONF_OPTION_BOOL(0, "mouse", &conf->mouse, true),
+		CONF_OPTION_UINT(0, "dpms-timeout", &conf->dpms_timeout, 0),
 
 		/* Grabs / Keyboard-Shortcuts */
 		CONF_OPTION_GRAB(0, "grab-scroll-up", &conf->grab_scroll_up, &def_grab_scroll_up),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -115,6 +115,8 @@ struct kmscon_conf_t {
 	unsigned int xkb_repeat_rate;
 	/* Enable mouse support */
 	bool mouse;
+	/* DPMS screen timeout in seconds (0 = disabled) */
+	unsigned int dpms_timeout;
 
 	/* Grabs / Keyboard-Shortcuts */
 	/* scroll-up grab */


### PR DESCRIPTION
## Summary
Implements automatic screen blanking after a configurable period of keyboard and mouse inactivity.

## Features
- Configurable timeout via `--dpms-timeout` option (in seconds, 0 = disabled by default)
- Per-seat DPMS timer and state tracking
- Automatic display turn-off (DPMS_OFF) after inactivity
- Immediate reactivation on any keyboard or mouse input
- Proper handling of display hotplug events (only applies DPMS to activated displays)