### PR TITLE
terminal: mark displays dirty on session activate

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -232,7 +232,7 @@ static void update_pointer_max_all(struct kmscon_terminal *term)
 		uterm_input_set_pointer_max(term->input, max_x, max_y);
 }
 
-static void redraw_all_test(struct kmscon_terminal *term)
+static void redraw_all_text(struct kmscon_terminal *term)
 {
 	struct shl_dlist *iter;
 	struct screen *scr;
@@ -804,6 +804,8 @@ static int session_event(struct kmscon_session *session, struct kmscon_session_e
 			 void *data)
 {
 	struct kmscon_terminal *term = data;
+	struct shl_dlist *iter;
+	struct screen *scr;
 
 	switch (ev->type) {
 	case KMSCON_SESSION_DISPLAY_NEW:
@@ -813,13 +815,18 @@ static int session_event(struct kmscon_session *session, struct kmscon_session_e
 		rm_display(term, ev->disp);
 		break;
 	case KMSCON_SESSION_DISPLAY_REFRESH:
-		redraw_all_test(term);
+		redraw_all_text(term);
 		break;
 	case KMSCON_SESSION_ACTIVATE:
 		term->awake = true;
 		if (!term->opened)
 			terminal_open(term);
-		redraw_all_test(term);
+		shl_dlist_for_each(iter, &term->screens)
+		{
+			scr = shl_dlist_entry(iter, struct screen, list);
+			uterm_display_set_need_redraw(scr->disp);
+		}
+		redraw_all_text(term);
 		break;
 	case KMSCON_SESSION_DEACTIVATE:
 		term->awake = false;

--- a/src/uterm_video.c
+++ b/src/uterm_video.c
@@ -323,10 +323,24 @@ int uterm_display_fake_blendv(struct uterm_display *disp, const struct uterm_vid
 }
 
 SHL_EXPORT
+void uterm_display_set_need_redraw(struct uterm_display *disp)
+{
+	if (!disp || !display_is_online(disp))
+		return;
+
+	disp->flags |= DISPLAY_NEED_REDRAW;
+}
+
+SHL_EXPORT
 bool uterm_display_need_redraw(struct uterm_display *disp)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
 		return false;
+
+	if (disp->flags & DISPLAY_NEED_REDRAW) {
+		disp->flags &= ~DISPLAY_NEED_REDRAW;
+		return true;
+	}
 
 	return VIDEO_CALL(disp->ops->need_redraw, 0, disp);
 }

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -165,6 +165,7 @@ int uterm_display_get_dpms(const struct uterm_display *disp);
 int uterm_display_use(struct uterm_display *disp);
 int uterm_display_swap(struct uterm_display *disp);
 bool uterm_display_is_swapping(struct uterm_display *disp);
+void uterm_display_set_need_redraw(struct uterm_display *disp);
 bool uterm_display_need_redraw(struct uterm_display *disp);
 
 int uterm_display_fill(struct uterm_display *disp, uint8_t r, uint8_t g, uint8_t b, unsigned int x,

--- a/src/uterm_video_internal.h
+++ b/src/uterm_video_internal.h
@@ -84,6 +84,7 @@ struct uterm_video_module {
 #define DISPLAY_OPENGL 0x80
 #define DISPLAY_INUSE 0x100
 #define DISPLAY_DAMAGE 0x200
+#define DISPLAY_NEED_REDRAW 0x400
 
 struct uterm_display {
 	char *name;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,3 +26,17 @@ test('test_shl', test_shl,
   protocol: 'tap',
   env: {'CK_TAP_LOG_FILE_NAME': '-', 'CK_VERBOSITY': 'silent'},
 )
+
+src_inc = include_directories('../src')
+
+test_text = executable('test_text', 'test_text.c',
+  include_directories: [src_inc],
+  dependencies: [libtsm_deps, shl_deps],
+)
+test('test_text', test_text)
+
+test_bbulk = executable('test_bbulk', 'test_bbulk.c',
+  include_directories: [src_inc],
+  dependencies: [libtsm_deps, htable_deps],
+)
+test('test_bbulk', test_bbulk)

--- a/tests/test_bbulk.c
+++ b/tests/test_bbulk.c
@@ -1,0 +1,218 @@
+/*
+ * Lightweight test for repeated bbulk_set calls (no leaks, all cells re-damaged).
+ * We include the implementation to access static helpers.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include "text.h"
+
+/* ---- Stubs for external dependencies used by text_bbulk.c ---- */
+#include "../src/font.h"	/* for kmscon_font_* */
+#include "../src/font_rotate.h" /* for prototypes and shl_hashtable */
+#include "../src/uterm_video.h" /* for uterm_display_* prototypes */
+unsigned int uterm_display_get_width(struct uterm_display *disp)
+{
+	(void)disp;
+	return 640;
+}
+unsigned int uterm_display_get_height(struct uterm_display *disp)
+{
+	(void)disp;
+	return 480;
+}
+
+/* Provide stub implementations matching the prototypes from font_rotate.h */
+int kmscon_rotate_create_tables(struct shl_hashtable **normal, struct shl_hashtable **bold,
+				void (*free_func)(void *data))
+{
+	(void)normal;
+	(void)bold;
+	(void)free_func;
+	return 0;
+}
+void kmscon_rotate_free_tables(struct shl_hashtable *normal, struct shl_hashtable *bold)
+{
+	(void)normal;
+	(void)bold;
+}
+
+/* Keep geometry tiny to minimize allocations */
+#define FAKE_CELL_W 8
+#define FAKE_CELL_H 16
+
+/* Stub font metrics APIs used indirectly by text.c/text_bbulk.c */
+unsigned int kmscon_font_get_width(const struct kmscon_font *font)
+{
+	(void)font;
+	return FAKE_CELL_W;
+}
+unsigned int kmscon_font_get_height(const struct kmscon_font *font)
+{
+	(void)font;
+	return FAKE_CELL_H;
+}
+
+/* Stub font rendering APIs used by text_bbulk.c */
+int kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch, size_t len,
+		       const struct kmscon_glyph **out)
+{
+	static struct kmscon_glyph g;
+	(void)font;
+	(void)id;
+	(void)ch;
+	(void)len;
+	memset(&g, 0, sizeof(g));
+	g.buf.format = UTERM_FORMAT_XRGB32;
+	g.buf.width = g.buf.height = FAKE_CELL_W;
+	g.buf.stride = g.buf.width * 4;
+	if (out)
+		*out = &g;
+	return 0;
+}
+int kmscon_font_render_inval(struct kmscon_font *font, const struct kmscon_glyph **out)
+{
+	return kmscon_font_render_empty(font, out);
+}
+int kmscon_font_render_empty(struct kmscon_font *font, const struct kmscon_glyph **out)
+{
+	static struct kmscon_glyph g;
+	(void)font;
+	memset(&g, 0, sizeof(g));
+	g.buf.format = UTERM_FORMAT_XRGB32;
+	g.buf.width = g.buf.height = FAKE_CELL_W;
+	g.buf.stride = g.buf.width * 4;
+	if (out)
+		*out = &g;
+	return 0;
+}
+int kmscon_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyph,
+			enum Orientation o, uint8_t align)
+{
+	(void)o;
+	(void)align;
+	if (!vb || !glyph)
+		return -EINVAL;
+	*vb = *glyph;
+	if (glyph->buf.stride == 0 || glyph->buf.height == 0)
+		return 0;
+	size_t buf_size = glyph->buf.stride * glyph->buf.height;
+	vb->buf.data = malloc(buf_size);
+	if (!vb->buf.data)
+		return -ENOMEM;
+	memset(vb->buf.data, 0x11, buf_size);
+	return 0;
+}
+
+/* Stub uterm display APIs used by text_bbulk.c */
+bool uterm_display_need_redraw(struct uterm_display *disp)
+{
+	(void)disp;
+	return false;
+}
+bool uterm_display_has_damage(struct uterm_display *disp)
+{
+	(void)disp;
+	return false;
+}
+bool uterm_display_supports_damage(struct uterm_display *disp)
+{
+	(void)disp;
+	return true;
+}
+int uterm_display_fill(struct uterm_display *disp, uint8_t r, uint8_t g, uint8_t b, unsigned int x,
+		       unsigned int y, unsigned int w, unsigned int h)
+{
+	(void)disp;
+	(void)r;
+	(void)g;
+	(void)b;
+	(void)x;
+	(void)y;
+	(void)w;
+	(void)h;
+	return 0;
+}
+int uterm_display_fake_blendv(struct uterm_display *disp, const struct uterm_video_blend_req *req,
+			      size_t num)
+{
+	(void)disp;
+	(void)req;
+	(void)num;
+	return 0;
+}
+void uterm_display_set_damage(struct uterm_display *disp, size_t n_rect,
+			      struct uterm_video_rect *damages)
+{
+	(void)disp;
+	(void)n_rect;
+	(void)damages;
+}
+
+/* Pull in the implementation so we can call bbulk_set directly */
+#include "../src/text_bbulk.c"
+
+/* Fake font objects with valid width/height for FONT_WIDTH/FONT_HEIGHT macros */
+static struct kmscon_font fake_font = {.attr = {.width = FAKE_CELL_W, .height = FAKE_CELL_H}};
+static struct kmscon_font fake_bold = {.attr = {.width = FAKE_CELL_W, .height = FAKE_CELL_H}};
+
+static void init_fake_txt(struct kmscon_text *txt)
+{
+	memset(txt, 0, sizeof(*txt));
+	txt->ops = &kmscon_text_bbulk_ops;
+	txt->disp = (struct uterm_display *)0x1; /* non-null stub */
+	txt->font = &fake_font;
+	txt->bold_font = &fake_bold;
+	txt->orientation = OR_NORMAL;
+	txt->ref = 1;
+}
+
+int main(void)
+{
+	struct kmscon_text txt;
+	int ret;
+
+	init_fake_txt(&txt);
+
+	ret = kmscon_text_bbulk_ops.init(&txt);
+	assert(ret == 0);
+	struct bbulk *bb = txt.data;
+	assert(bb != NULL);
+
+	/* First call allocates */
+	ret = bbulk_set(&txt);
+	assert(ret == 0);
+	assert(bb->reqs && bb->prev && bb->damages && bb->damage_rects);
+	unsigned int prev_cells = bb->cells;
+
+	/* Second call with identical geometry should remain valid and fully damaged */
+	ret = bbulk_set(&txt);
+	assert(ret == 0);
+	assert(bb->cells == prev_cells);
+	assert(bb->reqs != NULL);
+	assert(bb->prev != NULL);
+	assert(bb->damages != NULL);
+	assert(bb->damage_rects != NULL);
+	/* All cells should be marked damaged */
+	for (unsigned i = 0; i < bb->cells; ++i)
+		assert(bb->prev[i].id == ID_DAMAGED);
+
+	/* Exercise prepare/render + damage path */
+	struct tsm_screen_attr attr;
+	memset(&attr, 0, sizeof(attr));
+	ret = bbulk_prepare(&txt, &attr);
+	assert(ret == 0);
+	ret = bbulk_render(&txt);
+	assert(ret == 0);
+	assert(bb->damage_rect_len > 0);
+
+	bbulk_unset(&txt);
+	assert(bb->reqs == NULL);
+	assert(bb->prev == NULL);
+	assert(bb->damages == NULL);
+	assert(bb->damage_rects == NULL);
+	kmscon_text_bbulk_ops.destroy(&txt);
+	return 0;
+}

--- a/tests/test_text.c
+++ b/tests/test_text.c
@@ -1,0 +1,69 @@
+/*
+ * Lightweight test for kmscon_text_set / kmscon_text_unset.
+ * We avoid linking the whole tree by stubbing external deps.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include "../src/text.c" /* pull in kmscon_text_set without changing meson */
+
+/* --- Stubs for external functions used by kmscon_text_set --- */
+void kmscon_font_ref(struct kmscon_font *font) {}
+void kmscon_font_unref(struct kmscon_font *font) {}
+void uterm_display_ref(struct uterm_display *disp) {}
+void uterm_display_unref(struct uterm_display *disp) {}
+
+static int dummy_set_calls;
+static int dummy_unset_calls;
+static int dummy_set(struct kmscon_text *txt)
+{
+	dummy_set_calls++;
+	return 0;
+}
+static void dummy_unset(struct kmscon_text *txt)
+{
+	dummy_unset_calls++;
+}
+
+static struct kmscon_text_ops dummy_ops = {
+	.name = "dummytest",
+	.owner = NULL,
+	.init = NULL,
+	.destroy = NULL,
+	.set = dummy_set,
+	.unset = dummy_unset,
+};
+
+int main(void)
+{
+	struct kmscon_text txt;
+	struct kmscon_font fake_font;
+	struct uterm_display *fake_disp = (struct uterm_display *)0x1;
+	int ret;
+
+	memset(&txt, 0, sizeof(txt));
+	memset(&fake_font, 0, sizeof(fake_font));
+	txt.ops = &dummy_ops;
+
+	/* set calls backend set */
+	ret = kmscon_text_set(&txt, &fake_font, &fake_font, fake_disp);
+	assert(ret == 0);
+	assert(dummy_set_calls == 1);
+	assert(txt.font == &fake_font);
+	assert(txt.disp == fake_disp);
+
+	/* unset calls backend unset and clears pointers */
+	kmscon_text_unset(&txt);
+	assert(dummy_unset_calls == 1);
+	assert(txt.font == NULL);
+	assert(txt.disp == NULL);
+
+	/* NULL font must return -EINVAL */
+	ret = kmscon_text_set(&txt, NULL, NULL, fake_disp);
+	assert(ret == -EINVAL);
+	assert(dummy_set_calls == 1); /* not called again */
+
+	return 0;
+}


### PR DESCRIPTION
On session activate the bbulk cell cache may be stale if the framebuffer was overwritten by another session. With real VTs the DRM modeset already handles this by setting need_redraw, causing bbulk_prepare() to repaint every cell. With fake VTs there is no modeset, so need_redraw is never set and the display can show blank or corrupted content until the next cell change.

Add a generic DISPLAY_NEED_REDRAW flag and uterm_display_set_need_redraw() setter so the terminal layer can request a full repaint using the same mechanism as the DRM backend. Set the flag on each display during KMSCON_SESSION_ACTIVATE.

Closes #292 