### PR TITLE
Add an LRU hashtable, and use it for glyphs

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -370,3 +370,22 @@ struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, c
 		glyph = font->ops->render(font, invalid_char, &invalid_char, 1);
 	return glyph;
 }
+
+/**
+ * kmscon_font_has_glyph:
+ * @font: Valid font object
+ * @ch: Symbol to find a glyph for
+ * @len: Length of @ch
+ *
+ * Checks if the font has a glyph for the given symbol @ch.
+ *
+ * Returns: true if the font has a glyph for the given symbol, false otherwise
+ */
+SHL_EXPORT
+bool kmscon_font_has_glyph(struct kmscon_font *font, const uint32_t *ch, size_t len)
+{
+	if (!font)
+		return false;
+
+	return font->ops->has_glyph(font, ch, len);
+}

--- a/src/font.h
+++ b/src/font.h
@@ -91,6 +91,7 @@ struct kmscon_font_ops {
 	struct shl_module *owner;
 	int (*init)(struct kmscon_font *out, const struct kmscon_font_attr *attr);
 	void (*destroy)(struct kmscon_font *font);
+	bool (*has_glyph)(struct kmscon_font *font, const uint32_t *ch, size_t len);
 	struct kmscon_glyph *(*render)(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
 				       size_t len);
 };
@@ -105,6 +106,7 @@ void kmscon_font_unref(struct kmscon_font *font);
 
 struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, const uint32_t *ch,
 					size_t len);
+bool kmscon_font_has_glyph(struct kmscon_font *font, const uint32_t *ch, size_t len);
 
 /* modularized backends */
 

--- a/src/font_8x16.c
+++ b/src/font_8x16.c
@@ -110,9 +110,20 @@ static struct kmscon_glyph *new_glyph(uint32_t ch)
 	return glyph;
 }
 
+static bool kmscon_font_8x16_has_glyph(struct kmscon_font *font, const uint32_t *ch, size_t len)
+{
+	return (len == 1 && *ch < 256);
+}
+
 static struct kmscon_glyph *kmscon_font_8x16_render(struct kmscon_font *font, uint64_t id,
 						    const uint32_t *ch, size_t len)
 {
+	uint32_t c = *ch;
+
+	// Handle replacement character
+	if (c == 0xfffd)
+		c = '?';
+
 	if (len > 1 || *ch >= 256)
 		return NULL;
 
@@ -124,5 +135,6 @@ struct kmscon_font_ops kmscon_font_8x16_ops = {
 	.owner = NULL,
 	.init = kmscon_font_8x16_init,
 	.destroy = kmscon_font_8x16_destroy,
+	.has_glyph = kmscon_font_8x16_has_glyph,
 	.render = kmscon_font_8x16_render,
 };

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -43,6 +43,8 @@ struct ft_font {
 	/* FontSet and Pattern are used for fallback glyphs */
 	FcFontSet *fc;
 	FcPattern *pattern;
+	FT_Face fallback;
+	int fallback_index;
 };
 
 struct ft_data {
@@ -72,6 +74,10 @@ static void free_ft_font(struct ft_font *ftfont)
 	if (ftfont->pattern)
 		FcPatternDestroy(ftfont->pattern);
 	ftfont->pattern = NULL;
+	if (ftfont->fallback)
+		FT_Done_Face(ftfont->fallback);
+	ftfont->fallback = NULL;
+	ftfont->fallback_index = -1;
 }
 
 static int prepare_face(FT_Library ft, struct ft_font *ftfont)
@@ -193,6 +199,9 @@ static int prepare_font(FT_Library ft, struct ft_font *ftfont, struct kmscon_fon
 
 	if (compute_font_size(ftfont, attr))
 		goto err;
+
+	ftfont->fallback_index = -1;
+	ftfont->fallback = NULL;
 	return 0;
 err:
 	free_ft_font(ftfont);
@@ -457,8 +466,6 @@ static struct kmscon_glyph *kmscon_font_freetype_render(struct kmscon_font *font
 	struct ft_font *ftfont = font->attr.bold ? &ftd->bold : &ftd->regular;
 	FT_UInt glyph_index = FT_Get_Char_Index(ftfont->face, *ch);
 	int fallback_index;
-	FT_Face fallback;
-	struct kmscon_glyph *glyph;
 
 	if (!len)
 		return NULL;
@@ -471,18 +478,24 @@ static struct kmscon_glyph *kmscon_font_freetype_render(struct kmscon_font *font
 	if (fallback_index < 0)
 		return NULL;
 
-	fallback = prepare_tmp_face(ftd->ft, ftfont, fallback_index);
+	if (ftfont->fallback_index != fallback_index) {
+		if (ftfont->fallback)
+			FT_Done_Face(ftfont->fallback);
+		ftfont->fallback = NULL;
+		ftfont->fallback_index = fallback_index;
+	}
 
-	if (!fallback)
-		return NULL;
+	if (!ftfont->fallback) {
+		ftfont->fallback = prepare_tmp_face(ftd->ft, ftfont, fallback_index);
+		if (!ftfont->fallback)
+			return NULL;
+		select_font_size(ftfont->fallback, &font->attr);
+	}
 
-	select_font_size(fallback, &font->attr);
-	glyph_index = FT_Get_Char_Index(fallback, *ch);
+	glyph_index = FT_Get_Char_Index(ftfont->fallback, *ch);
 	if (!glyph_index)
 		return NULL;
-	glyph = render_glyph(fallback, glyph_index, id, ch, &font->attr);
-	FT_Done_Face(fallback);
-	return glyph;
+	return render_glyph(ftfont->fallback, glyph_index, id, ch, &font->attr);
 }
 
 struct kmscon_font_ops kmscon_font_freetype_ops = {

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -460,6 +460,18 @@ static int get_fallback(uint32_t ch, struct ft_font *ftf)
 	return -ENOENT;
 }
 
+static bool kmscon_font_freetype_has_glyph(struct kmscon_font *font, const uint32_t *ch, size_t len)
+{
+	struct ft_data *ftd = font->data;
+	struct ft_font *ftfont = font->attr.bold ? &ftd->bold : &ftd->regular;
+	FT_UInt glyph_index = FT_Get_Char_Index(ftfont->face, *ch);
+
+	if (glyph_index)
+		return true;
+
+	return get_fallback(*ch, ftfont) >= 0;
+}
+
 static struct kmscon_glyph *kmscon_font_freetype_render(struct kmscon_font *font, uint64_t id,
 							const uint32_t *ch, size_t len)
 {
@@ -504,5 +516,6 @@ struct kmscon_font_ops kmscon_font_freetype_ops = {
 	.owner = NULL,
 	.init = kmscon_font_freetype_init,
 	.destroy = kmscon_font_freetype_destroy,
+	.has_glyph = kmscon_font_freetype_has_glyph,
 	.render = kmscon_font_freetype_render,
 };

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -320,28 +320,29 @@ static void copy_glyph(struct uterm_video_buffer *buf, FT_Face face, FT_Bitmap *
 {
 	int top = (face->size->metrics.ascender >> 6) - face->glyph->bitmap_top;
 	int left = face->glyph->bitmap_left;
-	int width = min(buf->width, map->width);
-	int height = min(buf->height, map->rows);
+	int width, height;
 	int left_src = 0;
 	int top_src = 0;
 	int i;
 	uint8_t *dst;
 
-	if (top + height > buf->height)
-		height = buf->height - top;
+	if (!map->width || !map->rows)
+		return;
+
 	if (top < 0) {
 		top_src = -top;
-		height = min(buf->height, map->rows + top);
 		top = 0;
 	}
+	height = min((int)(buf->height - top), (int)(map->rows - top_src));
 
 	if (left < 0) {
 		left_src = -left;
-		width = min(buf->width, map->width + left);
 		left = 0;
 	}
-	if (left + width > buf->width)
-		width = buf->width - left;
+	width = min((int)(buf->width - left), (int)(map->width - left_src));
+
+	if (width <= 0 || height <= 0)
+		return;
 
 	dst = buf->data + left + top * buf->stride;
 	for (i = 0; i < height; i++) {
@@ -353,8 +354,8 @@ static void copy_glyph(struct uterm_video_buffer *buf, FT_Face face, FT_Bitmap *
 		draw_underline(buf, face);
 }
 
-static struct kmscon_glyph *render_glyph(FT_Face face, FT_UInt index, uint64_t id,
-					 const uint32_t *ch, const struct kmscon_font_attr *attr)
+static struct kmscon_glyph *render_glyph(FT_Face face, FT_UInt index, const uint32_t *ch,
+					 const struct kmscon_font_attr *attr)
 {
 	unsigned int cwidth;
 	struct kmscon_glyph *glyph;
@@ -471,7 +472,7 @@ static struct kmscon_glyph *kmscon_font_freetype_render(struct kmscon_font *font
 		return NULL;
 
 	if (glyph_index)
-		return render_glyph(ftfont->face, glyph_index, id, ch, &font->attr);
+		return render_glyph(ftfont->face, glyph_index, ch, &font->attr);
 
 	/* Fallback, if the glyph is not found in the regular font */
 	fallback_index = get_fallback(*ch, ftfont);
@@ -495,7 +496,7 @@ static struct kmscon_glyph *kmscon_font_freetype_render(struct kmscon_font *font
 	glyph_index = FT_Get_Char_Index(ftfont->fallback, *ch);
 	if (!glyph_index)
 		return NULL;
-	return render_glyph(ftfont->fallback, glyph_index, id, ch, &font->attr);
+	return render_glyph(ftfont->fallback, glyph_index, ch, &font->attr);
 }
 
 struct kmscon_font_ops kmscon_font_freetype_ops = {

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -377,6 +377,11 @@ static void kmscon_font_pango_destroy(struct kmscon_font *font)
 	manager_unlock();
 }
 
+static bool kmscon_font_pango_has_glyph(struct kmscon_font *font, const uint32_t *ch, size_t len)
+{
+	return true;
+}
+
 static struct kmscon_glyph *kmscon_font_pango_render(struct kmscon_font *font, uint64_t id,
 						     const uint32_t *ch, size_t len)
 {
@@ -388,5 +393,6 @@ struct kmscon_font_ops kmscon_font_pango_ops = {
 	.owner = NULL,
 	.init = kmscon_font_pango_init,
 	.destroy = kmscon_font_pango_destroy,
+	.has_glyph = kmscon_font_pango_has_glyph,
 	.render = kmscon_font_pango_render,
 };

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -171,15 +171,8 @@ static struct kmscon_glyph *find_glyph(uint64_t id, const struct kmscon_font *fo
 	data = (uint8_t *)uf->font_data + 4 + len * sizeof(struct unifont_glyph_block);
 
 	int idx = lookup_block(blocks, len, ch);
-	if (idx < 0) {
-		log_debug("codepoint %08x not found, using replacement glyph", ch);
-		ch = 0xfffd;
-		idx = lookup_block(blocks, len, ch);
-		if (idx < 0) {
-			log_warning("Replacement glyph not found");
-			return NULL;
-		}
-	}
+	if (idx < 0)
+		return NULL;
 
 	data += blocks[idx].offset + (ch - blocks[idx].codepoint) * blocks[idx].cwidth * 16;
 	if (data + 16 * blocks[idx].cwidth > uf->font_data + uf->len) {

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -155,6 +155,20 @@ static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const
 	return g;
 }
 
+static bool kmscon_font_unifont_has_glyph(struct kmscon_font *font, const uint32_t *ch, size_t len)
+{
+	struct unifont_data *uf = font->data;
+	uint32_t block_len;
+	const struct unifont_glyph_block *blocks;
+
+	/* First the length of the block index */
+	block_len = *((uint32_t *)uf->font_data);
+	/* Then the block index */
+	blocks = (struct unifont_glyph_block *)(uf->font_data + 4);
+
+	return lookup_block(blocks, block_len, *ch) >= 0;
+}
+
 static struct kmscon_glyph *find_glyph(uint64_t id, const struct kmscon_font *font)
 {
 	struct unifont_data *uf = font->data;
@@ -256,5 +270,6 @@ struct kmscon_font_ops kmscon_font_unifont_ops = {
 	.owner = NULL,
 	.init = kmscon_font_unifont_init,
 	.destroy = kmscon_font_unifont_destroy,
+	.has_glyph = kmscon_font_unifont_has_glyph,
 	.render = kmscon_font_unifont_render,
 };

--- a/src/shl_lru.h
+++ b/src/shl_lru.h
@@ -1,0 +1,156 @@
+/*
+ * shl - Simple LRU Cache
+ *
+ * Copyright (c) 2026 Red Hat.
+ * Author: Jocelyn Falempe <jfalempe@redhat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include "htable.h"
+#include "shl_dlist.h"
+#include "shl_log.h"
+
+struct shl_lru {
+	unsigned int max_size;
+	unsigned int size;
+	struct htable tbl;
+	struct shl_dlist list;
+};
+
+struct shl_lru_entry {
+	struct shl_dlist list;
+	uint64_t key;
+	void *value;
+};
+
+static size_t shl_lru_rehash(const void *ele, void *priv)
+{
+	const struct shl_lru_entry *ent = ele;
+
+	return ent->key;
+}
+
+static inline struct shl_lru *shl_lru_new(unsigned int max_size)
+{
+	struct shl_lru *lru;
+
+	if (max_size == 0)
+		return NULL;
+
+	lru = malloc(sizeof(*lru));
+	if (!lru)
+		return NULL;
+	memset(lru, 0, sizeof(*lru));
+
+	lru->max_size = max_size;
+	lru->size = 0;
+	shl_dlist_init(&lru->list);
+	htable_init(&lru->tbl, shl_lru_rehash, lru);
+
+	return lru;
+}
+
+static inline void shl_lru_free(struct shl_lru *lru)
+{
+	struct htable_iter i;
+	struct shl_lru_entry *entry;
+
+	if (!lru)
+		return;
+
+	for (entry = htable_first(&lru->tbl, &i); entry; entry = htable_next(&lru->tbl, &i)) {
+		htable_delval(&lru->tbl, &i);
+		free(entry->value);
+		free(entry);
+	}
+
+	htable_clear(&lru->tbl);
+	free(lru);
+}
+
+static inline void *shl_lru_get(struct shl_lru *lru, uint64_t key)
+{
+	struct htable_iter i;
+	struct shl_lru_entry *entry;
+
+	if (!lru)
+		return NULL;
+
+	for (entry = htable_firstval(&lru->tbl, &i, key); entry;
+	     entry = htable_nextval(&lru->tbl, &i, key)) {
+		if (key == entry->key) {
+			/* Put this entry at the top of the list */
+			shl_dlist_unlink(&entry->list);
+			shl_dlist_link(&lru->list, &entry->list);
+			return entry->value;
+		}
+	}
+	return NULL;
+}
+
+static inline int shl_lru_evict(struct shl_lru *lru)
+{
+	struct shl_lru_entry *last, *entry;
+	struct htable_iter i;
+
+	last = shl_dlist_last(&lru->list, struct shl_lru_entry, list);
+
+	for (entry = htable_firstval(&lru->tbl, &i, last->key); entry;
+	     entry = htable_nextval(&lru->tbl, &i, last->key)) {
+		if (last == entry) {
+			htable_delval(&lru->tbl, &i);
+			shl_dlist_unlink(&last->list);
+			free(entry->value);
+			free(entry);
+			lru->size--;
+			return 0;
+		}
+	}
+	log_warning("LRU evict failed key not found%ld", last->key);
+	return -ENOENT;
+}
+
+static inline int shl_lru_insert(struct shl_lru *lru, uint64_t key, void *value)
+{
+	struct shl_lru_entry *entry;
+
+	if (!lru)
+		return -EINVAL;
+
+	if (lru->size >= lru->max_size && shl_lru_evict(lru) < 0)
+		return -ENOMEM;
+
+	entry = malloc(sizeof(*entry));
+	if (!entry)
+		return -ENOMEM;
+	entry->key = key;
+	entry->value = value;
+
+	if (!htable_add(&lru->tbl, key, entry)) {
+		free(entry);
+		return -ENOMEM;
+	}
+	shl_dlist_link(&lru->list, &entry->list);
+	lru->size++;
+	return 0;
+}

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -42,8 +42,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include "font.h"
-#include "shl_hashtable.h"
 #include "shl_log.h"
+#include "shl_lru.h"
 #include "shl_misc.h"
 #include "text.h"
 #include "uterm_video.h"
@@ -67,7 +67,7 @@ struct bbulk {
 	unsigned int req_len;
 	unsigned int req_total_len;
 	struct tsm_screen_attr attr;
-	struct shl_hashtable *glyphs;
+	struct shl_lru *glyphs;
 	struct bbcell *prev;
 	unsigned int cells;
 	unsigned int sw;
@@ -98,13 +98,6 @@ static void bbulk_destroy(struct kmscon_text *txt)
 	struct bbulk *bb = txt->data;
 
 	free(bb);
-}
-
-static void free_glyph(void *data)
-{
-	struct kmscon_glyph *glyph = data;
-
-	free(glyph);
 }
 
 static void damage_cell(struct bbulk *bb, unsigned int off)
@@ -176,7 +169,9 @@ static int bbulk_set(struct kmscon_text *txt)
 	for (i = 0; i < (int)bb->cells; i++)
 		damage_cell(bb, i);
 
-	if (shl_hashtable_new(&bb->glyphs, shl_direct_hash, shl_direct_equal, free_glyph))
+	/* lru size should be at least bb->cells large */
+	bb->glyphs = shl_lru_new(2 * bb->cells);
+	if (!bb->glyphs)
 		goto free_r_damages;
 	return 0;
 
@@ -195,7 +190,7 @@ static void bbulk_unset(struct kmscon_text *txt)
 {
 	struct bbulk *bb = txt->data;
 
-	shl_hashtable_free(bb->glyphs);
+	shl_lru_free(bb->glyphs);
 	free(bb->damage_rects);
 	free(bb->reqs);
 	free(bb->damages);
@@ -304,7 +299,8 @@ static struct kmscon_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, con
 	font->attr.italic = !!attr->italic;
 	font->attr.bold = !!attr->bold;
 
-	if (shl_hashtable_find(bb->glyphs, (void **)&glyph, id))
+	glyph = shl_lru_get(bb->glyphs, id);
+	if (glyph)
 		return glyph;
 
 	glyph = kmscon_font_render(font, id, ch, len);
@@ -314,7 +310,7 @@ static struct kmscon_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, con
 	if (txt->orientation != OR_NORMAL)
 		glyph = bbulk_rotate_glyph(glyph, txt->orientation);
 
-	if (shl_hashtable_insert(bb->glyphs, id, glyph)) {
+	if (shl_lru_insert(bb->glyphs, id, glyph)) {
 		free(glyph);
 		return NULL;
 	}

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -294,10 +294,17 @@ static struct kmscon_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, con
 	struct bbulk *bb = txt->data;
 	struct kmscon_glyph *glyph;
 	struct kmscon_font *font = txt->font;
+	const uint32_t replacement_char = 0xfffd;
 
 	font->attr.underline = !!attr->underline;
 	font->attr.italic = !!attr->italic;
 	font->attr.bold = !!attr->bold;
+
+	if (len == 1 && !kmscon_font_has_glyph(font, ch, len)) {
+		id = (id & ~0xffffffff) | replacement_char;
+		ch = &replacement_char;
+		len = 1;
+	}
 
 	glyph = shl_lru_get(bb->glyphs, id);
 	if (glyph)

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -414,10 +414,17 @@ static struct glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint
 	const uint8_t *src;
 	struct kmscon_font *font = txt->font;
 	unsigned int num;
+	const uint32_t replacement_char = 0xfffd;
 
 	font->attr.underline = !!attr->underline;
 	font->attr.italic = !!attr->italic;
 	font->attr.bold = !!attr->bold;
+
+	if (len == 1 && !kmscon_font_has_glyph(font, ch, len)) {
+		id = (id & ~0xffffffff) | replacement_char;
+		ch = &replacement_char;
+		len = 1;
+	}
 
 	if (shl_hashtable_find(gt->glyphs, (void **)&glyph, id))
 		return glyph;

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -83,16 +83,16 @@ struct atlas {
 	GLfloat advance_vtex;
 };
 
-struct glyph {
-	struct kmscon_glyph *glyph;
+struct gl_glyph {
+	bool double_width;
 	struct atlas *atlas;
 	unsigned int texoff;
 };
 
-#define GLYPH_WIDTH(gly) ((gly)->glyph->buf.width)
-#define GLYPH_HEIGHT(gly) ((gly)->glyph->buf.height)
-#define GLYPH_STRIDE(gly) ((gly)->glyph->buf.stride)
-#define GLYPH_DATA(gly) ((gly)->glyph->buf.data)
+#define GLYPH_WIDTH(gly) ((gly)->buf.width)
+#define GLYPH_HEIGHT(gly) ((gly)->buf.height)
+#define GLYPH_STRIDE(gly) ((gly)->buf.stride)
+#define GLYPH_DATA(gly) ((gly)->buf.data)
 
 struct gltex {
 	struct shl_hashtable *glyphs;
@@ -145,9 +145,8 @@ static void gltex_destroy(struct kmscon_text *txt)
 
 static void free_glyph(void *data)
 {
-	struct glyph *glyph = data;
+	struct gl_glyph *glyph = data;
 
-	free(glyph->glyph);
 	free(glyph);
 }
 
@@ -402,12 +401,12 @@ err_free:
 	return NULL;
 }
 
-static struct glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint32_t *ch,
-				size_t len, const struct tsm_screen_attr *attr)
+static struct gl_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint32_t *ch,
+				   size_t len, const struct tsm_screen_attr *attr)
 {
 	struct gltex *gt = txt->data;
 	struct atlas *atlas;
-	struct glyph *glyph;
+	struct gl_glyph *glglyph;
 	int i;
 	GLenum err;
 	uint8_t *packed_data, *dst;
@@ -415,6 +414,7 @@ static struct glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint
 	struct kmscon_font *font = txt->font;
 	unsigned int num;
 	const uint32_t replacement_char = 0xfffd;
+	struct kmscon_glyph *glyph;
 
 	font->attr.underline = !!attr->underline;
 	font->attr.italic = !!attr->italic;
@@ -426,19 +426,21 @@ static struct glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint
 		len = 1;
 	}
 
-	if (shl_hashtable_find(gt->glyphs, (void **)&glyph, id))
-		return glyph;
+	if (shl_hashtable_find(gt->glyphs, (void **)&glglyph, id))
+		return glglyph;
 
-	glyph = malloc(sizeof(*glyph));
+	glglyph = malloc(sizeof(*glglyph));
+	if (!glglyph)
+		return NULL;
+	memset(glglyph, 0, sizeof(*glglyph));
+
+	glyph = kmscon_font_render(font, id, ch, len);
 	if (!glyph)
 		return NULL;
-	memset(glyph, 0, sizeof(*glyph));
 
-	glyph->glyph = kmscon_font_render(font, id, ch, len);
-	if (!glyph->glyph)
-		return NULL;
+	glglyph->double_width = glyph->double_width;
 
-	num = kmscon_glyph_cwidth(glyph->glyph);
+	num = kmscon_glyph_cwidth(glyph);
 	atlas = get_atlas(txt, num);
 	if (!atlas)
 		goto err_free;
@@ -505,18 +507,20 @@ static struct glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const uint
 		goto err_free;
 	}
 
-	glyph->atlas = atlas;
-	glyph->texoff = atlas->fill;
+	glglyph->atlas = atlas;
+	glglyph->texoff = atlas->fill;
 
-	if (shl_hashtable_insert(gt->glyphs, id, glyph))
+	if (shl_hashtable_insert(gt->glyphs, id, glglyph))
 		goto err_free;
 
 	atlas->fill += num;
+	free(glyph);
 
-	return glyph;
+	return glglyph;
 
 err_free:
 	free(glyph);
+	free(glglyph);
 	return NULL;
 }
 
@@ -566,7 +570,7 @@ static int gltex_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 {
 	struct gltex *gt = txt->data;
 	struct atlas *atlas;
-	struct glyph *glyph;
+	struct gl_glyph *glglyph;
 	float gl_x1, gl_x2, gl_y1, gl_y2;
 	int i, idx;
 
@@ -577,13 +581,13 @@ static int gltex_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 		gt->previous_overflow = false;
 		return 0;
 	}
-	glyph = find_glyph(txt, id, ch, len, attr);
-	if (!glyph)
+	glglyph = find_glyph(txt, id, ch, len, attr);
+	if (!glglyph)
 		return -ENOMEM;
 
-	atlas = glyph->atlas;
+	atlas = glglyph->atlas;
 
-	if (width == 1 && glyph->glyph->double_width) {
+	if (width == 1 && glglyph->double_width) {
 		gt->previous_overflow = true;
 		width = 2;
 	} else {
@@ -613,18 +617,18 @@ static int gltex_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 	atlas->cache_pos[idx + 10] = gl_x2;
 	atlas->cache_pos[idx + 11] = gl_y1;
 
-	atlas->cache_texpos[idx + 0] = glyph->texoff;
+	atlas->cache_texpos[idx + 0] = glglyph->texoff;
 	atlas->cache_texpos[idx + 1] = 0.0;
-	atlas->cache_texpos[idx + 2] = glyph->texoff;
+	atlas->cache_texpos[idx + 2] = glglyph->texoff;
 	atlas->cache_texpos[idx + 3] = 1.0;
-	atlas->cache_texpos[idx + 4] = glyph->texoff + width;
+	atlas->cache_texpos[idx + 4] = glglyph->texoff + width;
 	atlas->cache_texpos[idx + 5] = 1.0;
 
-	atlas->cache_texpos[idx + 6] = glyph->texoff;
+	atlas->cache_texpos[idx + 6] = glglyph->texoff;
 	atlas->cache_texpos[idx + 7] = 0.0;
-	atlas->cache_texpos[idx + 8] = glyph->texoff + width;
+	atlas->cache_texpos[idx + 8] = glglyph->texoff + width;
 	atlas->cache_texpos[idx + 9] = 1.0;
-	atlas->cache_texpos[idx + 10] = glyph->texoff + width;
+	atlas->cache_texpos[idx + 10] = glglyph->texoff + width;
 	atlas->cache_texpos[idx + 11] = 0.0;
 
 	for (i = 0; i < 6; ++i) {
@@ -655,7 +659,7 @@ static int gltex_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned 
 {
 	struct gltex *gt = txt->data;
 	struct atlas *atlas;
-	struct glyph *glyph;
+	struct gl_glyph *glyph;
 	float gl_x1, gl_x2, gl_y1, gl_y2;
 	unsigned int sw, sh;
 	int i, idx;

--- a/tests/test_bbulk.c
+++ b/tests/test_bbulk.c
@@ -109,7 +109,9 @@ void uterm_display_set_damage(struct uterm_display *disp, size_t n_rect,
 	(void)n_rect;
 	(void)damages;
 }
-
+#include "shl_log.h"
+#undef log_warning
+#define log_warning(f, ...)
 /* Pull in the implementation so we can call bbulk_set directly */
 #include "../src/text_bbulk.c"
 

--- a/tests/test_bbulk.c
+++ b/tests/test_bbulk.c
@@ -55,6 +55,14 @@ struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, c
 	return g;
 }
 
+bool kmscon_font_has_glyph(struct kmscon_font *font, const uint32_t *ch, size_t len)
+{
+	(void)font;
+	(void)ch;
+	(void)len;
+	return true;
+}
+
 int kmscon_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyph,
 			enum Orientation o, uint8_t align)
 {


### PR DESCRIPTION
Currently the glyph cache is a simple hashtable, and can grow forever, as long as new unicode characters need to be drawn.
Limit this cache size using a simple LRU mechanism.

Also add an has_glyph() font ops, so that bbulk and gltex can re-use the cache of the replacement glyph for all replaced glyph.

And for freetype, cache the last used fallback face, so when there are a few characters from that font, it saves a lot of time.