### PR TITLE
input_pointer: Fix touchpaddown detection

### DIFF
--- a/src/uterm_input_pointer.c
+++ b/src/uterm_input_pointer.c
@@ -68,6 +68,7 @@ void pointer_dev_sync(struct uterm_input_dev *dev)
 
 	shl_hook_call(dev->input->pointer_hook, dev->input, &pev);
 	pointer_update_inactivity_timer(dev);
+	dev->pointer.touchpaddown = false;
 }
 
 void pointer_dev_rel(struct uterm_input_dev *dev, uint16_t code, int32_t value)
@@ -197,7 +198,7 @@ void pointer_dev_button(struct uterm_input_dev *dev, uint16_t code, int32_t valu
 		pointer_dev_send_button(dev, 2, pressed, false);
 		break;
 	case BTN_TOUCH:
-		dev->pointer.touchpaddown = (value == 0);
+		dev->pointer.touchpaddown = pressed;
 		break;
 	default:
 		break;


### PR DESCRIPTION
The value should be 1 when the touchpad is pressed. Also restore the touchpaddown = false, as otherwise the pointer won't move at all.

This fix a regression introduced by commit
6e4c7f9 fix: Update `dev->pointer.touchpaddown` only on touch event.

Fixes #333 