### PR TITLE
cursor: Fix hardware cursor on VM

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -150,6 +150,7 @@ static uint32_t *generate_ibeam_cursor(unsigned int font_height, unsigned int *w
 	uint32_t *pixels;
 
 	h = font_height > 8 ? font_height : 8;
+	h = min(h, UTERM_CURSOR_MAX_SIZE);
 	w = 2 * (h / 6) + 3;
 
 	white = argb(255, 255, 255, 255);

--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -328,19 +328,15 @@ static void modeset_clear_cursor(drmModeAtomicReq *req, int fd)
 	drmModeFreePlaneResources(plane_res);
 }
 
-static int cursor_create_buffer(int fd, struct uterm_drm_cursor *cursor, uint32_t width,
-				uint32_t height)
+static int cursor_create_buffer(int fd, struct uterm_drm_cursor *cursor)
 {
 	uint32_t handles[4], pitches[4], offsets[4];
 	uint64_t mmap_offset;
 	int ret;
 
-	cursor->width = width;
-	cursor->height = height;
-
-	if (drmModeCreateDumbBuffer(fd, width, height, 32, 0, &cursor->bo_handle, &cursor->stride,
-				    &cursor->map_size)) {
-		log_err("cannot create cursor dumb buffer");
+	if (drmModeCreateDumbBuffer(fd, cursor->width, cursor->height, 32, 0, &cursor->bo_handle,
+				    &cursor->stride, &cursor->map_size)) {
+		log_err("cannot create cursor dumb buffer %dx%d", cursor->width, cursor->height);
 		return -EFAULT;
 	}
 
@@ -350,23 +346,23 @@ static int cursor_create_buffer(int fd, struct uterm_drm_cursor *cursor, uint32_
 	pitches[1] = pitches[2] = pitches[3] = 0;
 	offsets[0] = offsets[1] = offsets[2] = offsets[3] = 0;
 
-	ret = drmModeAddFB2(fd, width, height, DRM_FORMAT_ARGB8888, handles, pitches, offsets,
-			    &cursor->fb_id, 0);
+	ret = drmModeAddFB2(fd, cursor->width, cursor->height, DRM_FORMAT_ARGB8888, handles,
+			    pitches, offsets, &cursor->fb_id, 0);
 	if (ret) {
-		log_err("cannot create cursor framebuffer");
+		log_err("cannot create cursor framebuffer %d", ret);
 		goto err_buf;
 	}
 
 	ret = drmModeMapDumbBuffer(fd, cursor->bo_handle, &mmap_offset);
 	if (ret) {
-		log_err("cannot map cursor dumb buffer");
+		log_err("cannot map cursor dumb buffer %d", ret);
 		goto err_fb;
 	}
 
 	cursor->map =
 		mmap(0, cursor->map_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, mmap_offset);
 	if (cursor->map == MAP_FAILED) {
-		log_err("cannot mmap cursor dumb buffer");
+		log_err("cannot mmap cursor dumb buffer %d", ret);
 		cursor->map = NULL;
 		goto err_fb;
 	}
@@ -402,16 +398,14 @@ static void cursor_destroy_buffer(int fd, struct uterm_drm_cursor *cursor)
 }
 
 int uterm_drm_display_setup_cursor(struct uterm_display *disp, const uint32_t *pixels,
-				   unsigned int img_width, unsigned int img_height, int hot_x,
-				   int hot_y)
+				   unsigned int width, unsigned int height, int hot_x, int hot_y)
 {
 	struct uterm_drm_display *ddrm = disp->data;
 	struct uterm_drm_video *vdrm = disp->video->data;
 	struct uterm_drm_cursor *cursor = &ddrm->cursor;
-	uint64_t cap_w = 64, cap_h = 64;
+	uint64_t cap_w, cap_h;
 	uint32_t *dst;
-	unsigned int pitch, copy_w, copy_h, off_x, off_y;
-	unsigned int x, y;
+	unsigned int pitch, x, y, copy_w, copy_h;
 	int ret;
 
 	if (!pixels)
@@ -423,32 +417,31 @@ int uterm_drm_display_setup_cursor(struct uterm_display *disp, const uint32_t *p
 	if (cursor->active)
 		uterm_drm_display_destroy_cursor(disp);
 
-	drmGetCap(vdrm->fd, DRM_CAP_CURSOR_WIDTH, &cap_w);
-	drmGetCap(vdrm->fd, DRM_CAP_CURSOR_HEIGHT, &cap_h);
-	if (cap_w > 4096)
-		cap_w = 4096;
-	if (cap_h > 4096)
-		cap_h = 4096;
+	if (drmGetCap(vdrm->fd, DRM_CAP_CURSOR_WIDTH, &cap_w) < 0)
+		return -EOPNOTSUPP;
+	if (drmGetCap(vdrm->fd, DRM_CAP_CURSOR_HEIGHT, &cap_h) < 0)
+		return -EOPNOTSUPP;
 
-	ret = cursor_create_buffer(vdrm->fd, cursor, cap_w, cap_h);
+	cursor->width = min(cap_w, UTERM_CURSOR_MAX_SIZE);
+	cursor->height = min(cap_h, UTERM_CURSOR_MAX_SIZE);
+
+	ret = cursor_create_buffer(vdrm->fd, cursor);
 	if (ret)
 		return ret;
 
 	dst = (uint32_t *)cursor->map;
 	pitch = cursor->stride / 4;
-	copy_w = img_width < cap_w ? img_width : cap_w;
-	copy_h = img_height < cap_h ? img_height : cap_h;
-	off_x = (cap_w - copy_w) / 2;
-	off_y = (cap_h - copy_h) / 2;
+	copy_w = min(width, cursor->width);
+	copy_h = min(height, cursor->height);
 
 	for (y = 0; y < copy_h; y++) {
 		for (x = 0; x < copy_w; x++) {
-			dst[(off_y + y) * pitch + (off_x + x)] = pixels[y * img_width + x];
+			dst[y * pitch + x] = pixels[y * width + x];
 		}
 	}
 
-	cursor->hot_x = hot_x + off_x;
-	cursor->hot_y = hot_y + off_y;
+	cursor->hot_x = hot_x;
+	cursor->hot_y = hot_y;
 	cursor->off_x = 0;
 	cursor->off_y = 0;
 	cursor->active = true;
@@ -635,9 +628,11 @@ int uterm_drm_prepare_commit(int fd, struct uterm_drm_display *ddrm, drmModeAtom
 
 		if (cursor->active && cursor->visible) {
 			if (cursor_hotspot) {
-				if (set_drm_object_property(req, cp, "HOTSPOT_X", cursor->x) < 0)
+				if (set_drm_object_property(req, cp, "HOTSPOT_X", cursor->hot_x) <
+				    0)
 					return -1;
-				if (set_drm_object_property(req, cp, "HOTSPOT_Y", cursor->y) < 0)
+				if (set_drm_object_property(req, cp, "HOTSPOT_Y", cursor->hot_y) <
+				    0)
 					return -1;
 			}
 			if (set_drm_object_property(req, cp, "FB_ID", cursor->fb_id) < 0)

--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -381,12 +381,6 @@ err_buf:
 
 static void cursor_destroy_buffer(int fd, struct uterm_drm_cursor *cursor)
 {
-	if (!cursor->map)
-		return;
-
-	munmap(cursor->map, cursor->map_size);
-	cursor->map = NULL;
-
 	if (cursor->fb_id) {
 		drmModeRmFB(fd, cursor->fb_id);
 		cursor->fb_id = 0;
@@ -439,6 +433,9 @@ int uterm_drm_display_setup_cursor(struct uterm_display *disp, const uint32_t *p
 			dst[y * pitch + x] = pixels[y * width + x];
 		}
 	}
+	munmap(cursor->map, cursor->map_size);
+	cursor->map = NULL;
+	cursor->map_size = 0;
 
 	cursor->hot_x = hot_x;
 	cursor->hot_y = hot_y;

--- a/src/uterm_drm_shared_internal.h
+++ b/src/uterm_drm_shared_internal.h
@@ -92,8 +92,7 @@ struct uterm_drm_display {
 int uterm_drm_display_set_dpms(struct uterm_display *disp, int state);
 
 int uterm_drm_display_setup_cursor(struct uterm_display *disp, const uint32_t *pixels,
-				   unsigned int img_width, unsigned int img_height, int hot_x,
-				   int hot_y);
+				   unsigned int width, unsigned int height, int hot_x, int hot_y);
 void uterm_drm_display_destroy_cursor(struct uterm_display *disp);
 int uterm_drm_display_show_cursor(struct uterm_display *disp, int32_t x, int32_t y);
 int uterm_drm_display_hide_cursor(struct uterm_display *disp);

--- a/src/uterm_video.c
+++ b/src/uterm_video.c
@@ -341,14 +341,13 @@ bool uterm_display_need_redraw(struct uterm_display *disp)
 
 SHL_EXPORT
 int uterm_display_setup_cursor(struct uterm_display *disp, const uint32_t *pixels,
-			       unsigned int img_width, unsigned int img_height, int hot_x,
-			       int hot_y)
+			       unsigned int width, unsigned int height, int hot_x, int hot_y)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
 		return -EINVAL;
 
-	return VIDEO_CALL(disp->ops->setup_cursor, -EOPNOTSUPP, disp, pixels, img_width, img_height,
-			  hot_x, hot_y);
+	return VIDEO_CALL(disp->ops->setup_cursor, -EOPNOTSUPP, disp, pixels, width, height, hot_x,
+			  hot_y);
 }
 
 SHL_EXPORT

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -162,13 +162,15 @@ bool uterm_display_need_redraw(struct uterm_display *disp);
 
 int uterm_display_clear(struct uterm_display *disp, uint8_t r, uint8_t g, uint8_t b);
 
+/* cursor interface */
+#define UTERM_CURSOR_MAX_SIZE 64
 int uterm_display_setup_cursor(struct uterm_display *disp, const uint32_t *pixels,
-			       unsigned int img_width, unsigned int img_height, int hot_x,
-			       int hot_y);
+			       unsigned int width, unsigned int height, int hot_x, int hot_y);
 void uterm_display_destroy_cursor(struct uterm_display *disp);
 int uterm_display_show_cursor(struct uterm_display *disp, int32_t x, int32_t y);
 int uterm_display_hide_cursor(struct uterm_display *disp);
 void uterm_display_set_cursor_offset(struct uterm_display *disp, int32_t x, int32_t y);
+
 int uterm_display_fake_blendv(struct uterm_display *disp, const struct uterm_video_blend_req *req,
 			      size_t num);
 void uterm_display_set_damage(struct uterm_display *disp, size_t n_rect,

--- a/src/uterm_video_internal.h
+++ b/src/uterm_video_internal.h
@@ -52,8 +52,8 @@ struct display_ops {
 	void (*set_damage)(struct uterm_display *disp, size_t n_rect,
 			   struct uterm_video_rect *damages);
 	bool (*has_damage)(struct uterm_display *disp);
-	int (*setup_cursor)(struct uterm_display *disp, const uint32_t *pixels,
-			    unsigned int img_width, unsigned int img_height, int hot_x, int hot_y);
+	int (*setup_cursor)(struct uterm_display *disp, const uint32_t *pixels, unsigned int width,
+			    unsigned int height, int hot_x, int hot_y);
 	void (*destroy_cursor)(struct uterm_display *disp);
 	int (*show_cursor)(struct uterm_display *disp, int32_t x, int32_t y);
 	int (*hide_cursor)(struct uterm_display *disp);


### PR DESCRIPTION
HOTSPOT_X and HOTSPOT_Y were set to the pointer coordinate, but it should be an offset between the top left corner, and the pixel where the pointer select things.
Also limit the cursor size to 64, to avoid having it truncated, if the hardware doesn't support bigger size.

Fix #365 