### PR TITLE
text_bbulk: initialize x1 and y1 to fix -Werror=maybe-uninitialized

### DIFF
--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -609,7 +609,7 @@ static void bbulk_compute_damage(struct kmscon_text *txt)
 	struct bbulk *bb = txt->data;
 	int posx, posy, off;
 	struct uterm_video_rect r;
-	unsigned int x1, y1;
+	unsigned int x1 = 0, y1 = 0;
 	unsigned int fw, fh;
 	int prev;
 


### PR DESCRIPTION
In bbulk_compute_damage(), x1 and y1 are set by set_coordinate() which covers all enum cases, but GCC cannot prove this at -O3 and raises -werror=maybe-uninitialized, breaking release builds.