### PR TITLE
Read /proc/sys/kernel/ctrl-alt-del for reboot behavior

### DIFF
--- a/docs/man/kmscon.conf.1.xml.in
+++ b/docs/man/kmscon.conf.1.xml.in
@@ -392,7 +392,11 @@ font-name=Ubuntu Mono
         <listitem>
           <para>Reboot the system when this keyboard shortcut is pressed.
                 This option is disabled by default.
-                Use with caution as the reboot is immediate.
+                The reboot behavior follows the system-wide setting in
+                /proc/sys/kernel/ctrl-alt-del: when set to 0 (default),
+                a graceful reboot is performed by sending SIGINT to init (PID 1);
+                when set to a value greater than 0, an immediate hard reboot
+                is performed after syncing disk buffers.
                 Example: grab-reboot=&lt;Ctrl&gt;&lt;Alt&gt;Delete
                 (default: disabled)</para>
         </listitem>

--- a/scripts/etc/kmscon.conf.example
+++ b/scripts/etc/kmscon.conf.example
@@ -67,7 +67,10 @@
 #grab-terminal-new=<Ctrl><Logo>Return
 #grab-rotate-cw=<Logo>Plus
 #grab-rotate-ccw=<Logo>Minus
-## Reboot system (disabled by default, use with caution - immediate reboot without confirmation)
+## Reboot system (disabled by default)
+## Reboot behavior follows /proc/sys/kernel/ctrl-alt-del:
+##   0 (default): graceful reboot (sends SIGINT to init)
+##   >0: immediate hard reboot after syncing disk buffers
 #grab-reboot=<Ctrl><Alt>Delete
 
 ## Enable mouse


### PR DESCRIPTION
## Summary

This PR addresses the feedback from #260 by implementing reboot behavior that respects the system-wide `/proc/sys/kernel/ctrl-alt-del` setting instead of adding a new kmscon-specific parameter.

## Motivation

In PR #260, I initially proposed adding a `--grab-reboot-mode` parameter. The maintainer suggested a better approach: reading `/proc/sys/kernel/ctrl-alt-del` to respect the system's existing configuration.

## Changes

### Implementation (`src/kmscon_seat.c`)
- Modified `seat_trigger_reboot()` to read `/proc/sys/kernel/ctrl-alt-del` at runtime
- When value is `0` (default): performs **soft reboot** by sending `SIGINT` to PID 1 (init)
- When value is `>0`: performs **hard reboot** with `sync()` then `reboot(RB_AUTOBOOT)`
- Graceful error handling with fallback to soft reboot if file cannot be read

### Documentation
- Updated man page (`docs/man/kmscon.conf.1.xml.in`) to explain the behavior
- Updated example config (`scripts/etc/kmscon.conf.example`) with clear comments

## Testing

- ✅ Compiles cleanly with no warnings
- ✅ Passes all unit tests (1/1)
- ✅ Conforms to clang-format standards
- ✅ No residual parameters from previous approach

## Related

- Addresses feedback: https://github.com/kmscon/kmscon/pull/260#issuecomment-3816375104
- Supersedes: #260
