### PR TITLE
input: fix stuck modifiers on VT re-entry

### DIFF
--- a/src/uterm_input.c
+++ b/src/uterm_input.c
@@ -137,9 +137,6 @@ static void input_sleep_dev(struct uterm_input_dev *dev)
 	if (dev->rfd < 0)
 		return;
 
-	if (dev->capabilities & UTERM_DEVICE_HAS_KEYS)
-		uxkb_dev_sleep(dev);
-
 	dev->repeating = false;
 	ev_timer_update(dev->repeat_timer, NULL);
 	ev_eloop_rm_fd(dev->fd);

--- a/src/uterm_input_internal.h
+++ b/src/uterm_input_internal.h
@@ -94,8 +94,6 @@ struct uterm_input_dev {
 	/* For keyboards */
 	struct xkb_state *state;
 	struct xkb_compose_state *compose_state;
-	/* Used in sleep/wake up to store the key's pressed/released state. */
-	char key_state_bits[SHL_DIV_ROUND_UP(KEY_CNT, CHAR_BIT)];
 
 	unsigned int num_syms;
 	struct uterm_input_key_event event;
@@ -142,7 +140,6 @@ void uxkb_desc_destroy(struct uterm_input *input);
 int uxkb_dev_init(struct uterm_input_dev *dev);
 void uxkb_dev_destroy(struct uterm_input_dev *dev);
 int uxkb_dev_process(struct uterm_input_dev *dev, uint16_t key_state, uint16_t code);
-void uxkb_dev_sleep(struct uterm_input_dev *dev);
 void uxkb_dev_wake_up(struct uterm_input_dev *dev);
 
 void pointer_dev_rel(struct uterm_input_dev *dev, uint16_t code, int32_t value);

--- a/src/uterm_input_uxkb.c
+++ b/src/uterm_input_uxkb.c
@@ -493,34 +493,10 @@ int uxkb_dev_process(struct uterm_input_dev *dev, uint16_t key_state, uint16_t c
 	return 0;
 }
 
-void uxkb_dev_sleep(struct uterm_input_dev *dev)
-{
-	/*
-	 * While the device is asleep, we don't receive key events. This
-	 * means that when we wake up, the keyboard state may be different
-	 * (e.g. some key is pressed but we don't know about it). This can
-	 * cause various problems, like stuck modifiers: consider if we
-	 * miss a release of the left Shift key. When the user presses it
-	 * again, xkb_state_update_key() will think there is *another* left
-	 * Shift key that was pressed. When the key is released, it's as if
-	 * this "second" key was released, but the "first" is still left
-	 * pressed.
-	 * To handle this, when the device goes to sleep, we save our
-	 * current knowledge of the keyboard's press/release state. On wake
-	 * up, we compare the states before and after, and just feed
-	 * xkb_state_update_key() the deltas.
-	 */
-	memset(dev->key_state_bits, 0, sizeof(dev->key_state_bits));
-	errno = 0;
-	ioctl(dev->rfd, EVIOCGKEY(sizeof(dev->key_state_bits)), dev->key_state_bits);
-	if (errno)
-		llog_warn(dev->input, "failed to save keyboard state (%d): %m", errno);
-}
-
 void uxkb_dev_wake_up(struct uterm_input_dev *dev)
 {
 	uint32_t code;
-	char cur_bits[sizeof(dev->key_state_bits)];
+	char cur_bits[sizeof(SHL_DIV_ROUND_UP(KEY_CNT, CHAR_BIT))];
 	char cur_bit;
 	xkb_mod_mask_t locked_mods;
 	xkb_layout_index_t group;


### PR DESCRIPTION
## Problem

When switching away from a kmscon VT, `uxkb_dev_sleep()` saves the current key state via `EVIOCGKEY`. On re-entry, `uxkb_dev_wake_up()` diffs the saved state against the current kernel state and synthesizes key-up/down events for any changes — intended to handle modifiers released while the VT was inactive.

This approach has a race condition when a **Wayland compositor on another VT holds `EVIOCGRAB`**: at the exact moment `uxkb_dev_wake_up()` calls `EVIOCGKEY`, the compositor may not yet have released its grab, and the kernel still reports modifier keys (e.g. Alt) as physically held. The delta sees no change (`old=pressed`, `cur=pressed`), no key-up is synthesized, and the modifier stays **stuck in xkb state** even after the user physically releases the key.

Reproducer: use kmscon on tty1 with a Wayland compositor on tty2; switch with `Ctrl+Alt+F2`, release modifiers, switch back — Alt (or Ctrl) is stuck on tty1.

## Fix

Instead of relying on the delta against a sleep-time snapshot, **clear all depressed and latched modifiers** from the xkb state (preserving locked mods like CapsLock/NumLock) and **rebuild purely from `EVIOCGKEY`**:

```c
locked_mods = xkb_state_serialize_mods(dev->state, XKB_STATE_MODS_LOCKED);
group = xkb_state_serialize_layout(dev->state, XKB_STATE_LAYOUT_EFFECTIVE);
xkb_state_update_mask(dev->state, 0, 0, locked_mods, 0, 0, group);

for (code = 0; code < KEY_CNT; code++) {
    cur_bit = (cur_bits[code / 8] & (1 << (code % 8)));
    if (cur_bit)
        xkb_state_update_key(dev->state, code + EVDEV_KEYCODE_OFFSET, XKB_KEY_DOWN);
}
```

This eliminates the race entirely. Even if `EVIOCGKEY` returns all-zeros while the compositor still briefly holds the grab, all modifiers are cleared — the safe failure mode versus leaving them stuck.

This approach is consistent with what [libxkbcommon recommends](https://xkbcommon.org/doc/current/group__state.html) for handling missed input events.