### PR TITLE
Don't warn on pageflip failed on -EBUSY

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -183,7 +183,9 @@ static void do_redraw_screen(struct screen *scr)
 
 	ret = uterm_display_swap(scr->disp);
 	if (ret) {
-		log_warning("cannot swap display [%s] %d", uterm_display_name(scr->disp), ret);
+		if (ret != -EBUSY)
+			log_warning("cannot swap display [%s] %d", uterm_display_name(scr->disp),
+				    ret);
 		return;
 	}
 


### PR DESCRIPTION
The driver can return EBUSY if it can't do the pageflip immediately, but it's not a problem, as next pageflip will succeed.

Fix #215 