### PR TITLE
units: drop unnecessary templating of units

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -190,14 +190,6 @@ foreach filename, kwargs : {
     'install_dir': bindir,
     'install_mode': 'rwxr-xr-x',
   },
-  'scripts/systemd/kmscon.service.in': {
-    'install_dir': systemdsystemunitdir,
-    'install_mode': 'rw-r--r--',
-  },
-  'scripts/systemd/kmsconvt@.service.in': {
-    'install_dir': systemdsystemunitdir,
-    'install_mode': 'rw-r--r--',
-  },
 }
   install_data(configure_file(input: filename, output: '@BASENAME@', configuration: dirs_info),
     kwargs: kwargs,
@@ -208,4 +200,12 @@ endforeach
 install_data(
   'scripts/etc/kmscon.conf.example',
   install_dir: join_paths(get_option('sysconfdir'), 'kmscon')
+)
+install_data(
+  'scripts/systemd/kmscon.service',
+  install_dir: systemdsystemunitdir,
+)
+install_data(
+  'scripts/systemd/kmsconvt@.service',
+  install_dir: systemdsystemunitdir,
 )

--- a/scripts/systemd/kmscon.service
+++ b/scripts/systemd/kmscon.service
@@ -6,7 +6,7 @@ After=systemd-user-sessions.service
 After=rc-local.service
 
 [Service]
-ExecStart=@bindir@/kmscon --login -- /sbin/agetty -o '-p -- \\u' --noclear -- - $$TERM
+ExecStart=kmscon --login -- /sbin/agetty -o '-p -- \\u' --noclear -- - $$TERM
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/systemd/kmsconvt@.service
+++ b/scripts/systemd/kmsconvt@.service
@@ -38,7 +38,7 @@ IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
 
 [Service]
-ExecStart=@bindir@/kmscon --vt=%I --seats=seat0 --no-switchvt --login -- /sbin/agetty -o '-p -- \\u' --noclear -- - $$TERM
+ExecStart=kmscon --vt=%I --seats=seat0 --no-switchvt --login -- /sbin/agetty -o '-p -- \\u' --noclear -- - $$TERM
 UtmpIdentifier=%I
 TTYPath=/dev/%I
 TTYReset=yes


### PR DESCRIPTION
Systemd stopped requiring an absolute path in ExecStart= in systemd 239 (2018). It is nicer to keep the unit files the same everywhere, so drop the templating.

While at it, drop the explicit mode setting. rw-r--r-- is the default unless overriden.