### PR TITLE
Change default TERM to linux

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -244,7 +244,7 @@
         <listitem>
           <para>Specify the <varname>$TERM</varname> environment variable
                 that is set on new terminal sessions.
-                (default: xterm-256color)</para>
+                (default: linux)</para>
         </listitem>
       </varlistentry>
 

--- a/docs/man/kmscon.conf.5.xml.in
+++ b/docs/man/kmscon.conf.5.xml.in
@@ -189,7 +189,7 @@ font-name=Ubuntu Mono
       <varlistentry>
         <term><option>term</option></term>
         <listitem>
-          <para>Value of the TERM environment variable for the child process. (default: xterm-256color)</para>
+          <para>Value of the TERM environment variable for the child process. (default: linux)</para>
         </listitem>
       </varlistentry>
 

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -90,7 +90,7 @@ static void print_help()
 		"\t                              argv to this process. No more options\n"
 		"\t                              after '--' will be parsed so use it at\n"
 		"\t                              the end of the argument string\n"
-		"\t-t, --term <TERM>           [xterm-256color]\n"
+		"\t-t, --term <TERM>           [linux]\n"
 		"\t                              Value of the TERM environment variable\n"
 		"\t                              for the child process\n"
 		"\t    --reset-env             [on]\n"
@@ -754,7 +754,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		/* Terminal Options */
 		CONF_OPTION(0, 'l', "login", &conf_login, aftercheck_login, NULL, file_login,
 			    &conf->login, false),
-		CONF_OPTION_STRING('t', "term", &conf->term, "xterm-256color"),
+		CONF_OPTION_STRING('t', "term", &conf->term, "linux"),
 		CONF_OPTION_BOOL(0, "reset-env", &conf->reset_env, true),
 		CONF_OPTION_BOOL(0, "backspace-delete", &conf->backspace_delete, true),
 		CONF_OPTION_UINT(0, "sb-size", &conf->sb_size, 1000),


### PR DESCRIPTION
Change the default TERM from xterm-256color to linux. The reason is that kmscon is a replacement for fbcon, and kmscon is closer to fbcon terminal, than from a xterm gui.
for example, xterm-256color makes terminal apps uses "set title" or handle window focus, which don't have meaning for kmscon.