### PR TITLE
unifont: Add bold and underline support

### DIFF
--- a/src/font.h
+++ b/src/font.h
@@ -70,7 +70,6 @@ struct kmscon_font {
 	struct shl_register_record *record;
 	const struct kmscon_font_ops *ops;
 	struct kmscon_font_attr attr;
-	unsigned int baseline;
 	void *data;
 };
 

--- a/src/font_8x16.c
+++ b/src/font_8x16.c
@@ -69,7 +69,6 @@ static int kmscon_font_8x16_init(struct kmscon_font *out, const struct kmscon_fo
 	out->attr.width = 8;
 	out->attr.height = 16;
 	kmscon_font_attr_normalize(&out->attr);
-	out->baseline = 4;
 
 	return 0;
 }

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -418,7 +418,6 @@ static int kmscon_font_pango_init(struct kmscon_font *out, const struct kmscon_f
 	if (ret)
 		return ret;
 	memcpy(&out->attr, &face->real_attr, sizeof(out->attr));
-	out->baseline = face->baseline;
 
 	out->data = face;
 	return 0;

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -99,7 +99,8 @@ static void free_glyph(void *data)
 	free(g);
 }
 
-static uint8_t apply_attr(uint8_t c, const struct kmscon_font_attr *attr, bool last_line) {
+static uint8_t apply_attr(uint8_t c, const struct kmscon_font_attr *attr, bool last_line)
+{
 	if (attr->bold)
 		c |= c >> 1;
 	if (attr->underline && last_line)
@@ -146,7 +147,8 @@ static int lookup_block(const struct unifont_glyph_block *blocks, uint32_t len, 
 	return -1;
 }
 
-static int find_glyph(uint64_t id, const struct kmscon_glyph **out, const struct kmscon_font_attr *attr)
+static int find_glyph(uint64_t id, const struct kmscon_glyph **out,
+		      const struct kmscon_font_attr *attr)
 {
 	struct kmscon_glyph *g;
 	uint32_t ch = id & TSM_UCS4_MAX;
@@ -262,7 +264,6 @@ static int kmscon_font_unifont_init(struct kmscon_font *out, const struct kmscon
 	out->attr.width = 8;
 	out->attr.height = 16;
 	kmscon_font_attr_normalize(&out->attr);
-	out->baseline = 4;
 
 	cache_ref();
 	return 0;


### PR DESCRIPTION
bold and underline were ignored with unifont.

Add a very simple implementation, to have something nicer with unifont.