### PR TITLE
multi-monitor: Add an option to use only the largest monitor.

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -599,6 +599,19 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--multi-monitor {clone,largest}</option></term>
+        <listitem>
+          <para>When there are multiple monitors, this option controls how the monitors are
+          used.</para>
+          <para>`clone': All monitors will have the same size. The smallest monitor will be
+          used to determine the size.</para>
+          <para>`largest': The largest monitor will be used to determine the size. The other
+          monitors will be disabled. If multiple monitors have the largest size, they will all be used.</para>
+          <para>default: clone</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--rotate {orientation}</option></term>
         <listitem>
           <para>Select the desired orientation of the output. Available orientations

--- a/docs/man/kmscon.conf.5.xml.in
+++ b/docs/man/kmscon.conf.5.xml.in
@@ -75,6 +75,7 @@ dpms-timeout=0
 drm
 hwaccel
 gpus=all
+multi-monitor=clone
 rotate=normal
 
 ### Font Options ###
@@ -445,6 +446,19 @@ font-name=Ubuntu Mono
         <term><option>mode</option></term>
         <listitem>
           <para>Set the resolution to {width}x{height}</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>multi-monitor {clone,largest}</option></term>
+        <listitem>
+          <para>When there are multiple monitors, this option controls how the monitors are
+          used.</para>
+          <para>`clone': All monitors will have the same size. The smallest monitor will be
+          used to determine the size.</para>
+          <para>`largest': The largest monitor will be used to determine the size. The other
+          monitors will be disabled. If multiple monitors have the largest size, they will all be used.</para>
+          <para>default: clone</para>
         </listitem>
       </varlistentry>
 

--- a/scripts/etc/kmscon.conf.example
+++ b/scripts/etc/kmscon.conf.example
@@ -32,6 +32,9 @@
 ## Force a specific mode for all monitors, widthxheight
 #mode=1024x768
 
+## Multi monitor configuration [clone, largest], default is clone.
+#multi-monitor=clone
+
 ## Screen rotation, can be [normal, left, upside-down, right]
 #rotate=left
 

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -816,6 +816,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 			    (void *)KMSCON_GPU_ALL),
 		CONF_OPTION_BOOL(0, "use-original-mode", &conf->use_original_mode, true),
 		CONF_OPTION_STRING(0, "mode", &conf->mode, NULL),
+		CONF_OPTION_STRING(0, "multi-monitor", &conf->multi_monitor, "clone"),
 		CONF_OPTION_STRING(0, "rotate", &conf->rotate, "normal"),
 
 		/* Font Options */

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -169,6 +169,8 @@ struct kmscon_conf_t {
 	bool use_original_mode;
 	/* screen resolution */
 	char *mode;
+	/* multiple monitors */
+	char *multi_monitor;
 	/* orientation/rotation of output */
 	char *rotate;
 

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -61,6 +61,7 @@ struct screen {
 	bool swapping;
 	bool pending;
 	bool hw_cursor;
+	bool enabled;
 };
 
 struct kmscon_pointer {
@@ -249,6 +250,33 @@ static void refresh_hw_cursor(struct screen *scr)
 	setup_hw_cursor(scr);
 }
 
+static void disable_screen(struct screen *scr)
+{
+	int ret;
+
+	log_debug("Disabling screen %s", uterm_display_name(scr->disp));
+	if (scr->swapping)
+		scr->pending = true;
+	else {
+		log_info("Disabling screen %s", uterm_display_name(scr->disp));
+		scr->pending = false;
+		uterm_display_clear(scr->disp, 0, 0, 0);
+		ret = uterm_display_swap(scr->disp);
+		if (ret) {
+			if (ret != -EBUSY)
+				log_warning("cannot swap display [%s] %d",
+					    uterm_display_name(scr->disp), ret);
+			else {
+				log_debug("display [%s] is swapping",
+					  uterm_display_name(scr->disp));
+				scr->pending = true;
+			}
+		}
+		scr->swapping = true;
+	}
+	scr->enabled = false;
+}
+
 static void do_redraw_screen(struct screen *scr)
 {
 	struct tsm_screen_attr attr;
@@ -256,6 +284,13 @@ static void do_redraw_screen(struct screen *scr)
 
 	if (!scr->term->awake || !kmscon_session_get_foreground(scr->term->session))
 		return;
+
+	if (!scr->enabled) {
+		/* make sure to clear unused screen */
+		if (scr->pending)
+			disable_screen(scr);
+		return;
+	}
 
 	scr->pending = false;
 
@@ -278,7 +313,7 @@ static void do_redraw_screen(struct screen *scr)
 
 static void redraw_screen(struct screen *scr)
 {
-	if (!scr->term->awake)
+	if (!scr->term->awake || !scr->enabled)
 		return;
 
 	if (scr->swapping)
@@ -335,6 +370,8 @@ static void update_pointer_max_all(struct kmscon_terminal *term)
 	shl_dlist_for_each(iter, &term->screens)
 	{
 		scr = shl_dlist_entry(iter, struct screen, list);
+		if (!scr->enabled)
+			continue;
 
 		if (scr->txt->orientation == OR_NORMAL || scr->txt->orientation == OR_UPSIDE_DOWN) {
 			sw = uterm_display_get_width(scr->disp);
@@ -425,12 +462,10 @@ static void mouse_event(struct tsm_vte *vte, enum tsm_mouse_track_mode track_mod
 }
 
 /*
- * Resize terminal
- * We support multiple monitors per terminal. As some software-rendering
- * backends do not support scaling, we always use the smallest cols/rows that are
- * provided so wider displays will have black margins.
+ * We support multiple monitors per terminal. In clone mode, we use the smallest cols/rows that are
+ * provided so wider monitors will have black margins.
  */
-static bool terminal_update_size(struct kmscon_terminal *term)
+static bool terminal_update_size_clone(struct kmscon_terminal *term)
 {
 	struct shl_dlist *iter;
 	struct screen *scr;
@@ -458,10 +493,66 @@ static bool terminal_update_size(struct kmscon_terminal *term)
 	term->min_cols = min_cols;
 	term->min_rows = min_rows;
 
+	return true;
+}
+
+/*
+ * In largest mode, we use the largest cols/rows that are
+ * provided so smaller monitors will be disabled.
+ */
+static bool terminal_update_size_largest(struct kmscon_terminal *term)
+{
+	struct shl_dlist *iter;
+	struct screen *scr;
+	unsigned int rows, cols, cells;
+	unsigned int max_cells = 0;
+
 	shl_dlist_for_each(iter, &term->screens)
 	{
 		scr = shl_dlist_entry(iter, struct screen, list);
-		kmscon_text_resize(scr->txt, term->min_cols, term->min_rows);
+		rows = kmscon_text_get_rows(scr->txt);
+		cols = kmscon_text_get_cols(scr->txt);
+		cells = rows * cols;
+		if (cells > max_cells) {
+			max_cells = cells;
+			term->min_cols = cols;
+			term->min_rows = rows;
+		}
+	}
+	shl_dlist_for_each(iter, &term->screens)
+	{
+		scr = shl_dlist_entry(iter, struct screen, list);
+		rows = kmscon_text_get_rows(scr->txt);
+		cols = kmscon_text_get_cols(scr->txt);
+		if (rows != term->min_rows || cols != term->min_cols)
+			disable_screen(scr);
+		else if (!scr->enabled) {
+			log_info("Enabling screen %s", uterm_display_name(scr->disp));
+			scr->enabled = true;
+		}
+	}
+	return max_cells > 0;
+}
+
+static bool terminal_update_size(struct kmscon_terminal *term)
+{
+	struct shl_dlist *iter;
+	struct screen *scr;
+	bool ret;
+
+	if (term->conf->multi_monitor && !strcmp(term->conf->multi_monitor, "largest")) {
+		ret = terminal_update_size_largest(term);
+	} else {
+		ret = terminal_update_size_clone(term);
+	}
+	if (!ret)
+		return false;
+
+	shl_dlist_for_each(iter, &term->screens)
+	{
+		scr = shl_dlist_entry(iter, struct screen, list);
+		if (scr->enabled)
+			kmscon_text_resize(scr->txt, term->min_cols, term->min_rows);
 	}
 	return true;
 }
@@ -574,6 +665,7 @@ static int add_display(struct kmscon_terminal *term, struct uterm_display *disp)
 	memset(scr, 0, sizeof(*scr));
 	scr->term = term;
 	scr->disp = disp;
+	scr->enabled = true;
 
 	ret = uterm_display_register_cb(scr->disp, display_event, scr);
 	if (ret) {
@@ -614,6 +706,7 @@ static int add_display(struct kmscon_terminal *term, struct uterm_display *disp)
 	kmscon_text_resize(scr->txt, term->min_cols, term->min_rows);
 	update_pointer_max_all(term);
 	uterm_display_ref(scr->disp);
+	do_redraw_screen(scr);
 	return 0;
 
 err_text:


### PR DESCRIPTION
add a new multi-monitor option:
"clone" => use the smallest display for the terminal size, and clone on all monitors.
"largest" => Only use the largest monitor, if multiple monitor have the same largest resolution, it will clone on all of them.

Fix #325 