### PR TITLE
shl_lru: fix build error on i686

### DIFF
--- a/src/shl_lru.h
+++ b/src/shl_lru.h
@@ -126,7 +126,7 @@ static inline int shl_lru_evict(struct shl_lru *lru)
 			return 0;
 		}
 	}
-	log_warning("LRU evict failed key not found%ld", last->key);
+	log_warning("LRU evict failed key not found %" PRIu64, last->key);
 	return -ENOENT;
 }
 


### PR DESCRIPTION
Use PRIu64 for uint64_t, or it doesn't build on i686