### PR TITLE
dpms: Set default timeout to 10min

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -379,12 +379,13 @@
       <varlistentry>
         <term><option>--dpms-timeout</option></term>
         <listitem>
-          <para>Set screen timeout in seconds (default: 0 = disabled).
+          <para>Set screen timeout in seconds (default: 600 = 10 minutes).
                 When enabled, the screen will automatically turn off (DPMS OFF)
                 after the specified period of keyboard and mouse inactivity.
                 Any keyboard or mouse input will turn the screen back on and
                 reset the timer. This feature is useful for power saving on
                 systems where the screen is not always needed.
+                Set to 0 to disable.
           </para>
         </listitem>
       </varlistentry>

--- a/docs/man/kmscon.conf.5.xml.in
+++ b/docs/man/kmscon.conf.5.xml.in
@@ -69,7 +69,7 @@ xkb-layout=de
 xkb-repeat-delay=200
 xkb-repeat-rate=65
 mouse
-dpms-timeout=0
+dpms-timeout=600
 
 ### Video Options ###
 drm
@@ -298,12 +298,13 @@ font-name=Ubuntu Mono
       <varlistentry>
         <term><option>dpms-timeout</option></term>
         <listitem>
-          <para>Set screen timeout in seconds (default: 0 = disabled).
+          <para>Set screen timeout in seconds (default: 600 = 10 minutes).
                 When enabled, the screen will automatically turn off (DPMS OFF)
                 after the specified period of keyboard and mouse inactivity.
                 Any keyboard or mouse input will turn the screen back on and
                 reset the timer. This feature is useful for power saving on
                 systems where the screen is not always needed.
+                Set to 0 to disable.
           </para>
         </listitem>
       </varlistentry>

--- a/scripts/etc/kmscon.conf.example
+++ b/scripts/etc/kmscon.conf.example
@@ -85,7 +85,7 @@
 ## Screen timeout in seconds (0 = disabled)
 ## The screen will be turned off (DPMS OFF) after this period of inactivity
 ## Any keyboard or mouse input will turn the screen back on
-#dpms-timeout=0
+#dpms-timeout=600
 
 ## Terminal options
 ## value of the $TERM variable

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -128,7 +128,7 @@ static void print_help()
 		"\t                                 Enable mouse support\n"
 		"\t    --soft-cursor              [off]\n"
 		"\t                                 Force software cursor\n"
-		"\t    --dpms-timeout <secs>      [0]\n"
+		"\t    --dpms-timeout <secs>      [600]\n"
 		"\t                                 Screen timeout in seconds (0=off)\n"
 		"\n"
 		"Grabs / Keyboard-Shortcuts:\n"
@@ -784,7 +784,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_UINT(0, "xkb-repeat-rate", &conf->xkb_repeat_rate, 50),
 		CONF_OPTION_BOOL(0, "mouse", &conf->mouse, true),
 		CONF_OPTION_BOOL(0, "soft-cursor", &conf->soft_cursor, false),
-		CONF_OPTION_UINT(0, "dpms-timeout", &conf->dpms_timeout, 0),
+		CONF_OPTION_UINT(0, "dpms-timeout", &conf->dpms_timeout, 600),
 
 		/* Grabs / Keyboard-Shortcuts */
 		CONF_OPTION_GRAB(0, "grab-scroll-up", &conf->grab_scroll_up, &def_grab_scroll_up),


### PR DESCRIPTION
By default, dpms is disabled.
Set it to 10 min, to save power.

Suggested-by: Wren Turkal <wt@penguintechs.org>