### PR TITLE
Fix DPMS timer not resetting when display activates

### DIFF
--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -146,6 +146,9 @@ static void session_call_display_refresh(struct kmscon_session *sess, struct ute
 	session_call(sess, KMSCON_SESSION_DISPLAY_REFRESH, disp);
 }
 
+/* Forward declaration */
+static void seat_dpms_reset_timer(struct kmscon_seat *seat);
+
 static void activate_display(struct kmscon_display *d)
 {
 	int ret;
@@ -166,6 +169,9 @@ static void activate_display(struct kmscon_display *d)
 		ret = uterm_display_set_dpms(d->disp, UTERM_DPMS_ON);
 		if (ret)
 			log_warning("cannot set DPMS state to on for display: %d", ret);
+
+		/* Reset DPMS timer when display becomes active */
+		seat_dpms_reset_timer(seat);
 
 		shl_dlist_for_each_safe(iter, tmp, &seat->sessions)
 		{


### PR DESCRIPTION
When kmscon starts with the display off/disconnected, the DPMS timer starts counting immediately. When the display later becomes active (via activate_display()), the screen is turned on but the timer is never reset.

This causes the timer to expire based on time since kmscon startup rather than time since display activation, leading to unexpected screen blanking shortly after the display becomes active.

This PR fixes the issue by calling seat_dpms_reset_timer() in activate_display() after setting DPMS to ON, ensuring the timer starts fresh when a display becomes active.

**Changes:**
- Added forward declaration for seat_dpms_reset_timer()
- Added call to seat_dpms_reset_timer() in activate_display() after DPMS ON

**Testing:**
Tested on Intel Alder Lake-N with i915 driver. The fix ensures the DPMS timeout is correctly reset when the display becomes active, regardless of whether the display was on or off when kmscon started.