### PR TITLE
Fix build on i686

### DIFF
--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -566,7 +566,7 @@ void uterm_drm_display_set_damage(struct uterm_display *disp, size_t n_rect,
 	ret = drmModeCreatePropertyBlob(vdrm->fd, damages, n_rect * sizeof(*damages),
 					&ddrm->damage_blob_id);
 	if (ret)
-		log_warn("Cannot create damage property %d, [%ld]", ret, n_rect);
+		log_warn("Cannot create damage property %d, [%zu]", ret, n_rect);
 }
 
 bool uterm_drm_display_has_damage(struct uterm_display *disp)


### PR DESCRIPTION
Compilation fails with:

../src/uterm_drm_shared.c: In function ‘uterm_drm_display_set_damage’: ../src/shl_log.h:243:69: error: format ‘%ld’ expects argument of type ‘long int’, but argument 9 has type ‘size_t’ {aka ‘unsigned int’} [-Werror=format=]
  243 | #define log_printf(sev, format, ...) log_format(LOG_DEFAULT, (sev), (format), ##__VA_ARGS__)
      |                                                                     ^~~~~~~~
../src/shl_log.h:261:34: note: in expansion of macro ‘log_printf’
  261 | #define log_warning(format, ...) log_printf(LOG_WARNING, (format), ##__VA_ARGS__)
      |                                  ^~~~~~~~~~
../src/shl_log.h:268:18: note: in expansion of macro ‘log_warning’
  268 | #define log_warn log_warning
      |                  ^~~~~~~~~~~
../src/uterm_drm_shared.c:569:17: note: in expansion of macro ‘log_warn’
  569 |                 log_warn("Cannot create damage property %d, [%ld]", ret, n_rect);

use %zu for size_t type