### PR TITLE
Simplify font engine

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -52,12 +52,10 @@
  * is shared between different threads to reduce memory-footprint.
  */
 
-#include <errno.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 #include "font.h"
-#include "shl_dlist.h"
 #include "shl_log.h"
 #include "shl_misc.h"
 #include "shl_module.h"
@@ -353,47 +351,22 @@ SHL_EXPORT
 struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
 					size_t len)
 {
-	if (!font || !ch || !len)
-		return NULL;
+	uint32_t empty_char = ' ';
+	uint32_t replacement_char = 0xfffd;
+	uint32_t invalid_char = '?';
+	struct kmscon_glyph *glyph;
 
-	return font->ops->render(font, id, ch, len);
-}
-
-/**
- * kmscon_font_render_empty:
- * @font: Valid font object
- *
- * Same as kmscon_font_render() but this renders a glyph that has no content and
- * can be used to blit solid backgrounds. That is, the resulting buffer will be
- * all 0 but the dimensions are the same as for all other glyphs.
- *
- * Returns: a new allocated glyph object on success, NULL on failure
- */
-SHL_EXPORT
-struct kmscon_glyph *kmscon_font_render_empty(struct kmscon_font *font)
-{
 	if (!font)
 		return NULL;
 
-	return font->ops->render_empty(font);
-}
+	if (!len) {
+		return font->ops->render(font, empty_char, &empty_char, 1);
+	}
 
-/**
- * kmscon_font_render_inval:
- * @font: Valid font object
- *
- * Same as kmscon_font_render_empty() but renders a glyph that can be used as
- * replacement for any other non-drawable glyph. That is, if
- * kmscon_font_render() returns NULL, then this glyph can be used as
- * replacement.
- *
- * Returns: a new allocated glyph object on success, NULL on failure
- */
-SHL_EXPORT
-struct kmscon_glyph *kmscon_font_render_inval(struct kmscon_font *font)
-{
-	if (!font)
-		return NULL;
-
-	return font->ops->render_inval(font);
+	glyph = font->ops->render(font, id, ch, len);
+	if (!glyph)
+		glyph = font->ops->render(font, replacement_char, &replacement_char, 1);
+	if (!glyph)
+		glyph = font->ops->render(font, invalid_char, &invalid_char, 1);
+	return glyph;
 }

--- a/src/font.c
+++ b/src/font.c
@@ -343,63 +343,57 @@ void kmscon_font_unref(struct kmscon_font *font)
  * @id: Unique ID that identifies @ch globally
  * @ch: Symbol to find a glyph for
  * @len: Length of @ch
- * @out: Output buffer for glyph
  *
- * Renders the glyph for symbol @sym and places a pointer to the glyph in @out.
- * If the glyph cannot be found or is invalid, an error is returned. The glyph
- * is cached internally and removed when the last reference to this font is
- * dropped.
- * If the glyph is no available in this font-set, then -ERANGE is returned.
+ * Renders the glyph for symbol @ch and returns a pointer to the glyph.
+ * If the glyph cannot be found or is invalid, NULL is returned.
  *
- * Returns: 0 on success, negative error code on failure
+ * Returns: a new allocated glyph object on success, NULL on failure
  */
 SHL_EXPORT
-int kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch, size_t len,
-		       const struct kmscon_glyph **out)
+struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
+					size_t len)
 {
-	if (!font || !out || !ch || !len)
-		return -EINVAL;
+	if (!font || !ch || !len)
+		return NULL;
 
-	return font->ops->render(font, id, ch, len, out);
+	return font->ops->render(font, id, ch, len);
 }
 
 /**
  * kmscon_font_render_empty:
  * @font: Valid font object
- * @out: Output buffer for glyph
  *
  * Same as kmscon_font_render() but this renders a glyph that has no content and
  * can be used to blit solid backgrounds. That is, the resulting buffer will be
  * all 0 but the dimensions are the same as for all other glyphs.
  *
- * Returns: 0 on success, negative error code on failure
+ * Returns: a new allocated glyph object on success, NULL on failure
  */
 SHL_EXPORT
-int kmscon_font_render_empty(struct kmscon_font *font, const struct kmscon_glyph **out)
+struct kmscon_glyph *kmscon_font_render_empty(struct kmscon_font *font)
 {
-	if (!font || !out)
-		return -EINVAL;
+	if (!font)
+		return NULL;
 
-	return font->ops->render_empty(font, out);
+	return font->ops->render_empty(font);
 }
 
 /**
  * kmscon_font_render_inval:
  * @font: Valid font object
- * @out: Output buffer for glyph
  *
- * Same sa kmscon_font_render_empty() but renders a glyph that can be used as
+ * Same as kmscon_font_render_empty() but renders a glyph that can be used as
  * replacement for any other non-drawable glyph. That is, if
- * kmscon_font_render() returns -ERANGE, then this glyph can be used as
+ * kmscon_font_render() returns NULL, then this glyph can be used as
  * replacement.
  *
- * Returns: 0 on success ,engative error code on failure
+ * Returns: a new allocated glyph object on success, NULL on failure
  */
 SHL_EXPORT
-int kmscon_font_render_inval(struct kmscon_font *font, const struct kmscon_glyph **out)
+struct kmscon_glyph *kmscon_font_render_inval(struct kmscon_font *font)
 {
-	if (!font || !out)
-		return -EINVAL;
+	if (!font)
+		return NULL;
 
-	return font->ops->render_inval(font, out);
+	return font->ops->render_inval(font);
 }

--- a/src/font.h
+++ b/src/font.h
@@ -91,10 +91,10 @@ struct kmscon_font_ops {
 	struct shl_module *owner;
 	int (*init)(struct kmscon_font *out, const struct kmscon_font_attr *attr);
 	void (*destroy)(struct kmscon_font *font);
-	int (*render)(struct kmscon_font *font, uint64_t id, const uint32_t *ch, size_t len,
-		      const struct kmscon_glyph **out);
-	int (*render_empty)(struct kmscon_font *font, const struct kmscon_glyph **out);
-	int (*render_inval)(struct kmscon_font *font, const struct kmscon_glyph **out);
+	struct kmscon_glyph *(*render)(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
+				       size_t len);
+	struct kmscon_glyph *(*render_empty)(struct kmscon_font *font);
+	struct kmscon_glyph *(*render_inval)(struct kmscon_font *font);
 };
 
 int kmscon_font_register(const struct kmscon_font_ops *ops);
@@ -105,10 +105,10 @@ int kmscon_font_find(struct kmscon_font **out, const struct kmscon_font_attr *at
 void kmscon_font_ref(struct kmscon_font *font);
 void kmscon_font_unref(struct kmscon_font *font);
 
-int kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch, size_t len,
-		       const struct kmscon_glyph **out);
-int kmscon_font_render_empty(struct kmscon_font *font, const struct kmscon_glyph **out);
-int kmscon_font_render_inval(struct kmscon_font *font, const struct kmscon_glyph **out);
+struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
+					size_t len);
+struct kmscon_glyph *kmscon_font_render_empty(struct kmscon_font *font);
+struct kmscon_glyph *kmscon_font_render_inval(struct kmscon_font *font);
 
 /* modularized backends */
 

--- a/src/font.h
+++ b/src/font.h
@@ -68,9 +68,14 @@ void kmscon_font_attr_normalize(struct kmscon_font_attr *attr);
 bool kmscon_font_attr_match(const struct kmscon_font_attr *a1, const struct kmscon_font_attr *a2);
 
 struct kmscon_glyph {
-	unsigned int width;
+	bool double_width;
 	struct uterm_video_buffer buf; // Must be last
 };
+
+static inline unsigned int kmscon_glyph_cwidth(const struct kmscon_glyph *glyph)
+{
+	return glyph->double_width ? 2 : 1;
+}
 
 struct kmscon_font {
 	unsigned long ref;

--- a/src/font.h
+++ b/src/font.h
@@ -93,8 +93,6 @@ struct kmscon_font_ops {
 	void (*destroy)(struct kmscon_font *font);
 	struct kmscon_glyph *(*render)(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
 				       size_t len);
-	struct kmscon_glyph *(*render_empty)(struct kmscon_font *font);
-	struct kmscon_glyph *(*render_inval)(struct kmscon_font *font);
 };
 
 int kmscon_font_register(const struct kmscon_font_ops *ops);
@@ -107,8 +105,6 @@ void kmscon_font_unref(struct kmscon_font *font);
 
 struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
 					size_t len);
-struct kmscon_glyph *kmscon_font_render_empty(struct kmscon_font *font);
-struct kmscon_glyph *kmscon_font_render_inval(struct kmscon_font *font);
 
 /* modularized backends */
 

--- a/src/font.h
+++ b/src/font.h
@@ -68,8 +68,8 @@ void kmscon_font_attr_normalize(struct kmscon_font_attr *attr);
 bool kmscon_font_attr_match(const struct kmscon_font_attr *a1, const struct kmscon_font_attr *a2);
 
 struct kmscon_glyph {
-	struct uterm_video_buffer buf;
 	unsigned int width;
+	struct uterm_video_buffer buf; // Must be last
 };
 
 struct kmscon_font {

--- a/src/font_8x16.c
+++ b/src/font_8x16.c
@@ -100,7 +100,6 @@ static struct kmscon_glyph *new_glyph(uint32_t ch)
 	glyph->buf.width = 8;
 	glyph->buf.height = 16;
 	glyph->buf.stride = 8;
-	glyph->buf.format = UTERM_FORMAT_GREY;
 
 	for (i = 0; i < 16; i++) {
 		for (j = 0; j < 8; j++) {

--- a/src/font_8x16.c
+++ b/src/font_8x16.c
@@ -119,22 +119,10 @@ static struct kmscon_glyph *kmscon_font_8x16_render(struct kmscon_font *font, ui
 	return new_glyph(*ch);
 }
 
-static struct kmscon_glyph *kmscon_font_8x16_render_empty(struct kmscon_font *font)
-{
-	return new_glyph(' ');
-}
-
-static struct kmscon_glyph *kmscon_font_8x16_render_inval(struct kmscon_font *font)
-{
-	return new_glyph('?');
-}
-
 struct kmscon_font_ops kmscon_font_8x16_ops = {
 	.name = "8x16",
 	.owner = NULL,
 	.init = kmscon_font_8x16_init,
 	.destroy = kmscon_font_8x16_destroy,
 	.render = kmscon_font_8x16_render,
-	.render_empty = kmscon_font_8x16_render_empty,
-	.render_inval = kmscon_font_8x16_render_inval,
 };

--- a/src/font_8x16.c
+++ b/src/font_8x16.c
@@ -110,32 +110,23 @@ static struct kmscon_glyph *new_glyph(uint32_t ch)
 	return glyph;
 }
 
-static int kmscon_font_8x16_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
-				   size_t len, const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_8x16_render(struct kmscon_font *font, uint64_t id,
+						    const uint32_t *ch, size_t len)
 {
-	struct kmscon_glyph *glyph;
-
 	if (len > 1 || *ch >= 256)
-		return -ERANGE;
+		return NULL;
 
-	glyph = new_glyph(*ch);
-	if (!glyph)
-		return -ENOMEM;
-
-	*out = glyph;
-	return 0;
+	return new_glyph(*ch);
 }
 
-static int kmscon_font_8x16_render_empty(struct kmscon_font *font, const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_8x16_render_empty(struct kmscon_font *font)
 {
-	*out = new_glyph(' ');
-	return 0;
+	return new_glyph(' ');
 }
 
-static int kmscon_font_8x16_render_inval(struct kmscon_font *font, const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_8x16_render_inval(struct kmscon_font *font)
 {
-	*out = new_glyph('?');
-	return 0;
+	return new_glyph('?');
 }
 
 struct kmscon_font_ops kmscon_font_8x16_ops = {

--- a/src/font_8x16.c
+++ b/src/font_8x16.c
@@ -92,7 +92,7 @@ static struct kmscon_glyph *new_glyph(uint32_t ch)
 	if (font_data + 16 > _binary_font_8x16_data_end)
 		return NULL;
 
-	glyph = malloc(sizeof(*glyph));
+	glyph = malloc(sizeof(*glyph) + 8 * 16);
 	if (!glyph)
 		return NULL;
 
@@ -102,10 +102,6 @@ static struct kmscon_glyph *new_glyph(uint32_t ch)
 	glyph->buf.stride = 8;
 	glyph->buf.format = UTERM_FORMAT_GREY;
 
-	glyph->buf.data = malloc(glyph->buf.stride * glyph->buf.height);
-	if (!glyph->buf.data)
-		goto err_free;
-
 	for (i = 0; i < 16; i++) {
 		for (j = 0; j < 8; j++) {
 			c = (uint8_t)font_data[i];
@@ -113,10 +109,6 @@ static struct kmscon_glyph *new_glyph(uint32_t ch)
 		}
 	}
 	return glyph;
-
-err_free:
-	free(glyph);
-	return NULL;
 }
 
 static int kmscon_font_8x16_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,

--- a/src/font_8x16.c
+++ b/src/font_8x16.c
@@ -96,7 +96,7 @@ static struct kmscon_glyph *new_glyph(uint32_t ch)
 	if (!glyph)
 		return NULL;
 
-	glyph->width = 1;
+	glyph->double_width = false;
 	glyph->buf.width = 8;
 	glyph->buf.height = 16;
 	glyph->buf.stride = 8;

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -480,24 +480,10 @@ static struct kmscon_glyph *kmscon_font_freetype_render(struct kmscon_font *font
 	return glyph;
 }
 
-static struct kmscon_glyph *kmscon_font_freetype_render_empty(struct kmscon_font *font)
-{
-	static const uint32_t empty_char = ' ';
-	return kmscon_font_freetype_render(font, empty_char, &empty_char, 1);
-}
-
-static struct kmscon_glyph *kmscon_font_freetype_render_inval(struct kmscon_font *font)
-{
-	static const uint32_t question_mark = '?';
-	return kmscon_font_freetype_render(font, question_mark, &question_mark, 1);
-}
-
 struct kmscon_font_ops kmscon_font_freetype_ops = {
 	.name = "freetype",
 	.owner = NULL,
 	.init = kmscon_font_freetype_init,
 	.destroy = kmscon_font_freetype_destroy,
 	.render = kmscon_font_freetype_render,
-	.render_empty = kmscon_font_freetype_render_empty,
-	.render_inval = kmscon_font_freetype_render_inval,
 };

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -57,7 +57,6 @@ static void free_glyph(void *data)
 {
 	struct kmscon_glyph *g = data;
 
-	free(g->buf.data);
 	free(g);
 }
 
@@ -381,26 +380,19 @@ static int render_glyph(struct shl_hashtable *cache, FT_Face face, FT_UInt index
 		return -EINVAL;
 	}
 
-	glyph = malloc(sizeof(*glyph));
+	cwidth = (glyph_is_wide(face->glyph, attr->width) ? 2 : cwidth);
+	glyph = malloc(sizeof(*glyph) + cwidth * attr->width * attr->height);
 	if (!glyph) {
 		log_error("cannot allocate memory for new glyph");
 		return -ENOMEM;
 	}
-	memset(glyph, 0, sizeof(*glyph));
+	memset(glyph, 0, sizeof(*glyph) + cwidth * attr->width * attr->height);
 
-	glyph->width = glyph_is_wide(face->glyph, attr->width) ? 2 : cwidth;
+	glyph->width = cwidth;
 	glyph->buf.width = attr->width * glyph->width;
 	glyph->buf.height = attr->height;
 	glyph->buf.stride = glyph->buf.width;
 	glyph->buf.format = UTERM_FORMAT_GREY;
-
-	glyph->buf.data = malloc(glyph->buf.height * glyph->buf.stride);
-	if (!glyph->buf.data) {
-		log_error("cannot allocate bitmap memory");
-		free(glyph);
-		return -ENOMEM;
-	}
-	memset(glyph->buf.data, 0, glyph->buf.height * glyph->buf.stride);
 
 	if (face->glyph->bitmap.pixel_mode == FT_PIXEL_MODE_MONO)
 		copy_mono(&glyph->buf, &face->glyph->bitmap, attr->underline);

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -32,7 +32,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include "font.h"
-#include "shl_hashtable.h"
 #include "shl_log.h"
 #include "shl_misc.h"
 #include "uterm_video.h"
@@ -50,15 +49,7 @@ struct ft_data {
 	FT_Library ft;
 	struct ft_font regular;
 	struct ft_font bold;
-	struct shl_hashtable *cache;
 };
-
-static void free_glyph(void *data)
-{
-	struct kmscon_glyph *g = data;
-
-	free(g);
-}
 
 static void print_font_name(FcPattern *pattern)
 {
@@ -223,13 +214,10 @@ static int kmscon_font_freetype_init(struct kmscon_font *out, const struct kmsco
 	kmscon_copy_attr(&bold_attr, &out->attr);
 	bold_attr.bold = true;
 
-	if (shl_hashtable_new(&ftf->cache, shl_direct_hash, shl_direct_equal, free_glyph))
-		goto err_free;
-
 	err = FT_Init_FreeType(&ftf->ft);
 	if (err != 0) {
 		log_err("Failed to initialize FreeType\n");
-		goto err_freecache;
+		goto err_free;
 	}
 	if (prepare_font(ftf->ft, &ftf->regular, &out->attr))
 		goto err_done;
@@ -253,8 +241,6 @@ err_free_reg:
 	free_ft_font(&ftf->regular);
 err_done:
 	FT_Done_FreeType(ftf->ft);
-err_freecache:
-	shl_hashtable_free(ftf->cache);
 err_free:
 	free(ftf);
 	return -EINVAL;
@@ -268,7 +254,6 @@ static void kmscon_font_freetype_destroy(struct kmscon_font *font)
 	free_ft_font(&ftf->regular);
 	free_ft_font(&ftf->bold);
 	FT_Done_FreeType(ftf->ft);
-	shl_hashtable_free(ftf->cache);
 	free(ftf);
 	font->data = NULL;
 }
@@ -359,9 +344,8 @@ static void copy_glyph(struct uterm_video_buffer *buf, FT_Face face, FT_Bitmap *
 		draw_underline(buf, face);
 }
 
-static struct kmscon_glyph *render_glyph(struct shl_hashtable *cache, FT_Face face, FT_UInt index,
-					 uint64_t id, const uint32_t *ch,
-					 const struct kmscon_font_attr *attr)
+static struct kmscon_glyph *render_glyph(FT_Face face, FT_UInt index, uint64_t id,
+					 const uint32_t *ch, const struct kmscon_font_attr *attr)
 {
 	unsigned int cwidth;
 	struct kmscon_glyph *glyph;
@@ -398,10 +382,6 @@ static struct kmscon_glyph *render_glyph(struct shl_hashtable *cache, FT_Face fa
 	else
 		copy_glyph(&glyph->buf, face, &face->glyph->bitmap, attr->underline);
 
-	if (shl_hashtable_insert(cache, id, glyph)) {
-		free(glyph);
-		return NULL;
-	}
 	return glyph;
 }
 
@@ -483,12 +463,10 @@ static struct kmscon_glyph *kmscon_font_freetype_render(struct kmscon_font *font
 	if (!len)
 		return NULL;
 
-	if (shl_hashtable_find(ftd->cache, (void **)&glyph, id))
-		return glyph;
-
 	if (glyph_index)
-		return render_glyph(ftd->cache, ftfont->face, glyph_index, id, ch, &font->attr);
+		return render_glyph(ftfont->face, glyph_index, id, ch, &font->attr);
 
+	/* Fallback, if the glyph is not found in the regular font */
 	fallback_index = get_fallback(*ch, ftfont);
 	fallback = prepare_tmp_face(ftd->ft, ftfont, fallback_index);
 
@@ -497,7 +475,7 @@ static struct kmscon_glyph *kmscon_font_freetype_render(struct kmscon_font *font
 
 	select_font_size(fallback, &font->attr);
 	glyph_index = FT_Get_Char_Index(fallback, *ch);
-	glyph = render_glyph(ftd->cache, fallback, glyph_index, id, ch, &font->attr);
+	glyph = render_glyph(fallback, glyph_index, id, ch, &font->attr);
 	FT_Done_Face(fallback);
 	return glyph;
 }

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -359,32 +359,32 @@ static void copy_glyph(struct uterm_video_buffer *buf, FT_Face face, FT_Bitmap *
 		draw_underline(buf, face);
 }
 
-static int render_glyph(struct shl_hashtable *cache, FT_Face face, FT_UInt index, uint64_t id,
-			const uint32_t *ch, const struct kmscon_font_attr *attr,
-			const struct kmscon_glyph **out)
+static struct kmscon_glyph *render_glyph(struct shl_hashtable *cache, FT_Face face, FT_UInt index,
+					 uint64_t id, const uint32_t *ch,
+					 const struct kmscon_font_attr *attr)
 {
 	unsigned int cwidth;
 	struct kmscon_glyph *glyph;
 
 	cwidth = tsm_ucs4_get_width(*ch);
 	if (!cwidth)
-		return -ERANGE;
+		return NULL;
 
 	if (FT_Load_Glyph(face, index, FT_LOAD_NO_HINTING)) {
 		log_err("Failed to load glyph\n");
-		return -EINVAL;
+		return NULL;
 	}
 
 	if (FT_Render_Glyph(face->glyph, FT_RENDER_MODE_NORMAL)) {
 		log_err("Failed to render glyph\n");
-		return -EINVAL;
+		return NULL;
 	}
 
 	cwidth = glyph_is_wide(face->glyph, attr->width) ? 2 : cwidth;
 	glyph = malloc(sizeof(*glyph) + cwidth * attr->width * attr->height);
 	if (!glyph) {
 		log_error("cannot allocate memory for new glyph");
-		return -ENOMEM;
+		return NULL;
 	}
 	memset(glyph, 0, sizeof(*glyph) + cwidth * attr->width * attr->height);
 
@@ -398,10 +398,11 @@ static int render_glyph(struct shl_hashtable *cache, FT_Face face, FT_UInt index
 	else
 		copy_glyph(&glyph->buf, face, &face->glyph->bitmap, attr->underline);
 
-	shl_hashtable_insert(cache, id, glyph);
-
-	*out = glyph;
-	return 0;
+	if (shl_hashtable_insert(cache, id, glyph)) {
+		free(glyph);
+		return NULL;
+	}
+	return glyph;
 }
 
 static void select_font_size(FT_Face face, struct kmscon_font_attr *attr)
@@ -469,51 +470,48 @@ static int get_fallback(uint32_t ch, struct ft_font *ftf)
 	return -EINVAL;
 }
 
-static int kmscon_font_freetype_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
-				       size_t len, const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_freetype_render(struct kmscon_font *font, uint64_t id,
+							const uint32_t *ch, size_t len)
 {
 	struct ft_data *ftd = font->data;
 	struct ft_font *ftfont = font->attr.bold ? &ftd->bold : &ftd->regular;
 	FT_UInt glyph_index = FT_Get_Char_Index(ftfont->face, *ch);
 	int fallback_index;
 	FT_Face fallback;
-	int ret;
+	struct kmscon_glyph *glyph;
 
 	if (!len)
-		return -ERANGE;
+		return NULL;
 
-	if (shl_hashtable_find(ftd->cache, (void **)out, id))
-		return 0;
+	if (shl_hashtable_find(ftd->cache, (void **)&glyph, id))
+		return glyph;
 
 	if (glyph_index)
-		return render_glyph(ftd->cache, ftfont->face, glyph_index, id, ch, &font->attr,
-				    out);
+		return render_glyph(ftd->cache, ftfont->face, glyph_index, id, ch, &font->attr);
 
 	fallback_index = get_fallback(*ch, ftfont);
 	fallback = prepare_tmp_face(ftd->ft, ftfont, fallback_index);
 
-	if (fallback) {
-		select_font_size(fallback, &font->attr);
-		glyph_index = FT_Get_Char_Index(fallback, *ch);
-		ret = render_glyph(ftd->cache, fallback, glyph_index, id, ch, &font->attr, out);
-		FT_Done_Face(fallback);
-		return ret;
-	}
-	return -EINVAL;
+	if (!fallback)
+		return NULL;
+
+	select_font_size(fallback, &font->attr);
+	glyph_index = FT_Get_Char_Index(fallback, *ch);
+	glyph = render_glyph(ftd->cache, fallback, glyph_index, id, ch, &font->attr);
+	FT_Done_Face(fallback);
+	return glyph;
 }
 
-static int kmscon_font_freetype_render_empty(struct kmscon_font *font,
-					     const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_freetype_render_empty(struct kmscon_font *font)
 {
 	static const uint32_t empty_char = ' ';
-	return kmscon_font_freetype_render(font, empty_char, &empty_char, 1, out);
+	return kmscon_font_freetype_render(font, empty_char, &empty_char, 1);
 }
 
-static int kmscon_font_freetype_render_inval(struct kmscon_font *font,
-					     const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_freetype_render_inval(struct kmscon_font *font)
 {
 	static const uint32_t question_mark = '?';
-	return kmscon_font_freetype_render(font, question_mark, &question_mark, 1, out);
+	return kmscon_font_freetype_render(font, question_mark, &question_mark, 1);
 }
 
 struct kmscon_font_ops kmscon_font_freetype_ops = {

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -380,7 +380,7 @@ static int render_glyph(struct shl_hashtable *cache, FT_Face face, FT_UInt index
 		return -EINVAL;
 	}
 
-	cwidth = (glyph_is_wide(face->glyph, attr->width) ? 2 : cwidth);
+	cwidth = glyph_is_wide(face->glyph, attr->width) ? 2 : cwidth;
 	glyph = malloc(sizeof(*glyph) + cwidth * attr->width * attr->height);
 	if (!glyph) {
 		log_error("cannot allocate memory for new glyph");
@@ -388,8 +388,8 @@ static int render_glyph(struct shl_hashtable *cache, FT_Face face, FT_UInt index
 	}
 	memset(glyph, 0, sizeof(*glyph) + cwidth * attr->width * attr->height);
 
-	glyph->width = cwidth;
-	glyph->buf.width = attr->width * glyph->width;
+	glyph->double_width = cwidth == 2;
+	glyph->buf.width = attr->width * cwidth;
 	glyph->buf.height = attr->height;
 	glyph->buf.stride = glyph->buf.width;
 

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -392,7 +392,6 @@ static int render_glyph(struct shl_hashtable *cache, FT_Face face, FT_UInt index
 	glyph->buf.width = attr->width * glyph->width;
 	glyph->buf.height = attr->height;
 	glyph->buf.stride = glyph->buf.width;
-	glyph->buf.format = UTERM_FORMAT_GREY;
 
 	if (face->glyph->bitmap.pixel_mode == FT_PIXEL_MODE_MONO)
 		copy_mono(&glyph->buf, &face->glyph->bitmap, attr->underline);

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -198,8 +198,8 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 	}
 	memset(glyph, 0, sizeof(*glyph) + cwidth * face->real_attr.width * face->real_attr.height);
 
-	glyph->width = cwidth;
-	glyph->buf.width = face->real_attr.width * glyph->width;
+	glyph->double_width = cwidth == 2;
+	glyph->buf.width = face->real_attr.width * cwidth;
 	glyph->buf.height = face->real_attr.height;
 	glyph->buf.stride = glyph->buf.width;
 

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -202,7 +202,6 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 	glyph->buf.width = face->real_attr.width * glyph->width;
 	glyph->buf.height = face->real_attr.height;
 	glyph->buf.stride = glyph->buf.width;
-	glyph->buf.format = UTERM_FORMAT_GREY;
 
 	bitmap.rows = glyph->buf.height;
 	bitmap.width = glyph->buf.width;

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -105,8 +105,8 @@ static void manager__unref()
 	}
 }
 
-static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, const uint32_t *ch,
-		     size_t len, const struct kmscon_font_attr *attr)
+static struct kmscon_glyph *get_glyph(struct face *face, uint64_t id, const uint32_t *ch,
+				      size_t len, const struct kmscon_font_attr *attr)
 {
 	struct kmscon_glyph *glyph;
 	PangoLayout *layout;
@@ -121,18 +121,16 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 	int ret;
 
 	if (!len)
-		return -ERANGE;
+		return NULL;
 	cwidth = tsm_ucs4_get_width(*ch);
 	if (!cwidth)
-		return -ERANGE;
+		return NULL;
 
 	pthread_mutex_lock(&face->glyph_lock);
 	res = shl_hashtable_find(face->glyphs, (void **)&glyph, id);
 	pthread_mutex_unlock(&face->glyph_lock);
-	if (res) {
-		*out = glyph;
-		return 0;
-	}
+	if (res)
+		return glyph;
 
 	manager_lock();
 
@@ -169,18 +167,15 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 		pango_attr_list_change(attrlist, pango_attr_weight_new(PANGO_WEIGHT_NORMAL));
 
 	val = tsm_ucs4_to_utf8_alloc(ch, len, &ulen);
-	if (!val) {
-		ret = -ERANGE;
+	if (!val)
 		goto out_layout;
-	}
+
 	pango_layout_set_text(layout, val, ulen);
 	free(val);
 
 	cnt = pango_layout_get_line_count(layout);
-	if (cnt == 0) {
-		ret = -ERANGE;
+	if (cnt == 0)
 		goto out_layout;
-	}
 
 	line = pango_layout_get_line_readonly(layout, 0);
 
@@ -193,7 +188,6 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 	glyph = malloc(sizeof(*glyph) + cwidth * face->real_attr.width * face->real_attr.height);
 	if (!glyph) {
 		log_error("cannot allocate memory for new glyph");
-		ret = -ENOMEM;
 		goto out_unlock;
 	}
 	memset(glyph, 0, sizeof(*glyph) + cwidth * face->real_attr.width * face->real_attr.height);
@@ -219,9 +213,9 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 		log_error("cannot add glyph to hashtable");
 		goto out_glyph;
 	}
-
-	*out = glyph;
-	goto out_layout;
+	g_object_unref(layout);
+	manager_unlock();
+	return glyph;
 
 out_glyph:
 	free(glyph);
@@ -229,7 +223,7 @@ out_layout:
 	g_object_unref(layout);
 out_unlock:
 	manager_unlock();
-	return ret;
+	return NULL;
 }
 
 static void free_glyph(void *data)
@@ -434,30 +428,22 @@ static void kmscon_font_pango_destroy(struct kmscon_font *font)
 	manager_unlock();
 }
 
-static int kmscon_font_pango_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
-				    size_t len, const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_pango_render(struct kmscon_font *font, uint64_t id,
+						     const uint32_t *ch, size_t len)
 {
-	struct kmscon_glyph *glyph;
-	int ret;
-
-	ret = get_glyph(font->data, &glyph, id, ch, len, &font->attr);
-	if (ret)
-		return ret;
-
-	*out = glyph;
-	return 0;
+	return get_glyph(font->data, id, ch, len, &font->attr);
 }
 
-static int kmscon_font_pango_render_empty(struct kmscon_font *font, const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_pango_render_empty(struct kmscon_font *font)
 {
 	static const uint32_t empty_char = ' ';
-	return kmscon_font_pango_render(font, empty_char, &empty_char, 1, out);
+	return kmscon_font_pango_render(font, empty_char, &empty_char, 1);
 }
 
-static int kmscon_font_pango_render_inval(struct kmscon_font *font, const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_pango_render_inval(struct kmscon_font *font)
 {
 	static const uint32_t question_mark = '?';
-	return kmscon_font_pango_render(font, question_mark, &question_mark, 1, out);
+	return kmscon_font_pango_render(font, question_mark, &question_mark, 1);
 }
 
 struct kmscon_font_ops kmscon_font_pango_ops = {

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -383,24 +383,10 @@ static struct kmscon_glyph *kmscon_font_pango_render(struct kmscon_font *font, u
 	return get_glyph(font->data, id, ch, len, &font->attr);
 }
 
-static struct kmscon_glyph *kmscon_font_pango_render_empty(struct kmscon_font *font)
-{
-	static const uint32_t empty_char = ' ';
-	return kmscon_font_pango_render(font, empty_char, &empty_char, 1);
-}
-
-static struct kmscon_glyph *kmscon_font_pango_render_inval(struct kmscon_font *font)
-{
-	static const uint32_t question_mark = '?';
-	return kmscon_font_pango_render(font, question_mark, &question_mark, 1);
-}
-
 struct kmscon_font_ops kmscon_font_pango_ops = {
 	.name = "pango",
 	.owner = NULL,
 	.init = kmscon_font_pango_init,
 	.destroy = kmscon_font_pango_destroy,
 	.render = kmscon_font_pango_render,
-	.render_empty = kmscon_font_pango_render_empty,
-	.render_inval = kmscon_font_pango_render_inval,
 };

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -136,14 +136,6 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 
 	manager_lock();
 
-	glyph = malloc(sizeof(*glyph));
-	if (!glyph) {
-		log_error("cannot allocate memory for new glyph");
-		ret = -ENOMEM;
-		goto out_unlock;
-	}
-	memset(glyph, 0, sizeof(*glyph));
-
 	layout = pango_layout_new(face->ctx);
 	attrlist = pango_layout_get_attributes(layout);
 	if (attrlist == NULL) {
@@ -179,7 +171,7 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 	val = tsm_ucs4_to_utf8_alloc(ch, len, &ulen);
 	if (!val) {
 		ret = -ERANGE;
-		goto out_glyph;
+		goto out_layout;
 	}
 	pango_layout_set_text(layout, val, ulen);
 	free(val);
@@ -187,7 +179,7 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 	cnt = pango_layout_get_line_count(layout);
 	if (cnt == 0) {
 		ret = -ERANGE;
-		goto out_glyph;
+		goto out_layout;
 	}
 
 	line = pango_layout_get_line_readonly(layout, 0);
@@ -195,25 +187,22 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 	pango_layout_line_get_extents(line, &logical_rec, &rec);
 	pango_extents_to_pixels(&rec, &logical_rec);
 
-	glyph->width =
-		(logical_rec.x + logical_rec.width > rec.x + face->real_attr.width) ? 2 : cwidth;
+	if (logical_rec.x + logical_rec.width > rec.x + face->real_attr.width)
+		cwidth = 2;
+
+	glyph = malloc(sizeof(*glyph) + cwidth * face->real_attr.width * face->real_attr.height);
+	if (!glyph) {
+		log_error("cannot allocate memory for new glyph");
+		ret = -ENOMEM;
+		goto out_unlock;
+	}
+	memset(glyph, 0, sizeof(*glyph) + cwidth * face->real_attr.width * face->real_attr.height);
+
+	glyph->width = cwidth;
 	glyph->buf.width = face->real_attr.width * glyph->width;
 	glyph->buf.height = face->real_attr.height;
 	glyph->buf.stride = glyph->buf.width;
 	glyph->buf.format = UTERM_FORMAT_GREY;
-
-	if (!glyph->buf.width || !glyph->buf.height) {
-		ret = -ERANGE;
-		goto out_glyph;
-	}
-
-	glyph->buf.data = malloc(glyph->buf.height * glyph->buf.stride);
-	if (!glyph->buf.data) {
-		log_error("cannot allocate bitmap memory");
-		ret = -ENOMEM;
-		goto out_glyph;
-	}
-	memset(glyph->buf.data, 0, glyph->buf.height * glyph->buf.stride);
 
 	bitmap.rows = glyph->buf.height;
 	bitmap.width = glyph->buf.width;
@@ -229,14 +218,12 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out, uint64_t id, 
 	pthread_mutex_unlock(&face->glyph_lock);
 	if (ret) {
 		log_error("cannot add glyph to hashtable");
-		goto out_buffer;
+		goto out_glyph;
 	}
 
 	*out = glyph;
 	goto out_layout;
 
-out_buffer:
-	free(glyph->buf.data);
 out_glyph:
 	free(glyph);
 out_layout:
@@ -250,7 +237,6 @@ static void free_glyph(void *data)
 {
 	struct kmscon_glyph *glyph = data;
 
-	free(glyph->buf.data);
 	free(glyph);
 }
 

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -43,7 +43,6 @@
  * pango, freetype2 and more.
  */
 
-#include <errno.h>
 #include <glib.h>
 #include <libtsm.h>
 #include <pango/pango.h>
@@ -53,8 +52,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include "font.h"
-#include "shl_dlist.h"
-#include "shl_hashtable.h"
 #include "shl_log.h"
 #include "uterm_video.h"
 
@@ -65,8 +62,6 @@ struct face {
 	struct kmscon_font_attr real_attr;
 	unsigned int baseline;
 	PangoContext *ctx;
-	pthread_mutex_t glyph_lock;
-	struct shl_hashtable *glyphs;
 };
 
 static pthread_mutex_t manager_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -108,7 +103,7 @@ static void manager__unref()
 static struct kmscon_glyph *get_glyph(struct face *face, uint64_t id, const uint32_t *ch,
 				      size_t len, const struct kmscon_font_attr *attr)
 {
-	struct kmscon_glyph *glyph;
+	struct kmscon_glyph *glyph = NULL;
 	PangoLayout *layout;
 	PangoAttrList *attrlist;
 	PangoRectangle rec, logical_rec;
@@ -117,20 +112,12 @@ static struct kmscon_glyph *get_glyph(struct face *face, uint64_t id, const uint
 	unsigned int cwidth;
 	size_t ulen, cnt;
 	char *val;
-	bool res;
-	int ret;
 
 	if (!len)
 		return NULL;
 	cwidth = tsm_ucs4_get_width(*ch);
 	if (!cwidth)
 		return NULL;
-
-	pthread_mutex_lock(&face->glyph_lock);
-	res = shl_hashtable_find(face->glyphs, (void **)&glyph, id);
-	pthread_mutex_unlock(&face->glyph_lock);
-	if (res)
-		return glyph;
 
 	manager_lock();
 
@@ -206,31 +193,11 @@ static struct kmscon_glyph *get_glyph(struct face *face, uint64_t id, const uint
 
 	pango_ft2_render_layout_line(&bitmap, line, -rec.x, face->baseline);
 
-	pthread_mutex_lock(&face->glyph_lock);
-	ret = shl_hashtable_insert(face->glyphs, id, glyph);
-	pthread_mutex_unlock(&face->glyph_lock);
-	if (ret) {
-		log_error("cannot add glyph to hashtable");
-		goto out_glyph;
-	}
-	g_object_unref(layout);
-	manager_unlock();
-	return glyph;
-
-out_glyph:
-	free(glyph);
 out_layout:
 	g_object_unref(layout);
 out_unlock:
 	manager_unlock();
-	return NULL;
-}
-
-static void free_glyph(void *data)
-{
-	struct kmscon_glyph *glyph = data;
-
-	free(glyph);
+	return glyph;
 }
 
 /*
@@ -306,18 +273,6 @@ static int manager_get_face(struct face **out, struct kmscon_font_attr *attr)
 	memset(face, 0, sizeof(*face));
 	memcpy(&face->attr, attr, sizeof(*attr));
 
-	ret = pthread_mutex_init(&face->glyph_lock, NULL);
-	if (ret) {
-		log_error("cannot initialize glyph lock");
-		goto err_free;
-	}
-
-	ret = shl_hashtable_new(&face->glyphs, shl_direct_hash, shl_direct_equal, free_glyph);
-	if (ret) {
-		log_error("cannot allocate hashtable");
-		goto err_lock;
-	}
-
 	face->ctx = pango_font_map_create_context(manager__lib);
 	pango_context_set_base_dir(face->ctx, PANGO_DIRECTION_LTR);
 	pango_context_set_language(face->ctx, pango_language_get_default());
@@ -365,10 +320,6 @@ static int manager_get_face(struct face **out, struct kmscon_font_attr *attr)
 
 err_face:
 	g_object_unref(face->ctx);
-	shl_hashtable_free(face->glyphs);
-err_lock:
-	pthread_mutex_destroy(&face->glyph_lock);
-err_free:
 	free(face);
 err_manager:
 	manager__unref();
@@ -419,8 +370,6 @@ static void kmscon_font_pango_destroy(struct kmscon_font *font)
 
 	manager_lock();
 
-	shl_hashtable_free(face->glyphs);
-	pthread_mutex_destroy(&face->glyph_lock);
 	g_object_unref(face->ctx);
 	free(face);
 	manager__unref();

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -175,7 +175,7 @@ static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const
 	return g;
 }
 
-static int find_glyph(uint64_t id, const struct kmscon_glyph **out, const struct kmscon_font *font)
+static struct kmscon_glyph *find_glyph(uint64_t id, const struct kmscon_font *font)
 {
 	struct unifont_data *uf = font->data;
 	struct kmscon_glyph *g;
@@ -186,9 +186,9 @@ static int find_glyph(uint64_t id, const struct kmscon_glyph **out, const struct
 	int ret;
 	bool res;
 
-	res = shl_hashtable_find(uf->cache, (void **)out, id);
+	res = shl_hashtable_find(uf->cache, (void **)&g, id);
 	if (res)
-		return 0;
+		return g;
 
 	/* First the length of the block index */
 	len = *((uint32_t *)uf->font_data);
@@ -204,32 +204,27 @@ static int find_glyph(uint64_t id, const struct kmscon_glyph **out, const struct
 		idx = lookup_block(blocks, len, ch);
 		if (idx < 0) {
 			log_warning("Replacement glyph not found");
-			return -EINVAL;
+			return NULL;
 		}
 	}
 
 	data += blocks[idx].offset + (ch - blocks[idx].codepoint) * blocks[idx].cwidth * 16;
 	if (data + 16 * blocks[idx].cwidth > uf->font_data + uf->len) {
 		log_warning("glyph out of range %p %p", data, uf->font_data + uf->len);
-		return -ERANGE;
+		return NULL;
 	}
 
 	g = new_glyph(&font->attr, data, blocks[idx].cwidth);
 	if (!g)
-		return -ENOMEM;
+		return NULL;
 
 	ret = shl_hashtable_insert(uf->cache, id, g);
 	if (ret) {
 		log_error("cannot insert glyph into glyph-cache: %d", ret);
-		goto err_data;
+		free(g);
+		return NULL;
 	}
-
-	*out = g;
-	return 0;
-
-err_data:
-	free(g);
-	return ret;
+	return g;
 }
 
 static int kmscon_font_unifont_init(struct kmscon_font *out, const struct kmscon_font_attr *attr)
@@ -298,25 +293,23 @@ static void kmscon_font_unifont_destroy(struct kmscon_font *font)
 	shl_hashtable_free(uf->cache);
 }
 
-static int kmscon_font_unifont_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
-				      size_t len, const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_unifont_render(struct kmscon_font *font, uint64_t id,
+						       const uint32_t *ch, size_t len)
 {
 	if (len > 1)
-		return -ERANGE;
+		return NULL;
 
-	return find_glyph(id, out, font);
+	return find_glyph(id, font);
 }
 
-static int kmscon_font_unifont_render_inval(struct kmscon_font *font,
-					    const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_unifont_render_inval(struct kmscon_font *font)
 {
-	return find_glyph(0xfffd, out, font);
+	return find_glyph(0xfffd, font);
 }
 
-static int kmscon_font_unifont_render_empty(struct kmscon_font *font,
-					    const struct kmscon_glyph **out)
+static struct kmscon_glyph *kmscon_font_unifont_render_empty(struct kmscon_font *font)
 {
-	return find_glyph(' ', out, font);
+	return find_glyph(' ', font);
 }
 
 struct kmscon_font_ops kmscon_font_unifont_ops = {

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -62,7 +62,7 @@ struct unifont_glyph_block {
 	uint32_t codepoint; // First codepoint of the block
 	uint32_t offset;    // offset of the data
 	uint16_t len;	    // number of glyph in this block
-	uint8_t width;	    // glyph width (1 or 2 for double-width glyph)
+	uint8_t cwidth;	    // glyph width (1 or 2 for double-width glyph)
 } __attribute__((__packed__));
 
 struct unifont_data {
@@ -134,7 +134,7 @@ static int lookup_block(const struct unifont_glyph_block *blocks, uint32_t len, 
 }
 
 static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const uint8_t *data,
-				      int width)
+				      int cwidth)
 {
 	struct kmscon_glyph *g;
 	uint8_t c;
@@ -143,25 +143,25 @@ static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const
 	int off = 0;
 
 	scale = attr->height / 16;
-	g = malloc(sizeof(*g) + width * attr->width * attr->height);
+	g = malloc(sizeof(*g) + cwidth * attr->width * attr->height);
 	if (!g)
 		return NULL;
 	memset(g, 0, sizeof(*g));
-	g->width = width;
-	g->buf.width = g->width * attr->width;
+	g->double_width = (cwidth == 2);
+	g->buf.width = cwidth * attr->width;
 	g->buf.height = attr->height;
-	g->buf.stride = g->width * attr->width;
+	g->buf.stride = g->buf.width;
 
 	/* Unpack the glyph and apply scaling */
 	for (i = 0; i < 16; i++) {
-		c = apply_attr(data[g->width * i], attr, i == 15);
-		for (j = 0; j < g->buf.width / g->width; j++) {
+		c = apply_attr(data[cwidth * i], attr, i == 15);
+		for (j = 0; j < g->buf.width / cwidth; j++) {
 			k = j / scale;
 			g->buf.data[off++] = unfold(c & (1 << (7 - k)));
 		}
-		if (g->width == 2) {
-			c = apply_attr(data[g->width * i + 1], attr, i == 15);
-			for (j = 0; j < g->buf.width / g->width; j++) {
+		if (g->double_width) {
+			c = apply_attr(data[cwidth * i + 1], attr, i == 15);
+			for (j = 0; j < g->buf.width / cwidth; j++) {
 				k = j / scale;
 				g->buf.data[off++] = unfold(c & (1 << (7 - k)));
 			}
@@ -208,13 +208,13 @@ static int find_glyph(uint64_t id, const struct kmscon_glyph **out, const struct
 		}
 	}
 
-	data += blocks[idx].offset + (ch - blocks[idx].codepoint) * blocks[idx].width * 16;
-	if (data + 16 * blocks[idx].width > uf->font_data + uf->len) {
+	data += blocks[idx].offset + (ch - blocks[idx].codepoint) * blocks[idx].cwidth * 16;
+	if (data + 16 * blocks[idx].cwidth > uf->font_data + uf->len) {
 		log_warning("glyph out of range %p %p", data, uf->font_data + uf->len);
 		return -ERANGE;
 	}
 
-	g = new_glyph(&font->attr, data, blocks[idx].width);
+	g = new_glyph(&font->attr, data, blocks[idx].cwidth);
 	if (!g)
 		return -ENOMEM;
 

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -82,7 +82,6 @@ static void free_glyph(void *data)
 {
 	struct kmscon_glyph *g = data;
 
-	free(g->buf.data);
 	free(g);
 }
 
@@ -144,7 +143,7 @@ static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const
 	int off = 0;
 
 	scale = attr->height / 16;
-	g = malloc(sizeof(*g));
+	g = malloc(sizeof(*g) + width * attr->width * attr->height);
 	if (!g)
 		return NULL;
 	memset(g, 0, sizeof(*g));
@@ -153,12 +152,6 @@ static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const
 	g->buf.height = attr->height;
 	g->buf.stride = g->width * attr->width;
 	g->buf.format = UTERM_FORMAT_GREY;
-
-	g->buf.data = malloc(g->buf.stride * g->buf.height);
-	if (!g->buf.data) {
-		free(g);
-		return NULL;
-	}
 
 	/* Unpack the glyph and apply scaling */
 	for (i = 0; i < 16; i++) {
@@ -236,7 +229,6 @@ static int find_glyph(uint64_t id, const struct kmscon_glyph **out, const struct
 	return 0;
 
 err_data:
-	free(g->buf.data);
 	free(g);
 	return ret;
 }

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -151,7 +151,6 @@ static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const
 	g->buf.width = g->width * attr->width;
 	g->buf.height = attr->height;
 	g->buf.stride = g->width * attr->width;
-	g->buf.format = UTERM_FORMAT_GREY;
 
 	/* Unpack the glyph and apply scaling */
 	for (i = 0; i < 16; i++) {

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -38,7 +38,6 @@
  * This file is heavily based on font_8x16.c
  */
 
-#include <errno.h>
 #include <libtsm.h>
 #include <pthread.h>
 #include <stdint.h>
@@ -47,7 +46,6 @@
 #include <zlib.h>
 #include "font.h"
 #include "font_unifont_data.bin.h"
-#include "shl_hashtable.h"
 #include "shl_log.h"
 #include "uterm_video.h"
 
@@ -68,22 +66,7 @@ struct unifont_glyph_block {
 struct unifont_data {
 	unsigned char *font_data;
 	unsigned long len;
-	struct shl_hashtable *cache;
 };
-
-/*
- * Global glyph cache
- * The linked binary glyph data cannot be directly passed to the caller as it
- * has the wrong format. Hence, use a glyph-cache with all used glyphs and add
- * new ones as soon as they are used.
- */
-
-static void free_glyph(void *data)
-{
-	struct kmscon_glyph *g = data;
-
-	free(g);
-}
 
 static uint8_t apply_attr(uint8_t c, const struct kmscon_font_attr *attr, bool last_line)
 {
@@ -178,17 +161,10 @@ static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const
 static struct kmscon_glyph *find_glyph(uint64_t id, const struct kmscon_font *font)
 {
 	struct unifont_data *uf = font->data;
-	struct kmscon_glyph *g;
 	uint32_t ch = id & TSM_UCS4_MAX;
 	const uint8_t *data;
 	uint32_t len;
 	const struct unifont_glyph_block *blocks;
-	int ret;
-	bool res;
-
-	res = shl_hashtable_find(uf->cache, (void **)&g, id);
-	if (res)
-		return g;
 
 	/* First the length of the block index */
 	len = *((uint32_t *)uf->font_data);
@@ -214,17 +190,7 @@ static struct kmscon_glyph *find_glyph(uint64_t id, const struct kmscon_font *fo
 		return NULL;
 	}
 
-	g = new_glyph(&font->attr, data, blocks[idx].cwidth);
-	if (!g)
-		return NULL;
-
-	ret = shl_hashtable_insert(uf->cache, id, g);
-	if (ret) {
-		log_error("cannot insert glyph into glyph-cache: %d", ret);
-		free(g);
-		return NULL;
-	}
-	return g;
+	return new_glyph(&font->attr, data, blocks[idx].cwidth);
 }
 
 static int kmscon_font_unifont_init(struct kmscon_font *out, const struct kmscon_font_attr *attr)
@@ -232,26 +198,21 @@ static int kmscon_font_unifont_init(struct kmscon_font *out, const struct kmscon
 	static const char name[] = "static-unifont";
 	struct unifont_data *uf;
 	unsigned int scale;
-	int ret;
 
 	log_debug("loading static unifont font");
+	if (_binary_font_unifont_data_size == 0) {
+		log_error("unifont glyph information not found in binary");
+		return -EINVAL;
+	}
 
 	uf = malloc(sizeof(*uf));
 	if (!uf)
 		return -ENOMEM;
 
-	ret = shl_hashtable_new(&uf->cache, shl_direct_hash, shl_direct_equal, free_glyph);
-	if (ret)
-		goto err_free;
-
-	if (_binary_font_unifont_data_size == 0) {
-		log_error("unifont glyph information not found in binary");
-		goto err_free_hash;
-	}
 	uf->len = *((uint32_t *)_binary_font_unifont_data_start);
 	uf->font_data = malloc(uf->len);
 	if (!uf->font_data)
-		goto err_free_hash;
+		goto err_free;
 
 	if (uncompress(uf->font_data, &uf->len,
 		       (unsigned char *)_binary_font_unifont_data_start + 4,
@@ -277,8 +238,6 @@ static int kmscon_font_unifont_init(struct kmscon_font *out, const struct kmscon
 
 err_free_data:
 	free(uf->font_data);
-err_free_hash:
-	shl_hashtable_free(uf->cache);
 err_free:
 	free(uf);
 	return -EFAULT;
@@ -289,8 +248,8 @@ static void kmscon_font_unifont_destroy(struct kmscon_font *font)
 	struct unifont_data *uf = font->data;
 
 	log_debug("unloading static unifont font");
-
-	shl_hashtable_free(uf->cache);
+	free(uf->font_data);
+	free(uf);
 }
 
 static struct kmscon_glyph *kmscon_font_unifont_render(struct kmscon_font *font, uint64_t id,

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -97,9 +97,6 @@ static int lookup_block(const struct unifont_glyph_block *blocks, uint32_t len, 
 		look = max;
 
 	while (min < max) {
-		log_debug("lookup %d codep %d, look %d min %d max %d", ch, blocks[look].codepoint,
-			  look, min, max);
-
 		if (is_in_block(&blocks[look], ch))
 			return look;
 

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -261,22 +261,10 @@ static struct kmscon_glyph *kmscon_font_unifont_render(struct kmscon_font *font,
 	return find_glyph(id, font);
 }
 
-static struct kmscon_glyph *kmscon_font_unifont_render_inval(struct kmscon_font *font)
-{
-	return find_glyph(0xfffd, font);
-}
-
-static struct kmscon_glyph *kmscon_font_unifont_render_empty(struct kmscon_font *font)
-{
-	return find_glyph(' ', font);
-}
-
 struct kmscon_font_ops kmscon_font_unifont_ops = {
 	.name = "unifont",
 	.owner = NULL,
 	.init = kmscon_font_unifont_init,
 	.destroy = kmscon_font_unifont_destroy,
 	.render = kmscon_font_unifont_render,
-	.render_empty = kmscon_font_unifont_render_empty,
-	.render_inval = kmscon_font_unifont_render_inval,
 };

--- a/src/genunifont.c
+++ b/src/genunifont.c
@@ -55,7 +55,7 @@ struct unifont_glyph_block {
 	uint32_t codepoint; // First codepoint of the block
 	uint32_t offset;    // offset of the data
 	uint16_t len;	    // number of glyph in this block
-	uint8_t width;	    // glyph width (1 or 2 for double-width glyph)
+	uint8_t cwidth;	    // glyph width (1 or 2 for double-width glyph)
 } __attribute__((__packed__));
 
 static uint8_t hex_val(char c)
@@ -143,15 +143,15 @@ static struct unifont_glyph_block *gen_blocks(struct unifont_glyph *list, uint32
 	blocks[i].len = 0;
 	blocks[i].offset = 0;
 	blocks[i].codepoint = g->codepoint;
-	blocks[i].width = get_width(g->len);
+	blocks[i].cwidth = get_width(g->len);
 	while (g) {
-		if (blocks[i].width == get_width(g->len) &&
+		if (blocks[i].cwidth == get_width(g->len) &&
 		    g->codepoint == blocks[i].codepoint + blocks[i].len) {
 			/* This glyph can fit in current block */
 			blocks[i].len++;
 		} else {
 			/* Start a new block with this glyph as first glyph */
-			offset += blocks[i].len * 16 * blocks[i].width;
+			offset += blocks[i].len * 16 * blocks[i].cwidth;
 			i++;
 			if (i >= table_size) {
 				table_size *= 2;
@@ -164,7 +164,7 @@ static struct unifont_glyph_block *gen_blocks(struct unifont_glyph *list, uint32
 			}
 			blocks[i].len = 1;
 			blocks[i].codepoint = g->codepoint;
-			blocks[i].width = get_width(g->len);
+			blocks[i].cwidth = get_width(g->len);
 			blocks[i].offset = offset;
 		}
 		g = g->next;

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -104,7 +104,6 @@ static void free_glyph(void *data)
 {
 	struct uterm_video_buffer *bb_glyph = data;
 
-	free(bb_glyph->data);
 	free(bb_glyph);
 }
 
@@ -231,7 +230,8 @@ static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph
 	int width;
 	int height;
 	int i, j;
-	uint8_t *dst, *src;
+	uint8_t *dst;
+	const uint8_t *src;
 	const struct uterm_video_buffer *buf = &glyph->buf;
 
 	if (orientation == OR_NORMAL || orientation == OR_UPSIDE_DOWN) {
@@ -241,11 +241,6 @@ static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph
 		width = buf->height;
 		height = buf->width;
 	}
-
-	vb->buf.data = malloc(width * height);
-
-	if (!vb->buf.data)
-		return -ENOMEM;
 
 	src = buf->data;
 	dst = vb->buf.data;
@@ -312,11 +307,6 @@ static int find_glyph(struct kmscon_text *txt, struct kmscon_glyph **out, uint64
 		return 0;
 	}
 
-	bb_glyph = malloc(sizeof(*bb_glyph));
-	if (!bb_glyph)
-		return -ENOMEM;
-	memset(bb_glyph, 0, sizeof(*bb_glyph));
-
 	if (!len)
 		ret = kmscon_font_render_empty(font, &glyph);
 	else
@@ -325,23 +315,27 @@ static int find_glyph(struct kmscon_text *txt, struct kmscon_glyph **out, uint64
 	if (ret) {
 		ret = kmscon_font_render_inval(font, &glyph);
 		if (ret)
-			goto err_free;
+			return ret;
 	}
+
+	bb_glyph = malloc(sizeof(*bb_glyph) + glyph->buf.width * glyph->buf.height);
+	if (!bb_glyph)
+		return -ENOMEM;
+
+	memset(bb_glyph, 0, sizeof(*bb_glyph) + glyph->buf.width * glyph->buf.height);
 
 	ret = bbulk_rotate_glyph(bb_glyph, glyph, txt->orientation);
 	if (ret)
-		goto err_free;
+		goto err_bb_glyph;
 
 	ret = shl_hashtable_insert(bb->glyphs, id, bb_glyph);
 	if (ret)
-		goto err_free_vb;
+		goto err_bb_glyph;
 
 	*out = bb_glyph;
 	return 0;
 
-err_free_vb:
-	free(bb_glyph->buf.data);
-err_free:
+err_bb_glyph:
 	free(bb_glyph);
 	return ret;
 }

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -307,16 +307,9 @@ static struct kmscon_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, con
 	if (shl_hashtable_find(bb->glyphs, (void **)&glyph, id))
 		return glyph;
 
-	if (!len)
-		glyph = kmscon_font_render_empty(font);
-	else
-		glyph = kmscon_font_render(font, id, ch, len);
-
-	if (!glyph) {
-		glyph = kmscon_font_render_inval(font);
-		if (!glyph)
-			return NULL;
-	}
+	glyph = kmscon_font_render(font, id, ch, len);
+	if (!glyph)
+		return NULL;
 
 	if (txt->orientation != OR_NORMAL)
 		glyph = bbulk_rotate_glyph(glyph, txt->orientation);

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -282,7 +282,6 @@ static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph
 	vb->buf.width = width;
 	vb->buf.height = height;
 	vb->buf.stride = width;
-	vb->buf.format = buf->format;
 	vb->width = glyph->width;
 	return 0;
 }

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -226,11 +226,10 @@ static int bbulk_rotate(struct kmscon_text *txt, enum Orientation orientation)
 }
 
 static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyph,
-			      enum Orientation orientation, uint8_t align)
+			      enum Orientation orientation)
 {
 	int width;
 	int height;
-	int stride;
 	int i, j;
 	uint8_t *dst, *src;
 	const struct uterm_video_buffer *buf = &glyph->buf;
@@ -243,8 +242,7 @@ static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph
 		height = buf->width;
 	}
 
-	stride = align * ((width + (align - 1)) / align);
-	vb->buf.data = malloc(stride * height);
+	vb->buf.data = malloc(width * height);
 
 	if (!vb->buf.data)
 		return -ENOMEM;
@@ -257,14 +255,14 @@ static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph
 	case OR_NORMAL:
 		for (i = 0; i < buf->height; i++) {
 			memcpy(dst, src, buf->width);
-			dst += stride;
+			dst += width;
 			src += buf->stride;
 		}
 		break;
 	case OR_RIGHT:
 		for (i = 0; i < buf->height; i++) {
 			for (j = 0; j < buf->width; j++) {
-				dst[j * stride + (width - i - 1)] = src[j];
+				dst[j * width + (width - i - 1)] = src[j];
 			}
 			src += buf->stride;
 		}
@@ -274,21 +272,21 @@ static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph
 		for (i = 0; i < buf->height; i++) {
 			for (j = 0; j < buf->width; j++)
 				dst[j] = src[buf->width - j - 1];
-			dst += stride;
+			dst += width;
 			src -= buf->stride;
 		}
 		break;
 	case OR_LEFT:
 		for (i = 0; i < buf->height; i++) {
 			for (j = 0; j < buf->width; j++) {
-				dst[(height - j - 1) * stride + i] = src[j];
+				dst[(height - j - 1) * width + i] = src[j];
 			}
 			src += buf->stride;
 		}
 	}
 	vb->buf.width = width;
 	vb->buf.height = height;
-	vb->buf.stride = stride;
+	vb->buf.stride = width;
 	vb->buf.format = buf->format;
 	vb->width = glyph->width;
 	return 0;
@@ -330,7 +328,7 @@ static int find_glyph(struct kmscon_text *txt, struct kmscon_glyph **out, uint64
 			goto err_free;
 	}
 
-	ret = bbulk_rotate_glyph(bb_glyph, glyph, txt->orientation, 1);
+	ret = bbulk_rotate_glyph(bb_glyph, glyph, txt->orientation);
 	if (ret)
 		goto err_free;
 

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -102,9 +102,9 @@ static void bbulk_destroy(struct kmscon_text *txt)
 
 static void free_glyph(void *data)
 {
-	struct uterm_video_buffer *bb_glyph = data;
+	struct kmscon_glyph *glyph = data;
 
-	free(bb_glyph);
+	free(glyph);
 }
 
 static void damage_cell(struct bbulk *bb, unsigned int off)
@@ -224,15 +224,24 @@ static int bbulk_rotate(struct kmscon_text *txt, enum Orientation orientation)
 	return bbulk_set(txt);
 }
 
-static void bbulk_rotate_glyph(struct kmscon_glyph *rglyph, const struct kmscon_glyph *glyph,
-			       enum Orientation orientation)
+/*
+ * Rotate a glyph to the given orientation
+ * Return a new rotated glyph, and free the original glyph
+ */
+static struct kmscon_glyph *bbulk_rotate_glyph(struct kmscon_glyph *glyph,
+					       enum Orientation orientation)
 {
-	int width;
-	int height;
-	int i, j;
-	uint8_t *dst;
-	const uint8_t *src;
-	const struct uterm_video_buffer *buf = &glyph->buf;
+	struct uterm_video_buffer *buf = &glyph->buf;
+	struct kmscon_glyph *rglyph;
+	int width, height, i, j;
+	uint8_t *dst, *src;
+	unsigned int size = sizeof(*rglyph) + glyph->buf.width * glyph->buf.height;
+
+	rglyph = malloc(size);
+	if (!rglyph)
+		goto err_free;
+
+	memset(rglyph, 0, size);
 
 	if (orientation == OR_NORMAL || orientation == OR_UPSIDE_DOWN) {
 		width = buf->width;
@@ -241,18 +250,13 @@ static void bbulk_rotate_glyph(struct kmscon_glyph *rglyph, const struct kmscon_
 		width = buf->height;
 		height = buf->width;
 	}
-
 	src = buf->data;
 	dst = rglyph->buf.data;
 
 	switch (orientation) {
 	default:
 	case OR_NORMAL:
-		for (i = 0; i < buf->height; i++) {
-			memcpy(dst, src, buf->width);
-			dst += width;
-			src += buf->stride;
-		}
+		/* should never happen */
 		break;
 	case OR_RIGHT:
 		for (i = 0; i < buf->height; i++) {
@@ -283,13 +287,16 @@ static void bbulk_rotate_glyph(struct kmscon_glyph *rglyph, const struct kmscon_
 	rglyph->buf.height = height;
 	rglyph->buf.stride = width;
 	rglyph->double_width = glyph->double_width;
+
+err_free:
+	free(glyph);
+	return rglyph;
 }
 
 static struct kmscon_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint32_t *ch,
 				       size_t len, const struct tsm_screen_attr *attr)
 {
 	struct bbulk *bb = txt->data;
-	struct kmscon_glyph *bb_glyph;
 	struct kmscon_glyph *glyph;
 	struct kmscon_font *font = txt->font;
 
@@ -311,19 +318,14 @@ static struct kmscon_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, con
 			return NULL;
 	}
 
-	bb_glyph = malloc(sizeof(*bb_glyph) + glyph->buf.width * glyph->buf.height);
-	if (!bb_glyph)
-		return NULL;
+	if (txt->orientation != OR_NORMAL)
+		glyph = bbulk_rotate_glyph(glyph, txt->orientation);
 
-	memset(bb_glyph, 0, sizeof(*bb_glyph) + glyph->buf.width * glyph->buf.height);
-
-	bbulk_rotate_glyph(bb_glyph, glyph, txt->orientation);
-
-	if (shl_hashtable_insert(bb->glyphs, id, bb_glyph)) {
-		free(bb_glyph);
+	if (shl_hashtable_insert(bb->glyphs, id, glyph)) {
+		free(glyph);
 		return NULL;
 	}
-	return bb_glyph;
+	return glyph;
 }
 
 /*

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -282,7 +282,7 @@ static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph
 	vb->buf.width = width;
 	vb->buf.height = height;
 	vb->buf.stride = width;
-	vb->width = glyph->width;
+	vb->double_width = glyph->double_width;
 	return 0;
 }
 
@@ -437,7 +437,7 @@ static int bbulk_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 	if (ret)
 		return ret;
 
-	if (bb_glyph->width == 2 && !last_col) {
+	if (bb_glyph->double_width && !last_col) {
 		prev->overflow = true;
 		bb->prev[offset + 1].overflow = false;
 	} else
@@ -458,7 +458,7 @@ static int bbulk_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 	req->buf = &bb_glyph->buf;
 	set_color(req, attr);
 
-	if (width == 2 && bb_glyph->width == 1 && !last_col) {
+	if (width == 2 && !bb_glyph->double_width && !last_col) {
 		/* libtsm thinks this glyph is wide, but the font uses a single
 		 * width character. So draw a space on next cell to avoid a
 		 * graphical glitch

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -224,8 +224,8 @@ static int bbulk_rotate(struct kmscon_text *txt, enum Orientation orientation)
 	return bbulk_set(txt);
 }
 
-static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyph,
-			      enum Orientation orientation)
+static void bbulk_rotate_glyph(struct kmscon_glyph *rglyph, const struct kmscon_glyph *glyph,
+			       enum Orientation orientation)
 {
 	int width;
 	int height;
@@ -243,7 +243,7 @@ static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph
 	}
 
 	src = buf->data;
-	dst = vb->buf.data;
+	dst = rglyph->buf.data;
 
 	switch (orientation) {
 	default:
@@ -279,64 +279,51 @@ static int bbulk_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph
 			src += buf->stride;
 		}
 	}
-	vb->buf.width = width;
-	vb->buf.height = height;
-	vb->buf.stride = width;
-	vb->double_width = glyph->double_width;
-	return 0;
+	rglyph->buf.width = width;
+	rglyph->buf.height = height;
+	rglyph->buf.stride = width;
+	rglyph->double_width = glyph->double_width;
 }
 
-static int find_glyph(struct kmscon_text *txt, struct kmscon_glyph **out, uint64_t id,
-		      const uint32_t *ch, size_t len, const struct tsm_screen_attr *attr)
+static struct kmscon_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint32_t *ch,
+				       size_t len, const struct tsm_screen_attr *attr)
 {
 	struct bbulk *bb = txt->data;
 	struct kmscon_glyph *bb_glyph;
-	const struct kmscon_glyph *glyph;
+	struct kmscon_glyph *glyph;
 	struct kmscon_font *font = txt->font;
-	int ret;
-	bool res;
 
 	font->attr.underline = !!attr->underline;
 	font->attr.italic = !!attr->italic;
 	font->attr.bold = !!attr->bold;
 
-	res = shl_hashtable_find(bb->glyphs, (void **)&bb_glyph, id);
-	if (res) {
-		*out = bb_glyph;
-		return 0;
-	}
+	if (shl_hashtable_find(bb->glyphs, (void **)&glyph, id))
+		return glyph;
 
 	if (!len)
-		ret = kmscon_font_render_empty(font, &glyph);
+		glyph = kmscon_font_render_empty(font);
 	else
-		ret = kmscon_font_render(font, id, ch, len, &glyph);
+		glyph = kmscon_font_render(font, id, ch, len);
 
-	if (ret) {
-		ret = kmscon_font_render_inval(font, &glyph);
-		if (ret)
-			return ret;
+	if (!glyph) {
+		glyph = kmscon_font_render_inval(font);
+		if (!glyph)
+			return NULL;
 	}
 
 	bb_glyph = malloc(sizeof(*bb_glyph) + glyph->buf.width * glyph->buf.height);
 	if (!bb_glyph)
-		return -ENOMEM;
+		return NULL;
 
 	memset(bb_glyph, 0, sizeof(*bb_glyph) + glyph->buf.width * glyph->buf.height);
 
-	ret = bbulk_rotate_glyph(bb_glyph, glyph, txt->orientation);
-	if (ret)
-		goto err_bb_glyph;
+	bbulk_rotate_glyph(bb_glyph, glyph, txt->orientation);
 
-	ret = shl_hashtable_insert(bb->glyphs, id, bb_glyph);
-	if (ret)
-		goto err_bb_glyph;
-
-	*out = bb_glyph;
-	return 0;
-
-err_bb_glyph:
-	free(bb_glyph);
-	return ret;
+	if (shl_hashtable_insert(bb->glyphs, id, bb_glyph)) {
+		free(bb_glyph);
+		return NULL;
+	}
+	return bb_glyph;
 }
 
 /*
@@ -393,12 +380,11 @@ static int bbulk_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 		      const struct tsm_screen_attr *attr)
 {
 	struct bbulk *bb = txt->data;
-	struct kmscon_glyph *bb_glyph;
+	struct kmscon_glyph *glyph;
 	struct uterm_video_blend_req *req;
 	struct bbcell *prev;
 	unsigned int offset = posx + posy * txt->cols;
 	bool last_col = (posx == txt->cols - 1);
-	int ret;
 
 	if (!width)
 		return 0;
@@ -433,11 +419,11 @@ static int bbulk_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 	prev->id = id;
 	memcpy(&prev->attr, attr, sizeof(*attr));
 
-	ret = find_glyph(txt, &bb_glyph, id, ch, len, attr);
-	if (ret)
-		return ret;
+	glyph = find_glyph(txt, id, ch, len, attr);
+	if (!glyph)
+		return -ENOMEM;
 
-	if (bb_glyph->double_width && !last_col) {
+	if (glyph->double_width && !last_col) {
 		prev->overflow = true;
 		bb->prev[offset + 1].overflow = false;
 	} else
@@ -455,21 +441,21 @@ static int bbulk_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 	else
 		set_coordinate(txt, &req->x, &req->y, posx, posy);
 
-	req->buf = &bb_glyph->buf;
+	req->buf = &glyph->buf;
 	set_color(req, attr);
 
-	if (width == 2 && !bb_glyph->double_width && !last_col) {
+	if (width == 2 && !glyph->double_width && !last_col) {
 		/* libtsm thinks this glyph is wide, but the font uses a single
 		 * width character. So draw a space on next cell to avoid a
 		 * graphical glitch
 		 */
-		ret = find_glyph(txt, &bb_glyph, ' ', NULL, 0, attr);
-		if (ret)
-			return ret;
+		glyph = find_glyph(txt, ' ', NULL, 0, attr);
+		if (!glyph)
+			return -ENOMEM;
 
 		req = &bb->reqs[bb->req_len++];
 		set_coordinate(txt, &req->x, &req->y, posx + 1, posy);
-		req->buf = &bb_glyph->buf;
+		req->buf = &glyph->buf;
 		set_color(req, attr);
 	}
 	return 0;
@@ -576,8 +562,6 @@ static int bbulk_draw_pointer(struct kmscon_text *txt, unsigned int pointer_x,
 	uint32_t ch = 'I';
 	uint64_t id = ch;
 
-	int ret;
-
 	if (bb->req_len >= bb->req_total_len)
 		return -ENOMEM;
 
@@ -587,9 +571,9 @@ static int bbulk_draw_pointer(struct kmscon_text *txt, unsigned int pointer_x,
 	req = &bb->reqs[bb->req_len++];
 	mark_damaged(txt, bb, pointer_x, pointer_y);
 
-	ret = find_glyph(txt, &bb_glyph, id, &ch, 1, &bb->attr);
-	if (ret)
-		return ret;
+	bb_glyph = find_glyph(txt, id, &ch, 1, &bb->attr);
+	if (!bb_glyph)
+		return -ENOMEM;
 
 	req->buf = &bb_glyph->buf;
 	set_pointer_coordinate(bb, txt, req, pointer_x, pointer_y);

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -84,7 +84,7 @@ struct atlas {
 };
 
 struct glyph {
-	const struct kmscon_glyph *glyph;
+	struct kmscon_glyph *glyph;
 	struct atlas *atlas;
 	unsigned int texoff;
 };
@@ -147,6 +147,7 @@ static void free_glyph(void *data)
 {
 	struct glyph *glyph = data;
 
+	free(glyph->glyph);
 	free(glyph);
 }
 

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -45,6 +45,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include "font.h"
 #include "shl_dlist.h"
 #include "shl_gl.h"
 #include "shl_hashtable.h"
@@ -412,6 +413,7 @@ static int find_glyph(struct kmscon_text *txt, struct glyph **out, uint64_t id, 
 	uint8_t *packed_data, *dst;
 	const uint8_t *src;
 	struct kmscon_font *font = txt->font;
+	unsigned int num;
 
 	font->attr.underline = !!attr->underline;
 	font->attr.italic = !!attr->italic;
@@ -439,7 +441,8 @@ static int find_glyph(struct kmscon_text *txt, struct glyph **out, uint64_t id, 
 			goto err_free;
 	}
 
-	atlas = get_atlas(txt, glyph->glyph->width);
+	num = kmscon_glyph_cwidth(glyph->glyph);
+	atlas = get_atlas(txt, num);
 	if (!atlas) {
 		ret = -EFAULT;
 		goto err_free;
@@ -516,7 +519,7 @@ static int find_glyph(struct kmscon_text *txt, struct glyph **out, uint64_t id, 
 	if (ret)
 		goto err_free;
 
-	atlas->fill += glyph->glyph->width;
+	atlas->fill += num;
 
 	*out = glyph;
 	return 0;
@@ -588,7 +591,7 @@ static int gltex_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 		return ret;
 	atlas = glyph->atlas;
 
-	if (width == 1 && glyph->glyph->width == 2) {
+	if (width == 1 && glyph->glyph->double_width) {
 		gt->previous_overflow = true;
 		width = 2;
 	} else {

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -427,16 +427,9 @@ static struct glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint
 		return NULL;
 	memset(glyph, 0, sizeof(*glyph));
 
-	if (!len)
-		glyph->glyph = kmscon_font_render_empty(font);
-	else
-		glyph->glyph = kmscon_font_render(font, id, ch, len);
-
-	if (!glyph->glyph) {
-		glyph->glyph = kmscon_font_render_inval(font);
-		if (!glyph->glyph)
-			return NULL;
-	}
+	glyph->glyph = kmscon_font_render(font, id, ch, len);
+	if (!glyph->glyph)
+		return NULL;
 
 	num = kmscon_glyph_cwidth(glyph->glyph);
 	atlas = get_atlas(txt, num);

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -409,7 +409,8 @@ static int find_glyph(struct kmscon_text *txt, struct glyph **out, uint64_t id, 
 	bool res;
 	int ret, i;
 	GLenum err;
-	uint8_t *packed_data, *dst, *src;
+	uint8_t *packed_data, *dst;
+	const uint8_t *src;
 	struct kmscon_font *font = txt->font;
 
 	font->attr.underline = !!attr->underline;

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -401,14 +401,13 @@ err_free:
 	return NULL;
 }
 
-static int find_glyph(struct kmscon_text *txt, struct glyph **out, uint64_t id, const uint32_t *ch,
-		      size_t len, const struct tsm_screen_attr *attr)
+static struct glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint32_t *ch,
+				size_t len, const struct tsm_screen_attr *attr)
 {
 	struct gltex *gt = txt->data;
 	struct atlas *atlas;
 	struct glyph *glyph;
-	bool res;
-	int ret, i;
+	int i;
 	GLenum err;
 	uint8_t *packed_data, *dst;
 	const uint8_t *src;
@@ -419,34 +418,29 @@ static int find_glyph(struct kmscon_text *txt, struct glyph **out, uint64_t id, 
 	font->attr.italic = !!attr->italic;
 	font->attr.bold = !!attr->bold;
 
-	res = shl_hashtable_find(gt->glyphs, (void **)&glyph, id);
-	if (res) {
-		*out = glyph;
-		return 0;
-	}
+	if (shl_hashtable_find(gt->glyphs, (void **)&glyph, id))
+		return glyph;
 
 	glyph = malloc(sizeof(*glyph));
 	if (!glyph)
-		return -ENOMEM;
+		return NULL;
 	memset(glyph, 0, sizeof(*glyph));
 
 	if (!len)
-		ret = kmscon_font_render_empty(font, &glyph->glyph);
+		glyph->glyph = kmscon_font_render_empty(font);
 	else
-		ret = kmscon_font_render(font, id, ch, len, &glyph->glyph);
+		glyph->glyph = kmscon_font_render(font, id, ch, len);
 
-	if (ret) {
-		ret = kmscon_font_render_inval(font, &glyph->glyph);
-		if (ret)
-			goto err_free;
+	if (!glyph->glyph) {
+		glyph->glyph = kmscon_font_render_inval(font);
+		if (!glyph->glyph)
+			return NULL;
 	}
 
 	num = kmscon_glyph_cwidth(glyph->glyph);
 	atlas = get_atlas(txt, num);
-	if (!atlas) {
-		ret = -EFAULT;
+	if (!atlas)
 		goto err_free;
-	}
 
 	/* Funnily, not all OpenGLESv2 implementations support specifying the
 	 * stride of a texture. Therefore, we then need to create a
@@ -468,7 +462,6 @@ static int find_glyph(struct kmscon_text *txt, struct glyph **out, uint64_t id, 
 			packed_data = malloc(GLYPH_WIDTH(glyph) * GLYPH_HEIGHT(glyph));
 			if (!packed_data) {
 				log_error("cannot allocate memory for glyph storage");
-				ret = -ENOMEM;
 				goto err_free;
 			}
 
@@ -508,25 +501,22 @@ static int find_glyph(struct kmscon_text *txt, struct glyph **out, uint64_t id, 
 		log_warning("cannot load glyph data into OpenGL texture (%d: %s); disable the "
 			    "GL-renderer if this does not work reliably",
 			    err, gl_err_to_str(err));
-		ret = -EFAULT;
 		goto err_free;
 	}
 
 	glyph->atlas = atlas;
 	glyph->texoff = atlas->fill;
 
-	ret = shl_hashtable_insert(gt->glyphs, id, glyph);
-	if (ret)
+	if (shl_hashtable_insert(gt->glyphs, id, glyph))
 		goto err_free;
 
 	atlas->fill += num;
 
-	*out = glyph;
-	return 0;
+	return glyph;
 
 err_free:
 	free(glyph);
-	return ret;
+	return NULL;
 }
 
 static void gltex_resize(struct kmscon_text *txt, unsigned int cols, unsigned int rows)
@@ -577,7 +567,7 @@ static int gltex_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 	struct atlas *atlas;
 	struct glyph *glyph;
 	float gl_x1, gl_x2, gl_y1, gl_y2;
-	int ret, i, idx;
+	int i, idx;
 
 	if (!width)
 		return 0;
@@ -586,9 +576,10 @@ static int gltex_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 		gt->previous_overflow = false;
 		return 0;
 	}
-	ret = find_glyph(txt, &glyph, id, ch, len, attr);
-	if (ret)
-		return ret;
+	glyph = find_glyph(txt, id, ch, len, attr);
+	if (!glyph)
+		return -ENOMEM;
+
 	atlas = glyph->atlas;
 
 	if (width == 1 && glyph->glyph->double_width) {
@@ -666,13 +657,13 @@ static int gltex_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned 
 	struct glyph *glyph;
 	float gl_x1, gl_x2, gl_y1, gl_y2;
 	unsigned int sw, sh;
-	int ret, i, idx;
+	int i, idx;
 	uint32_t ch = 'I';
 	uint64_t id = ch;
 
-	ret = find_glyph(txt, &glyph, id, &ch, 1, &gt->attr);
-	if (ret)
-		return ret;
+	glyph = find_glyph(txt, id, &ch, 1, &gt->attr);
+	if (!glyph)
+		return -ENOMEM;
 
 	atlas = glyph->atlas;
 

--- a/src/uterm_drm2d_render.c
+++ b/src/uterm_drm2d_render.c
@@ -50,7 +50,8 @@ int uterm_drm2d_display_fake_blendv(struct uterm_display *disp,
 				    const struct uterm_video_blend_req *req, size_t num)
 {
 	unsigned int tmp;
-	uint8_t *dst, *src;
+	uint8_t *dst;
+	const uint8_t *src;
 	unsigned int width, height, i, j;
 	unsigned int sw, sh;
 	uint_fast32_t r, g, b, out;

--- a/src/uterm_drm2d_render.c
+++ b/src/uterm_drm2d_render.c
@@ -69,9 +69,6 @@ int uterm_drm2d_display_fake_blendv(struct uterm_display *disp,
 		if (!req->buf)
 			continue;
 
-		if (req->buf->format != UTERM_FORMAT_GREY)
-			return -EOPNOTSUPP;
-
 		tmp = req->x + req->buf->width;
 		if (tmp < req->x || req->x >= sw)
 			return -EINVAL;

--- a/src/uterm_drm3d_render.c
+++ b/src/uterm_drm3d_render.c
@@ -113,7 +113,8 @@ static int display_blend(struct uterm_display *disp, const struct uterm_video_bu
 	float mat[16];
 	float vertices[6 * 2], texpos[6 * 2], fgcol[3], bgcol[3];
 	int ret;
-	uint8_t *packed, *src, *dst;
+	uint8_t *packed, *dst;
+	const uint8_t *src;
 
 	if (!buf || buf->format != UTERM_FORMAT_GREY)
 		return -EINVAL;

--- a/src/uterm_drm3d_render.c
+++ b/src/uterm_drm3d_render.c
@@ -116,7 +116,7 @@ static int display_blend(struct uterm_display *disp, const struct uterm_video_bu
 	uint8_t *packed, *dst;
 	const uint8_t *src;
 
-	if (!buf || buf->format != UTERM_FORMAT_GREY)
+	if (!buf)
 		return -EINVAL;
 
 	v3d = uterm_drm_video_get_data(disp->video);

--- a/src/uterm_fbdev_render.c
+++ b/src/uterm_fbdev_render.c
@@ -132,9 +132,6 @@ int uterm_fbdev_display_fake_blendv(struct uterm_display *disp,
 		if (!req->buf)
 			continue;
 
-		if (req->buf->format != UTERM_FORMAT_GREY)
-			return -EOPNOTSUPP;
-
 		tmp = req->x + req->buf->width;
 		if (tmp < req->x || req->x >= fbdev->xres)
 			return -EINVAL;

--- a/src/uterm_fbdev_render.c
+++ b/src/uterm_fbdev_render.c
@@ -118,7 +118,8 @@ int uterm_fbdev_display_fake_blendv(struct uterm_display *disp,
 				    const struct uterm_video_blend_req *req, size_t num)
 {
 	unsigned int tmp;
-	uint8_t *dst, *src;
+	uint8_t *dst;
+	const uint8_t *src;
 	unsigned int width, height, i, j;
 	unsigned int r, g, b;
 	uint32_t val;

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -108,7 +108,7 @@ struct uterm_video_buffer {
 	unsigned int height;
 	unsigned int stride;
 	unsigned int format;
-	uint8_t *data;
+	uint8_t data[];
 };
 
 struct uterm_video_blend_req {

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -96,18 +96,10 @@ struct uterm_display_event {
 	int action;
 };
 
-enum uterm_video_format {
-	UTERM_FORMAT_GREY = 0x01,
-	UTERM_FORMAT_XRGB32 = 0x02,
-	UTERM_FORMAT_RGB16 = 0x04,
-	UTERM_FORMAT_RGB24 = 0x08,
-};
-
 struct uterm_video_buffer {
 	unsigned int width;
 	unsigned int height;
 	unsigned int stride;
-	unsigned int format;
 	uint8_t data[];
 };
 

--- a/tests/test_bbulk.c
+++ b/tests/test_bbulk.c
@@ -40,8 +40,8 @@ unsigned int kmscon_font_get_height(const struct kmscon_font *font)
 }
 
 /* Stub font rendering APIs used by text_bbulk.c */
-int kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch, size_t len,
-		       const struct kmscon_glyph **out)
+struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
+					size_t len)
 {
 	static struct kmscon_glyph g;
 	(void)font;
@@ -51,24 +51,20 @@ int kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch
 	memset(&g, 0, sizeof(g));
 	g.buf.width = g.buf.height = FAKE_CELL_W;
 	g.buf.stride = g.buf.width * 4;
-	if (out)
-		*out = &g;
-	return 0;
+	return &g;
 }
-int kmscon_font_render_inval(struct kmscon_font *font, const struct kmscon_glyph **out)
+struct kmscon_glyph *kmscon_font_render_inval(struct kmscon_font *font)
 {
-	return kmscon_font_render_empty(font, out);
+	return kmscon_font_render_empty(font);
 }
-int kmscon_font_render_empty(struct kmscon_font *font, const struct kmscon_glyph **out)
+struct kmscon_glyph *kmscon_font_render_empty(struct kmscon_font *font)
 {
 	static struct kmscon_glyph g;
 	(void)font;
 	memset(&g, 0, sizeof(g));
 	g.buf.width = g.buf.height = FAKE_CELL_W;
 	g.buf.stride = g.buf.width * 4;
-	if (out)
-		*out = &g;
-	return 0;
+	return &g;
 }
 int kmscon_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyph,
 			enum Orientation o, uint8_t align)

--- a/tests/test_bbulk.c
+++ b/tests/test_bbulk.c
@@ -83,9 +83,6 @@ int kmscon_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyp
 	if (glyph->buf.stride == 0 || glyph->buf.height == 0)
 		return 0;
 	size_t buf_size = glyph->buf.stride * glyph->buf.height;
-	vb->buf.data = malloc(buf_size);
-	if (!vb->buf.data)
-		return -ENOMEM;
 	memset(vb->buf.data, 0x11, buf_size);
 	return 0;
 }

--- a/tests/test_bbulk.c
+++ b/tests/test_bbulk.c
@@ -49,7 +49,6 @@ int kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch
 	(void)ch;
 	(void)len;
 	memset(&g, 0, sizeof(g));
-	g.buf.format = UTERM_FORMAT_XRGB32;
 	g.buf.width = g.buf.height = FAKE_CELL_W;
 	g.buf.stride = g.buf.width * 4;
 	if (out)
@@ -65,7 +64,6 @@ int kmscon_font_render_empty(struct kmscon_font *font, const struct kmscon_glyph
 	static struct kmscon_glyph g;
 	(void)font;
 	memset(&g, 0, sizeof(g));
-	g.buf.format = UTERM_FORMAT_XRGB32;
 	g.buf.width = g.buf.height = FAKE_CELL_W;
 	g.buf.stride = g.buf.width * 4;
 	if (out)

--- a/tests/test_bbulk.c
+++ b/tests/test_bbulk.c
@@ -43,29 +43,18 @@ unsigned int kmscon_font_get_height(const struct kmscon_font *font)
 struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
 					size_t len)
 {
-	static struct kmscon_glyph g;
+	struct kmscon_glyph *g;
 	(void)font;
 	(void)id;
 	(void)ch;
 	(void)len;
-	memset(&g, 0, sizeof(g));
-	g.buf.width = g.buf.height = FAKE_CELL_W;
-	g.buf.stride = g.buf.width * 4;
-	return &g;
+	g = malloc(sizeof(*g) + FAKE_CELL_W * FAKE_CELL_W);
+	memset(g, 0, sizeof(*g) + FAKE_CELL_W * FAKE_CELL_W);
+	g->buf.width = g->buf.height = FAKE_CELL_W;
+	g->buf.stride = g->buf.width;
+	return g;
 }
-struct kmscon_glyph *kmscon_font_render_inval(struct kmscon_font *font)
-{
-	return kmscon_font_render_empty(font);
-}
-struct kmscon_glyph *kmscon_font_render_empty(struct kmscon_font *font)
-{
-	static struct kmscon_glyph g;
-	(void)font;
-	memset(&g, 0, sizeof(g));
-	g.buf.width = g.buf.height = FAKE_CELL_W;
-	g.buf.stride = g.buf.width * 4;
-	return &g;
-}
+
 int kmscon_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyph,
 			enum Orientation o, uint8_t align)
 {


### PR DESCRIPTION
Refactor the font engine.

 * Use one level of cache.
 * Use one function for rendering.
 * Remove unused format support.
 * Bbulk: re-use the glyph if it's not rotated.

This lower the memory footprint of the glyphs, and will make an LRU cache easier to implement.
 