### PR TITLE
Remove render-engine configuration

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -539,15 +539,6 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>--render-engine {engine}</option></term>
-        <listitem>
-          <para>Specify console the rendering engine. Available engines are
-                `bbulk', and `gltex'.
-                (default: detect by GPU type)</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <term><option>--use-original-mode</option></term>
         <listitem>
           <para>Use original KMS mode to prevent modesetting. (default: on)</para>

--- a/docs/man/kmscon.conf.1.xml.in
+++ b/docs/man/kmscon.conf.1.xml.in
@@ -421,13 +421,6 @@ font-name=Ubuntu Mono
       </varlistentry>
 
       <varlistentry>
-        <term><option>render-engine</option></term>
-        <listitem>
-          <para>Console renderer. (default: not set)</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <term><option>use-original-mode</option></term>
         <listitem>
           <para>Use the original KMS video mode. (default: on)</para>

--- a/scripts/etc/kmscon.conf.example
+++ b/scripts/etc/kmscon.conf.example
@@ -23,12 +23,8 @@
 ## GPU to use, [all, primary, aux]
 #gpus=all
 
-## Enable 3d rendering (only useful with gltex)
+## Enable 3d rendering, using gltex with drm3d instead of bbulk with drm2d
 #hwaccel
-
-## Text renderer, can be [gltex, bbulk]
-## gltex only works with hwaccel enabled, and others work with hwaccel disabled
-#render-engine=gltex
 
 ## Use original mode (enabled by default)
 #use-original-mode

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -153,7 +153,6 @@ static void print_help()
 		"\t    --hwaccel                 [off]   Use 3D hardware-acceleration if\n"
 		"\t                                      available\n"
 		"\t    --gpus={all,aux,primary}  [all]   GPU selection mode\n"
-		"\t    --render-engine <eng>     [-]     Console renderer\n"
 		"\t    --use-original-mode     [on]    Use original KMS video mode\n"
 		"\t    --mode <width>x<height>   [0x0]  Set the desired mode for the\n"
 		"\t                                     output. If the specified mode is\n"
@@ -758,7 +757,6 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_BOOL(0, "hwaccel", &conf->hwaccel, false),
 		CONF_OPTION(0, 0, "gpus", &conf_gpus, NULL, NULL, NULL, &conf->gpus,
 			    (void *)KMSCON_GPU_ALL),
-		CONF_OPTION_STRING(0, "render-engine", &conf->render_engine, NULL),
 		CONF_OPTION_BOOL(0, "use-original-mode", &conf->use_original_mode, true),
 		CONF_OPTION_STRING(0, "mode", &conf->mode, NULL),
 		CONF_OPTION_STRING(0, "rotate", &conf->rotate, "normal"),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -155,8 +155,6 @@ struct kmscon_conf_t {
 	bool hwaccel;
 	/* gpu selection mode */
 	unsigned int gpus;
-	/* render engine */
-	char *render_engine;
 	/* use current KMS video mode to avoid modesetting */
 	bool use_original_mode;
 	/* screen resolution */

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -443,9 +443,7 @@ static int add_display(struct kmscon_terminal *term, struct uterm_display *disp)
 	}
 
 	opengl = uterm_display_has_opengl(scr->disp);
-	if (term->conf->render_engine)
-		be = term->conf->render_engine;
-	else if (ret >= 0 && opengl)
+	if (opengl)
 		be = "gltex";
 	else
 		be = "bbulk";


### PR DESCRIPTION
It made sense when there was a pixman and a bblit renderer. Now the only supported possibilities are:

| gpu backend | text renderer |
+-------------+---------------+
|   fbdev     +    bbulk      |
|   drm2d     +    bbulk      |
|   drm3d     +    gltex      |
+-------------+---------------+

gltex can only work with drm3d, and with the damage support, bbulk doesn't work anymore with drm3d, so this parameter is not useful.

Fix #219 