### PR TITLE
Improved error messages around configuring to build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ On Debian-based system, to install the systemd service files in the right locati
 sudo apt install systemd-dev
 ```
 
+To build with manpages and documentation, the following is required:
+ - xsltproc (packaged as `libxslt` in Fedora, or `xsltproc` in Ubuntu/Debian)
+ - docbook stylesheets (packaged as `docbook-style-xsl` in Fedora, or `docbook-xsl` in Ubuntu/Debian)
+
 ## Download
 
 Released tarballs can be found at: https://github.com/kmscon/kmscon/releases
@@ -72,6 +76,8 @@ explicitly enable it via command line:
 |`renderer_gltex`| `auto` | OpenGLESv2 accelerated renderer |
 |`session_dummy`| `auto` | Dummy fallback session |
 |`session_terminal`| `auto` | Terminal-emulator sessions |
+|`docs`|`auto`| Build manpages and documentation |
+
 
 ## Running
 

--- a/meson.build
+++ b/meson.build
@@ -139,8 +139,16 @@ manpages_stylesheet = 'http://docbook.sourceforge.net/release/xsl/current/manpag
 have_manpages_stylesheet = false
 if xsltproc.found()
   have_manpages_stylesheet = run_command(xsltproc, '--nonet', manpages_stylesheet, check: false).returncode() == 0
+  if not have_manpages_stylesheet
+    docs_error_string = 'docbook.xsl stylesheet was not found.'
+  else
+    docs_error_string = ''
+  endif
+else
+  docs_error_string = 'executable xsltproc was not found.'
 endif
-enable_docs = get_option('docs').require(xsltproc.found() and have_manpages_stylesheet).allowed()
+enable_docs = get_option('docs').require(xsltproc.found() and have_manpages_stylesheet, 
+  error_message: docs_error_string).allowed()
 
 # Additionally check if glesv2 is needed
 enable_glesv2 = enable_video_drm3d or enable_renderer_gltex


### PR DESCRIPTION
Three minor adjustments:
- Update readme to denote there _is_ a way to build documentation
- Update readme to clarify the extra dependencies to build documentation
- Add an explicit error message when configured with `-Ddocs=enabled` but the dependencies aren't found.

Closes #187