### PR TITLE
unifont: fix lookup_block() infinite loop

### DIFF
--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -106,7 +106,7 @@ static int lookup_block(const struct unifont_glyph_block *blocks, uint32_t len, 
 	if (look > max)
 		look = max;
 
-	while (min != max) {
+	while (min < max) {
 		log_debug("lookup %d codep %d, look %d min %d max %d", ch, blocks[look].codepoint,
 			  look, min, max);
 


### PR DESCRIPTION
When looking for a codepoint that has no glyph, it's possible to have min > max, and thus looping forever.