### PR TITLE
font: remove the dpi option

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -623,9 +623,9 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>--font-size {points}</option></term>
+        <term><option>--font-size {pixels}</option></term>
         <listitem>
-          <para>Font size in pixels. (default: 12)</para>
+          <para>Font size in pixels. (default: 16)</para>
         </listitem>
       </varlistentry>
 

--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -625,7 +625,7 @@
       <varlistentry>
         <term><option>--font-size {points}</option></term>
         <listitem>
-          <para>Font size in points (pt). (default: 12)</para>
+          <para>Font size in pixels. (default: 12)</para>
         </listitem>
       </varlistentry>
 
@@ -635,14 +635,6 @@
           <para>Name of the font to be used, note that Fontconfig fallback may
                 be used if the `pango' font rendering engine is specified.
                 (default: monospace)</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><option>--font-dpi {dpi}</option></term>
-        <listitem>
-          <para>DPI (dots-per-inch) used for font-rendering. Per monitor DPI
-                values override this global default. (default: 96)</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/docs/man/kmscon.conf.5.xml.in
+++ b/docs/man/kmscon.conf.5.xml.in
@@ -466,7 +466,7 @@ font-name=Ubuntu Mono
       <varlistentry>
         <term><option>font-size</option></term>
         <listitem>
-          <para>Font size in pixels. (default: 12)</para>
+          <para>Font size in pixels. (default: 16)</para>
         </listitem>
       </varlistentry>
 

--- a/docs/man/kmscon.conf.5.xml.in
+++ b/docs/man/kmscon.conf.5.xml.in
@@ -466,7 +466,7 @@ font-name=Ubuntu Mono
       <varlistentry>
         <term><option>font-size</option></term>
         <listitem>
-          <para>Font size in points. (default: 12)</para>
+          <para>Font size in pixels. (default: 12)</para>
         </listitem>
       </varlistentry>
 
@@ -474,13 +474,6 @@ font-name=Ubuntu Mono
         <term><option>font-name</option></term>
         <listitem>
           <para>Font name to use. (default: monospace)</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><option>font-dpi</option></term>
-        <listitem>
-          <para>Force DPI value for all fonts. (default: 96)</para>
         </listitem>
       </varlistentry>
 

--- a/scripts/etc/kmscon.conf.example
+++ b/scripts/etc/kmscon.conf.example
@@ -40,7 +40,6 @@
 #font-engine=pango
 #font-size=18
 #font-name=Hack Nerd Font
-#font-dpi=96
 
 ### Input Options ###
 ## Keyboard

--- a/src/font.c
+++ b/src/font.c
@@ -65,39 +65,6 @@
 
 static struct shl_register font_reg = SHL_REGISTER_INIT(font_reg);
 
-/**
- * kmscon_font_attr_normalize:
- * @attr: Attribute to normalize
- *
- * This normalizes @attr and fills out missing entries. The following is done:
- * - If attr->name is empty, then it is set to KMSCON_FONT_DEFAULT_NAME
- * - If attr->ppi is 0, it is set to KMSCON_FONT_DEFAULT_PPI
- * - If attr->height is not set but attr->points is given, then attr->heights is
- *   calculated from attr->points.
- * - If attr->height is set, then attr->points is recalculated and overwritten
- *
- * The other fields are not changed. If attr->points is set but attr->height is
- * not set, then the height is calculated and after that the points are
- * recalculated so we will never have division-errors.
- */
-SHL_EXPORT
-void kmscon_font_attr_normalize(struct kmscon_font_attr *attr)
-{
-	if (!attr)
-		return;
-
-	if (!*attr->name)
-		memcpy(attr->name, KMSCON_FONT_DEFAULT_NAME, sizeof(KMSCON_FONT_DEFAULT_NAME));
-
-	if (!attr->ppi)
-		attr->ppi = KMSCON_FONT_DEFAULT_PPI;
-
-	if (!attr->height && attr->points)
-		attr->height = attr->points * attr->ppi / 72;
-	if (attr->height)
-		attr->points = attr->height * 72 / attr->ppi;
-}
-
 static inline void kmscon_font_destroy(void *data)
 {
 	const struct kmscon_font_ops *ops = data;
@@ -220,47 +187,7 @@ static int new_font(struct kmscon_font *font, const struct kmscon_font_attr *att
  * that you can allocate your own fallback font are pretty small so don't do it.
  *
  * About DPI and Point Sizes:
- * Many computer graphics systems use "Points" as measurement for font sizes.
- * However, most of them also use 72 or 96 as fixed DPI size for monitors. This
- * means, the Point sizes can be directly converted into pixels. But lets
- * look at the facts:
- *   1 Point is defined as 1/72 of an inch. That is, a 10 Point font will be
- *   exactly 10 / 72 inches, which is ~0.13889 inches, which is
- *   0.13889 * 2.54 cm, which is approximately 0.3528 cm. This applies to
- *   printed paper. If we want the same on a monitor, we must need more
- *   information. First, the monitor renders in pixels, that is, we must know
- *   how many Pixels per Inch (PPI) are displayed. Often the same information is
- *   given as Dots per Inch (DPI) but these two are identical in this context.
- *   If the DPI is 96, we know that our 10 Point font is 10 / 72 inches. Which
- *   then means it is 10 / 72 * 96 pixels, which is ~13.333 pixels. So we
- *   internally render the font with 13 pixels and display it as 13 pixels. This
- *   guarantees, that the font will be 10 Point big which means 0.3528 cm on the
- *   display. This of course requires that we know the exact PPI/DPI of the
- *   display.
- * But if we take into account that Windows uses fixed 96 PPI and Mac OS X 72
- * PPI (independent of the monitor), they drop all this information and instead
- * render the font in pixel sizes. Because if you use fixed 72 PPI, a 10 Point
- * font will always be 10 / 72 * 72 = 10 pixels high. This means, it would be
- * rather convenient to directly specify pixel-sizes on the monitor. If you want
- * to work with documents that shall be printed, you want to specify Points so
- * the printed result will look nice. But the disadvantage is, that your monitor
- * can print this font in the weirdest size if it uses PPI much bigger or lower
- * than the common 96 or 72. Therefore, if you work with a monitor you probably
- * want to also specify the pixel-height of the font as you probably don't know
- * the PPI of your monitor and don't want to do all that math in your head.
- * Therefore, for applications that will probably never print their output (like
- * the virtual (!) console this is for), it is often requested that we can
- * specify the pixel size instead of the Point size of a font so you can
- * predict the output better.
- * Hence, we provide both. If pixel information is given, that is, attr->height
- * is not 0, then we try to return a font with this pixel height.
- * If it is 0, attr->points is used together with attr->ppi to calculate the
- * pixel size. If attr->ppi is 0, then 72 is used.
- * After the font was chosen, all fields "points", "ppi", "height" and "width"
- * will contain the exact values for this font. If "ppi" was zero and pixel
- * sizes where specified, then the resulting "points" size is calculated with
- * "ppi" = 72 again. So if you use the "points" field please always specify
- * "ppi", either.
+ * Use a fixed DPI of 72, so point size is the same as height in pixels.
  *
  * Returns: 0 on success, error code on failure
  */
@@ -273,9 +200,8 @@ int kmscon_font_find(struct kmscon_font **out, const struct kmscon_font_attr *at
 	if (!out || !attr)
 		return -EINVAL;
 
-	log_debug("searching for: be: %s nm: %s ppi: %u pt: %u b: %d i: %d he: %u wt: %u", backend,
-		  attr->name, attr->ppi, attr->points, attr->bold, attr->italic, attr->height,
-		  attr->width);
+	log_debug("searching for: be: %s nm: %s b: %d size %ux%u", backend, attr->name, attr->bold,
+		  attr->height, attr->width);
 
 	font = malloc(sizeof(*font));
 	if (!font) {
@@ -291,9 +217,8 @@ int kmscon_font_find(struct kmscon_font **out, const struct kmscon_font_attr *at
 			goto err_free;
 	}
 
-	log_debug("using: be: %s nm: %s ppi: %u pt: %u b: %d i: %d he: %u wt: %u", font->ops->name,
-		  font->attr.name, font->attr.ppi, font->attr.points, font->attr.bold,
-		  font->attr.italic, font->attr.height, font->attr.width);
+	log_debug("using: be: %s nm: %s b: %d size %ux%u", font->ops->name, font->attr.name,
+		  font->attr.bold, font->attr.height, font->attr.width);
 	*out = font;
 	return 0;
 

--- a/src/font.h
+++ b/src/font.h
@@ -49,8 +49,6 @@ struct kmscon_font_ops;
 
 struct kmscon_font_attr {
 	char name[KMSCON_FONT_MAX_NAME];
-	unsigned int ppi;
-	unsigned int points;
 	bool bold;
 	bool italic;
 	bool underline;
@@ -64,7 +62,6 @@ static inline void kmscon_copy_attr(struct kmscon_font_attr *to,
 	memcpy(to, from, sizeof(*to));
 }
 
-void kmscon_font_attr_normalize(struct kmscon_font_attr *attr);
 bool kmscon_font_attr_match(const struct kmscon_font_attr *a1, const struct kmscon_font_attr *a2);
 
 struct kmscon_glyph {

--- a/src/font_8x16.c
+++ b/src/font_8x16.c
@@ -66,7 +66,6 @@ static int kmscon_font_8x16_init(struct kmscon_font *out, const struct kmscon_fo
 	out->attr.italic = false;
 	out->attr.width = 8;
 	out->attr.height = 16;
-	kmscon_font_attr_normalize(&out->attr);
 
 	return 0;
 }

--- a/src/font_freetype.c
+++ b/src/font_freetype.c
@@ -219,7 +219,6 @@ static int kmscon_font_freetype_init(struct kmscon_font *out, const struct kmsco
 		return -ENOMEM;
 	memset(ftf, 0, sizeof(*ftf));
 	kmscon_copy_attr(&out->attr, attr);
-	kmscon_font_attr_normalize(&out->attr);
 	kmscon_copy_attr(&bold_attr, &out->attr);
 	bold_attr.bold = true;
 

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -308,7 +308,6 @@ static int manager_get_face(struct face **out, struct kmscon_font_attr *attr)
 	face->baseline = PANGO_PIXELS_CEIL(pango_layout_get_baseline(layout));
 	g_object_unref(layout);
 
-	kmscon_font_attr_normalize(&face->real_attr);
 	if (!face->real_attr.height || !face->real_attr.width) {
 		log_warning("invalid scaled font sizes");
 		ret = -EFAULT;
@@ -345,7 +344,6 @@ static int kmscon_font_pango_init(struct kmscon_font *out, const struct kmscon_f
 	int ret;
 
 	memcpy(&out->attr, attr, sizeof(*attr));
-	kmscon_font_attr_normalize(&out->attr);
 
 	log_debug("loading pango font %s", out->attr.name);
 

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -228,13 +228,12 @@ static int kmscon_font_unifont_init(struct kmscon_font *out, const struct kmscon
 	out->attr.bold = attr->bold;
 	out->attr.italic = false;
 
-	scale = (attr->points + 8) / 16;
+	scale = (attr->height + 8) / 16;
 	if (!scale)
 		scale = 1;
 
 	out->attr.width = 8 * scale;
 	out->attr.height = 16 * scale;
-	kmscon_font_attr_normalize(&out->attr);
 	out->increase_step = 16;
 	out->data = uf;
 

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -178,7 +178,7 @@ static void print_help()
 		"Font Options:\n"
 		"\t    --font-engine <engine>  [pango]\n"
 		"\t                              Font rendering engine\n"
-		"\t    --font-size <pixels>    [12]\n"
+		"\t    --font-size <pixels>    [16]\n"
 		"\t                              Font size in pixels\n"
 		"\t    --font-name <name>      [monospace]\n"
 		"\t                              Font name\n"
@@ -820,7 +820,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 
 		/* Font Options */
 		CONF_OPTION_STRING(0, "font-engine", &conf->font_engine, "pango"),
-		CONF_OPTION_UINT(0, "font-size", &conf->font_size, 12),
+		CONF_OPTION_UINT(0, "font-size", &conf->font_size, 16),
 		CONF_OPTION_STRING(0, "font-name", &conf->font_name, "monospace"),
 
 		/* Palette Options */

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -178,12 +178,10 @@ static void print_help()
 		"Font Options:\n"
 		"\t    --font-engine <engine>  [pango]\n"
 		"\t                              Font rendering engine\n"
-		"\t    --font-size <points>    [12]\n"
-		"\t                              Font size in points (pt)\n"
+		"\t    --font-size <pixels>    [12]\n"
+		"\t                              Font size in pixels\n"
 		"\t    --font-name <name>      [monospace]\n"
 		"\t                              Font name\n"
-		"\t    --font-dpi <dpi>        [96]\n"
-		"\t                              Force DPI value for all fonts\n"
 		"\n"
 		"Palette Options:\n"
 		"\t    --palette <name>                [default]\n"
@@ -824,7 +822,6 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_STRING(0, "font-engine", &conf->font_engine, "pango"),
 		CONF_OPTION_UINT(0, "font-size", &conf->font_size, 12),
 		CONF_OPTION_STRING(0, "font-name", &conf->font_name, "monospace"),
-		CONF_OPTION_UINT(0, "font-dpi", &conf->font_ppi, 96),
 
 		/* Palette Options */
 		CONF_OPTION_STRING(0, "palette", &conf->palette, NULL),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -179,8 +179,6 @@ struct kmscon_conf_t {
 	unsigned int font_size;
 	/* font name */
 	char *font_name;
-	/* font ppi (overrides per monitor PPI) */
-	unsigned int font_ppi;
 
 	/* Palette Options */
 	/* color palette */

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -701,22 +701,22 @@ static void input_event(struct uterm_input *input, struct uterm_input_key_event 
 	}
 	if (conf_grab_matches(term->conf->grab_zoom_in, ev->mods, ev->num_syms, ev->keysyms)) {
 		ev->handled = true;
-		if (term->font_attr.points + term->font->increase_step < term->font_attr.points)
+		if (term->font_attr.height + term->font->increase_step < term->font_attr.height)
 			return;
 
-		term->font_attr.points += term->font->increase_step;
+		term->font_attr.height += term->font->increase_step;
 		if (font_set(term))
-			term->font_attr.points -= term->font->increase_step;
+			term->font_attr.height -= term->font->increase_step;
 		return;
 	}
 	if (conf_grab_matches(term->conf->grab_zoom_out, ev->mods, ev->num_syms, ev->keysyms)) {
 		ev->handled = true;
-		if (term->font_attr.points <= term->font->increase_step)
+		if (term->font_attr.height <= term->font->increase_step)
 			return;
 
-		term->font_attr.points -= term->font->increase_step;
+		term->font_attr.height -= term->font->increase_step;
 		if (font_set(term))
-			term->font_attr.points += term->font->increase_step;
+			term->font_attr.height += term->font->increase_step;
 		return;
 	}
 	if (conf_grab_matches(term->conf->grab_rotate_cw, ev->mods, ev->num_syms, ev->keysyms)) {
@@ -1083,8 +1083,7 @@ int kmscon_terminal_register(struct kmscon_session **out, struct kmscon_seat *se
 	term->conf = conf_ctx_get_mem(term->conf_ctx);
 
 	strncpy(term->font_attr.name, term->conf->font_name, KMSCON_FONT_MAX_NAME - 1);
-	term->font_attr.ppi = term->conf->font_ppi;
-	term->font_attr.points = term->conf->font_size;
+	term->font_attr.height = term->conf->font_size;
 
 	ret = tsm_screen_new(&term->console, log_llog, NULL);
 	if (ret)


### PR DESCRIPTION
It's only a multiplier for the font size, as kmscon doesn't read DPI from the monitor.