### PR TITLE
kmscon launcher script: redirect dbus-send errors to /dev/null

### DIFF
--- a/scripts/kmscon.in
+++ b/scripts/kmscon.in
@@ -26,7 +26,7 @@ helperdir=@libexecdir@
 
 # Get a property from org.freedesktop.locale1
 queryLocale1() {
-    dbus-send --system --print-reply=literal --dest=org.freedesktop.locale1 /org/freedesktop/locale1 org.freedesktop.DBus.Properties.Get "string:org.freedesktop.locale1" "string:$1" | awk '{print $2}'
+    dbus-send --system --print-reply=literal --dest=org.freedesktop.locale1 /org/freedesktop/locale1 org.freedesktop.DBus.Properties.Get "string:org.freedesktop.locale1" "string:$1" 2>/dev/null | awk '{print $2}'
 }
 
 # Query and setup system locale settings before start kmscon


### PR DESCRIPTION
On systems that don't use systemd or dbus, it can print those error messages:

Error org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.locale1 was not provided by any .service files
Error org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.locale1 was not provided by any .service files
Error org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.locale1 was not provided by any .service files
Error org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.locale1 was not provided by any .service files

Fix #213 