### PR TITLE
Only take drm master if needed

### DIFF
--- a/src/uterm_drm_shared_internal.h
+++ b/src/uterm_drm_shared_internal.h
@@ -94,6 +94,7 @@ struct uterm_drm_video {
 	struct shl_timer *timer;
 	struct ev_timer *vt_timer;
 	bool legacy;
+	bool master;
 	const struct display_ops *display_ops;
 };
 


### PR DESCRIPTION
If there are no display connected on a device, don't take drm master.

Also check dpms value, and set it only if it needed.