### PR TITLE
drm: Fix black screen when switching back to kmscon

### DIFF
--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -673,7 +673,7 @@ err_commit:
 			disp->flags &= ~DISPLAY_ONLINE;
 			uterm_display_unref(disp);
 		} else
-			disp->flags |= DISPLAY_ONLINE;
+			disp->flags |= DISPLAY_ONLINE | DISPLAY_VSYNC;
 	}
 	return ret;
 }


### PR DESCRIPTION
When switching back to a kmscon console, the screen is black until an input event occurs (keyboard or mouse). This is particularly visible with drm3d (hwaccel), even if the fix applies also to drm2d.