### PR TITLE
input_uxkb: fix wrong cur_bit size

### DIFF
--- a/src/uterm_input_uxkb.c
+++ b/src/uterm_input_uxkb.c
@@ -496,7 +496,7 @@ int uxkb_dev_process(struct uterm_input_dev *dev, uint16_t key_state, uint16_t c
 void uxkb_dev_wake_up(struct uterm_input_dev *dev)
 {
 	uint32_t code;
-	char cur_bits[sizeof(SHL_DIV_ROUND_UP(KEY_CNT, CHAR_BIT))];
+	char cur_bits[SHL_DIV_ROUND_UP(KEY_CNT, CHAR_BIT)];
 	char cur_bit;
 	xkb_mod_mask_t locked_mods;
 	xkb_layout_index_t group;


### PR DESCRIPTION
the commit 6bc7eb uxkb: remove the now unused key_state_bits field mistakenly added a sizeof() to the size of cur_bit. This leads to cur_bit being only 4 bytes long, which result in a buffer overflow.