### PR TITLE
systemd: start login instead of agetty

### DIFF
--- a/scripts/systemd/kmscon.service
+++ b/scripts/systemd/kmscon.service
@@ -6,7 +6,7 @@ After=systemd-user-sessions.service
 After=rc-local.service
 
 [Service]
-ExecStart=kmscon --login -- /sbin/agetty -o '-p -- \\u' --noclear -- - $$TERM
+ExecStart=kmscon
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/systemd/kmsconvt@.service
+++ b/scripts/systemd/kmsconvt@.service
@@ -38,7 +38,7 @@ IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
 
 [Service]
-ExecStart=kmscon --vt=%I --seats=seat0 --no-switchvt --login -- /sbin/agetty -8 -o '-p -- \\u' --noclear -- - $$TERM
+ExecStart=kmscon --vt=%I --seats=seat0 --no-switchvt
 UtmpIdentifier=%I
 TTYPath=/dev/%I
 TTYReset=yes


### PR DESCRIPTION
Now that kmscon support /etc/issue and /etc/issue.d, there is no need to run agetty.
Simplify the scripts, and use the default /bin/login