### PR TITLE
hw_cursor: Set offset

### DIFF
--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -117,6 +117,7 @@ static void compute_border(struct kmscon_text *txt)
 		bb->off_x = (bb->sw - txt->rows * FONT_HEIGHT(txt)) / 2;
 		bb->off_y = (bb->sh - txt->cols * FONT_WIDTH(txt)) / 2;
 	}
+	uterm_display_set_cursor_offset(txt->disp, bb->off_x, bb->off_y);
 }
 
 static int bbulk_set(struct kmscon_text *txt)

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -173,11 +173,12 @@ static void compute_advance_and_offset(struct kmscon_text *txt)
 	} else {
 		gt->advance_x = 2.0 / gt->sh * FONT_WIDTH(txt);
 		gt->advance_y = 2.0 / gt->sw * FONT_HEIGHT(txt);
-		off_x = (gt->sh - txt->cols * FONT_WIDTH(txt)) / 2;
-		off_y = (gt->sw - txt->rows * FONT_HEIGHT(txt)) / 2;
-		gt->off_x = (float)2.0 * off_x / gt->sh;
-		gt->off_y = (float)2.0 * off_y / gt->sw;
+		off_x = (gt->sw - txt->rows * FONT_HEIGHT(txt)) / 2;
+		off_y = (gt->sh - txt->cols * FONT_WIDTH(txt)) / 2;
+		gt->off_x = (float)2.0 * off_y / gt->sh;
+		gt->off_y = (float)2.0 * off_x / gt->sw;
 	}
+	uterm_display_set_cursor_offset(txt->disp, off_x, off_y);
 }
 
 static int gltex_set(struct kmscon_text *txt)

--- a/src/uterm_drm2d_video.c
+++ b/src/uterm_drm2d_video.c
@@ -240,6 +240,7 @@ static const struct display_ops drm2d_display_ops = {
 	.destroy_cursor = uterm_drm_display_destroy_cursor,
 	.show_cursor = uterm_drm_display_show_cursor,
 	.hide_cursor = uterm_drm_display_hide_cursor,
+	.set_cursor_offset = uterm_drm_display_set_cursor_offset,
 };
 
 static void show_displays(struct uterm_video *video)

--- a/src/uterm_drm3d_video.c
+++ b/src/uterm_drm3d_video.c
@@ -381,6 +381,7 @@ static const struct display_ops drm_display_ops = {
 	.destroy_cursor = uterm_drm_display_destroy_cursor,
 	.show_cursor = uterm_drm_display_show_cursor,
 	.hide_cursor = uterm_drm_display_hide_cursor,
+	.set_cursor_offset = uterm_drm_display_set_cursor_offset,
 };
 
 static void show_displays(struct uterm_video *video)

--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -449,6 +449,8 @@ int uterm_drm_display_setup_cursor(struct uterm_display *disp, const uint32_t *p
 
 	cursor->hot_x = hot_x + off_x;
 	cursor->hot_y = hot_y + off_y;
+	cursor->off_x = 0;
+	cursor->off_y = 0;
 	cursor->active = true;
 	cursor->visible = false;
 
@@ -482,7 +484,6 @@ int uterm_drm_display_show_cursor(struct uterm_display *disp, int32_t x, int32_t
 	cursor->x = x;
 	cursor->y = y;
 	cursor->visible = true;
-	uterm_display_set_need_redraw(disp);
 
 	return 0;
 }
@@ -496,9 +497,17 @@ int uterm_drm_display_hide_cursor(struct uterm_display *disp)
 		return 0;
 
 	cursor->visible = false;
-	uterm_display_set_need_redraw(disp);
 
 	return 0;
+}
+
+void uterm_drm_display_set_cursor_offset(struct uterm_display *disp, int32_t x, int32_t y)
+{
+	struct uterm_drm_display *ddrm = disp->data;
+	struct uterm_drm_cursor *cursor = &ddrm->cursor;
+
+	cursor->off_x = x;
+	cursor->off_y = y;
 }
 
 static void modeset_drm_object_fini(struct drm_object *obj)
@@ -645,11 +654,11 @@ int uterm_drm_prepare_commit(int fd, struct uterm_drm_display *ddrm, drmModeAtom
 			if (set_drm_object_property(req, cp, "SRC_H",
 						    (uint64_t)cursor->height << 16) < 0)
 				return -1;
-			if (set_drm_object_property(req, cp, "CRTC_X", cursor->x - cursor->hot_x) <
-			    0)
+			if (set_drm_object_property(req, cp, "CRTC_X",
+						    cursor->off_x + cursor->x - cursor->hot_x) < 0)
 				return -1;
-			if (set_drm_object_property(req, cp, "CRTC_Y", cursor->y - cursor->hot_y) <
-			    0)
+			if (set_drm_object_property(req, cp, "CRTC_Y",
+						    cursor->off_y + cursor->y - cursor->hot_y) < 0)
 				return -1;
 			if (set_drm_object_property(req, cp, "CRTC_W", cursor->width) < 0)
 				return -1;

--- a/src/uterm_drm_shared_internal.h
+++ b/src/uterm_drm_shared_internal.h
@@ -60,6 +60,8 @@ struct uterm_drm_cursor {
 	int32_t y;
 	int32_t hot_x;
 	int32_t hot_y;
+	int32_t off_x;
+	int32_t off_y;
 };
 
 struct uterm_drm_display {
@@ -95,6 +97,7 @@ int uterm_drm_display_setup_cursor(struct uterm_display *disp, const uint32_t *p
 void uterm_drm_display_destroy_cursor(struct uterm_display *disp);
 int uterm_drm_display_show_cursor(struct uterm_display *disp, int32_t x, int32_t y);
 int uterm_drm_display_hide_cursor(struct uterm_display *disp);
+void uterm_drm_display_set_cursor_offset(struct uterm_display *disp, int32_t x, int32_t y);
 int uterm_drm_display_wait_pflip(struct uterm_display *disp);
 int uterm_drm_prepare_commit(int fd, struct uterm_drm_display *ddrm, drmModeAtomicReq *req,
 			     uint32_t fb, uint32_t width, uint32_t height, bool cursor_hotspot);

--- a/src/uterm_video.c
+++ b/src/uterm_video.c
@@ -379,6 +379,15 @@ int uterm_display_hide_cursor(struct uterm_display *disp)
 }
 
 SHL_EXPORT
+void uterm_display_set_cursor_offset(struct uterm_display *disp, int32_t x, int32_t y)
+{
+	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
+		return;
+
+	VIDEO_CALL(disp->ops->set_cursor_offset, 0, disp, x, y);
+}
+
+SHL_EXPORT
 void uterm_display_set_damage(struct uterm_display *disp, size_t n_rect,
 			      struct uterm_video_rect *damages)
 {

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -168,6 +168,7 @@ int uterm_display_setup_cursor(struct uterm_display *disp, const uint32_t *pixel
 void uterm_display_destroy_cursor(struct uterm_display *disp);
 int uterm_display_show_cursor(struct uterm_display *disp, int32_t x, int32_t y);
 int uterm_display_hide_cursor(struct uterm_display *disp);
+void uterm_display_set_cursor_offset(struct uterm_display *disp, int32_t x, int32_t y);
 int uterm_display_fake_blendv(struct uterm_display *disp, const struct uterm_video_blend_req *req,
 			      size_t num);
 void uterm_display_set_damage(struct uterm_display *disp, size_t n_rect,

--- a/src/uterm_video_internal.h
+++ b/src/uterm_video_internal.h
@@ -57,6 +57,7 @@ struct display_ops {
 	void (*destroy_cursor)(struct uterm_display *disp);
 	int (*show_cursor)(struct uterm_display *disp, int32_t x, int32_t y);
 	int (*hide_cursor)(struct uterm_display *disp);
+	void (*set_cursor_offset)(struct uterm_display *disp, int32_t x, int32_t y);
 };
 
 struct video_ops {

--- a/tests/test_bbulk.c
+++ b/tests/test_bbulk.c
@@ -117,6 +117,12 @@ void uterm_display_set_damage(struct uterm_display *disp, size_t n_rect,
 	(void)n_rect;
 	(void)damages;
 }
+void uterm_display_set_cursor_offset(struct uterm_display *disp, int32_t x, int32_t y)
+{
+	(void)disp;
+	(void)x;
+	(void)y;
+}
 #include "shl_log.h"
 #undef log_warning
 #define log_warning(f, ...)


### PR DESCRIPTION
When there are multiple monitors, the terminal is now centered, which means there is a big offset between the top left pixel of the screen, and the top left pixel of the terminal. Take this into account to draw the hw cursor.