### PR TITLE
drm: clear cursor plane before dropping master

### DIFF
--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -1555,6 +1555,25 @@ int uterm_drm_video_wake_up(struct uterm_video *video)
 void uterm_drm_video_sleep(struct uterm_video *video)
 {
 	struct uterm_drm_video *vdrm = video->data;
+	struct shl_dlist *iter;
+	struct uterm_display *disp;
+	drmModeAtomicReq *req;
+
+	if (vdrm->master && !vdrm->legacy) {
+		shl_dlist_for_each(iter, &video->displays)
+		{
+			disp = shl_dlist_entry(iter, struct uterm_display, list);
+			uterm_drm_display_wait_pflip(disp);
+		}
+
+		req = drmModeAtomicAlloc();
+		if (req) {
+			modeset_clear_cursor(req, vdrm->fd);
+			if (drmModeAtomicCommit(vdrm->fd, req, 0, NULL) < 0)
+				log_warn("cannot hide hardware cursor before VT switch");
+			drmModeAtomicFree(req);
+		}
+	}
 
 	drop_drm_master(vdrm);
 	ev_timer_drain(vdrm->vt_timer, NULL);


### PR DESCRIPTION
Commit 6133da467eeb ("terminal: use DRM hardware cursor plane for the mouse pointer") moved the I-beam pointer onto a DRM cursor plane.

When kmscon is put to sleep during a VT handoff, it drops DRM master without first committing the hidden cursor state. That can leave the old I-beam cursor plane visible after booting a display manager or desktop environment.

Before dropping DRM master, wait for any pending page flips and submit a final atomic commit that clears all cursor planes.