### PR TITLE
drm: Fix when no display is connected at startup

### DIFF
--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -1165,6 +1165,9 @@ int uterm_drm_video_hotplug(struct uterm_video *video, bool read_dpms, bool mode
 		if (!(disp->flags & DISPLAY_AVAILABLE))
 			uterm_display_unbind(disp);
 	}
+	if (shl_dlist_empty(&video->displays))
+		goto finish_hotplug;
+
 	if (modeset || new_display) {
 		ret = try_modeset(video);
 		if (ret)
@@ -1176,6 +1179,7 @@ int uterm_drm_video_hotplug(struct uterm_video *video, bool read_dpms, bool mode
 		uterm_display_ready(disp);
 	}
 
+finish_hotplug:
 	video->flags &= ~VIDEO_HOTPLUG;
 	return 0;
 }


### PR DESCRIPTION
If no display is connected, there is no modeset to do. This fixes kmscon looping forever with:
ERROR: drm_shared: modeset atomic commit failed, -22

Fix #221 