### PR TITLE
README.md: fix the kms.conf link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ See `man kmscon` for more information.
 ### Config file
 
 The default configuration file is `/etc/kmscon/kmscon.conf`. Any command line option can be put in the config file in
-its long form without the leading `--` (double dash). See `man kmscon` for more information or look at [kmscon.conf](scripts/etc/kmscon.conf)
+its long form without the leading `--` (double dash). See `man kmscon` for more information or look at [kmscon.conf](scripts/etc/kmscon.conf.example)
 
 ## License
 


### PR DESCRIPTION
The linked `kms.conf` file in the README.md file points to `scripts/etc/kmscon.conf` instead of `scripts/etc/kms.conf.example`.
I think this change created the 404: https://github.com/kmscon/kmscon/pull/211

Note: I only corrected the link but did not change the name since I think that's not needed.