### PR TITLE
input: Add natural scrolling option to configuration

### DIFF
--- a/docs/man/kmscon.conf.5.xml.in
+++ b/docs/man/kmscon.conf.5.xml.in
@@ -287,6 +287,16 @@ font-name=Ubuntu Mono
       </varlistentry>
 
       <varlistentry>
+        <term><option>natural-scrolling</option></term>
+        <listitem>
+          <para>Invert the mouse wheel direction (natural scrolling).
+                When enabled, scrolling up with the wheel scrolls down and vice versa.
+                (default: off)
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>soft-cursor</option></term>
         <listitem>
           <para>Force software cursor, if hardware cursor is not working properly.

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -126,6 +126,8 @@ static void print_help()
 		"\t                                 Delay between two key repeats in ms\n"
 		"\t    --mouse                    [on]\n"
 		"\t                                 Enable mouse support\n"
+		"\t    --natural-scrolling        [off]\n"
+		"\t                                 Invert mouse wheel direction\n"
 		"\t    --soft-cursor              [off]\n"
 		"\t                                 Force software cursor\n"
 		"\t    --dpms-timeout <secs>      [600]\n"
@@ -783,6 +785,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_UINT(0, "xkb-repeat-delay", &conf->xkb_repeat_delay, 250),
 		CONF_OPTION_UINT(0, "xkb-repeat-rate", &conf->xkb_repeat_rate, 50),
 		CONF_OPTION_BOOL(0, "mouse", &conf->mouse, true),
+		CONF_OPTION_BOOL(0, "natural-scrolling", &conf->natural_scrolling, false),
 		CONF_OPTION_BOOL(0, "soft-cursor", &conf->soft_cursor, false),
 		CONF_OPTION_UINT(0, "dpms-timeout", &conf->dpms_timeout, 600),
 

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -123,6 +123,8 @@ struct kmscon_conf_t {
 	unsigned int xkb_repeat_rate;
 	/* Enable mouse support */
 	bool mouse;
+	/* Natural scrolling (invert mouse wheel direction) */
+	bool natural_scrolling;
 	/* Force software cursor */
 	bool soft_cursor;
 	/* DPMS screen timeout in seconds (0 = disabled) */

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -871,8 +871,12 @@ static void forward_pointer_event(struct kmscon_terminal *term,
 {
 	unsigned int event;
 	unsigned int button;
+	int32_t wheel;
 
 	button = ev->button;
+	wheel = ev->wheel;
+	if (term->conf->natural_scrolling)
+		wheel = -wheel;
 
 	switch (ev->event) {
 	case UTERM_MOVED:
@@ -891,7 +895,7 @@ static void forward_pointer_event(struct kmscon_terminal *term,
 	case UTERM_WHEEL:
 		/* Convert wheel events to button 4 (scroll up) or 5 (scroll down) */
 		event = TSM_MOUSE_EVENT_PRESSED;
-		if (ev->wheel > 0)
+		if (wheel > 0)
 			button = 4; /* Scroll up */
 		else
 			button = 5; /* Scroll down */
@@ -1019,7 +1023,7 @@ static void pointer_event(struct uterm_input *input, struct uterm_input_pointer_
 		break;
 	case UTERM_WHEEL:
 		tsm_screen_selection_reset(term->console);
-		if (ev->wheel > 0)
+		if ((term->conf->natural_scrolling ? -ev->wheel : ev->wheel) > 0)
 			tsm_screen_sb_up(term->console, 3);
 		else
 			tsm_screen_sb_down(term->console, 3);

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -1023,7 +1023,7 @@ static void pointer_event(struct uterm_input *input, struct uterm_input_pointer_
 		break;
 	case UTERM_WHEEL:
 		tsm_screen_selection_reset(term->console);
-		if ((term->conf->natural_scrolling ? -ev->wheel : ev->wheel) > 0)
+		if (term->conf->natural_scrolling != (ev->wheel > 0))
 			tsm_screen_sb_up(term->console, 3);
 		else
 			tsm_screen_sb_down(term->console, 3);


### PR DESCRIPTION
This commit introduces a new configuration option for natural scrolling, allowing users to invert the mouse wheel direction. The option is added to the configuration file, help output, and the relevant structures to handle its state.

Closes #382 