### PR TITLE
agetty: Add -8 arguments to accept full 8-bits characters

### DIFF
--- a/scripts/systemd/kmsconvt@.service
+++ b/scripts/systemd/kmsconvt@.service
@@ -38,7 +38,7 @@ IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
 
 [Service]
-ExecStart=kmscon --vt=%I --seats=seat0 --no-switchvt --login -- /sbin/agetty -o '-p -- \\u' --noclear -- - $$TERM
+ExecStart=kmscon --vt=%I --seats=seat0 --no-switchvt --login -- /sbin/agetty -8 -o '-p -- \\u' --noclear -- - $$TERM
 UtmpIdentifier=%I
 TTYPath=/dev/%I
 TTYReset=yes


### PR DESCRIPTION
kmscon sends utf-8 characters, which get silently dropped by agetty. This leads to some weird behavior with accented letters.

Fixes #256 
Fixes #253 