### PR TITLE
Fix XDG_VTNR not set:

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -916,7 +916,7 @@ int kmscon_terminal_register(struct kmscon_session **out, struct kmscon_seat *se
 		goto err_font;
 
 	ret = kmscon_pty_set_conf(term->pty, term->conf->term, "kmscon", term->conf->argv,
-				  kmscon_seat_get_name(seat), term->conf->reset_env,
+				  kmscon_seat_get_name(seat), vtnr, term->conf->reset_env,
 				  term->conf->backspace_delete);
 	if (ret)
 		goto err_pty;

--- a/src/pty.c
+++ b/src/pty.c
@@ -140,8 +140,11 @@ void kmscon_pty_unref(struct kmscon_pty *pty)
 }
 
 int kmscon_pty_set_conf(struct kmscon_pty *pty, const char *term, const char *colorterm,
-			char **argv, const char *seat, bool do_reset, bool backspace)
+			char **argv, const char *seat, unsigned int vtnr, bool do_reset,
+			bool backspace)
 {
+	char *vt;
+
 	if (!pty)
 		return -EINVAL;
 
@@ -163,7 +166,11 @@ int kmscon_pty_set_conf(struct kmscon_pty *pty, const char *term, const char *co
 		if (!pty->seat)
 			return -ENOMEM;
 	}
-
+	if (vtnr) {
+		if (asprintf(&vt, "%u", vtnr) < 0)
+			return -ENOMEM;
+		pty->vtnr = vt;
+	}
 	if (argv && *argv && **argv)
 		return shl_dup_array(&pty->argv, argv);
 	return 0;

--- a/src/pty.h
+++ b/src/pty.h
@@ -53,7 +53,8 @@ int kmscon_pty_new(struct kmscon_pty **out, kmscon_pty_input_cb input_cb, void *
 void kmscon_pty_ref(struct kmscon_pty *pty);
 void kmscon_pty_unref(struct kmscon_pty *pty);
 int kmscon_pty_set_conf(struct kmscon_pty *pty, const char *term, const char *colorterm,
-			char **argv, const char *seat, bool do_reset, bool backspace);
+			char **argv, const char *seat, unsigned int vtnr, bool do_reset,
+			bool backspace);
 
 int kmscon_pty_get_fd(struct kmscon_pty *pty);
 void kmscon_pty_dispatch(struct kmscon_pty *pty);


### PR DESCRIPTION
There was a regression with commit
6964db1 Merge all kmscon_pty_set_xxx() into kmscon_pty_set_conf()

The XDG_VTNR env variable was no more set in the pty spawned login shell.

Fix #232 