### PR TITLE
meson: add subproject fallback for libtsm

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,7 @@ systemdsystemunitdir = systemd_deps.get_variable('systemdsystemunitdir', default
 fs = import('fs')
 
 xkbcommon_deps = dependency('xkbcommon', version: '>=0.5.0')
-libtsm_deps = dependency('libtsm', version: '>=4.4.0')
+libtsm_deps = dependency('libtsm', version: '>=4.4.0', allow_fallback: true)
 libudev_deps = dependency('libudev', version: '>=172')
 dl_deps = dependency('dl')
 threads_deps = dependency('threads')

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,3 @@
+*
+!*.gitignore
+!*.wrap

--- a/subprojects/libtsm.wrap
+++ b/subprojects/libtsm.wrap
@@ -1,0 +1,9 @@
+[wrap-git]
+directory = libtsm
+
+url = https://github.com/kmscon/libtsm
+revision = v4.4.2
+depth = 1
+
+[provide]
+libtsm = libtsm_dep


### PR DESCRIPTION
This allows meson to compile libtsm inside the kmscon build when the distro packages are not recent enough.