### PR TITLE
launch-gui: add a small delay before running the command.

### DIFF
--- a/scripts/kmscon-launch-gui.sh
+++ b/scripts/kmscon-launch-gui.sh
@@ -17,6 +17,9 @@ tmux) printf '\033Ptmux;\033\033]setBackground\a\033\\' ;;
 *) printf '\033]setBackground\a' ;;
 esac
 
+# Give time for kmscon to release drm master. Handle old version of sleep
+sleep 0.2 || sleep 1
+
 "$@"
 
 # If the current tty has changed, wait until the user switches back.


### PR DESCRIPTION
When testing with kmscube, often kmscube will crash because it can't take drm master. Give time to kmscon to release drm master before running the command.
Handle the older version of sleep that doesn't support fraction of seconds.