### PR TITLE
Libseat vt

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -27,7 +27,7 @@ jobs:
         echo github.event_name: ${{ github.event_name }}
 
     - name: Install dependencies on Ubuntu
-      run: sudo apt-get update && sudo apt-get install -y meson check libudev-dev libxkbcommon-dev libdrm-dev libgbm-dev libegl1-mesa-dev libgles-dev libpango1.0-dev libsystemd-dev jq
+      run: sudo apt-get update && sudo apt-get install -y meson check libudev-dev libxkbcommon-dev libdrm-dev libgbm-dev libegl1-mesa-dev libgles-dev libpango1.0-dev libsystemd-dev jq libseat-dev
 
     - name: Compile and install libtsm
       env:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ For font handling the following is required:
 - freetype: lightweight font rendering, using only freetype2 and fontconfig.
 - pango: drawing text with pango Pango requires: glib, pango, fontconfig, freetype2 and more
 
+Seat:
+- libseat: Kmscon can take a seat with [libseat](https://sr.ht/~kennylevinsen/seatd/). In this case you must have either systemd-logind, elogind, or seatd configured. It allows to run kmscon as a regular user, and configure which GPU/input device are allowed for kmscon. The drawback is that kmscon-launch-gui won't work to launch another GUI that uses libseat, as the seat is already in use.
+
 For multi-seat support you need the following packages:
-- systemd: Actually only the systemd-logind daemon and library is required.
+- systemd or elogind
 
 On Debian-based system, to install the systemd service files in the right location, you need to install systemd-dev.
 ```bash
@@ -68,6 +71,7 @@ explicitly enable it via command line:
 |:------|:-------:|:-----------|
 |`extra_debug`| `false` | Additional debug outputs |
 |`multi_seat`| `auto` | This requires the systemd-logind library to provide multi-seat support for kmscon |
+|`libseat`| `auto` | Use libseat to get access to device (DRM and inputs) |
 |`video_fbdev`| `auto` | Linux fbdev video backend |
 |`video_drm2d`| `auto` | Linux DRM software-rendering backend |
 |`video_drm3d`| `auto` | Linux DRM hardware-rendering backend |

--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -168,6 +168,16 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--libseat</option></term>
+        <listitem>
+          <para>Use libseat for seat management, input and video devices.
+                This option is only available if KMSCON was compiled with
+                libseat support. Use --no-libseat to disable it.
+                (default: on)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--seats {list,of,seats}</option></term>
         <listitem>
           <para>List of seats KMSCON will run on. Use `all' to make KMSCON run

--- a/docs/man/kmscon.conf.5.xml.in
+++ b/docs/man/kmscon.conf.5.xml.in
@@ -148,6 +148,13 @@ font-name=Ubuntu Mono
       </varlistentry>
 
       <varlistentry>
+        <term><option>libseat</option></term>
+        <listitem>
+          <para>Use libseat for seat management. (default: on)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>seats</option></term>
         <listitem>
           <para>Select seats to run on. (default: current)</para>

--- a/meson.build
+++ b/meson.build
@@ -195,6 +195,11 @@ endif
 dirs_info = configuration_data()
 dirs_info.set('libexecdir', prefix / libexecdir)
 dirs_info.set('bindir', prefix / bindir)
+if enable_libseat
+  dirs_info.set('PAM_CFG', 'User=root\nPAMName=kmscon')
+else
+  dirs_info.set('PAM_CFG', '')
+endif
 foreach filename, kwargs : {
   'scripts/kmscon.in': {
     'install_dir': bindir,
@@ -203,6 +208,14 @@ foreach filename, kwargs : {
   'scripts/kmscon-launch-gui.sh': {
     'install_dir': bindir,
     'install_mode': 'rwxr-xr-x',
+  },
+  'scripts/systemd/kmscon.service.in': {
+    'install_dir': systemdsystemunitdir,
+    'install_mode': 'rw-r--r--',
+  },
+  'scripts/systemd/kmsconvt@.service.in': {
+    'install_dir': systemdsystemunitdir,
+    'install_mode': 'rw-r--r--',
   },
 }
   install_data(configure_file(input: filename, output: '@BASENAME@', configuration: dirs_info),
@@ -215,11 +228,10 @@ install_data(
   'scripts/etc/kmscon.conf.example',
   install_dir: join_paths(get_option('sysconfdir'), 'kmscon')
 )
-install_data(
-  'scripts/systemd/kmscon.service',
-  install_dir: systemdsystemunitdir,
-)
-install_data(
-  'scripts/systemd/kmsconvt@.service',
-  install_dir: systemdsystemunitdir,
-)
+if enable_libseat
+  install_data(
+    'scripts/pam/kmscon',
+    install_dir: get_option('sysconfdir') / 'pam.d',
+    rename: 'kmscon',
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -72,6 +72,7 @@ else
 	multi_seat_dep = 'libsystemd'
 endif
 libsystemd_deps = dependency(multi_seat_dep, disabler: true, required: get_option('multi_seat'))
+libseat_deps = dependency('libseat', disabler: true, required: get_option('libseat'))
 libdrm_deps = dependency('libdrm', disabler: true, required: require_libdrm)
 gbm_deps = dependency('gbm', disabler: true, required: get_option('video_drm3d'))
 egl_deps = dependency('egl', disabler: true, required: get_option('video_drm3d'))
@@ -98,6 +99,7 @@ config = configuration_data()
 # Note: keep this in sync with the dependencies above
 foreach name, reqs : {
   'multi_seat': [libsystemd_deps],
+  'libseat': [libseat_deps],
   'video_fbdev': [],
   'video_drm2d': [libdrm_deps],
   'video_drm3d': [libdrm_deps, gbm_deps, egl_deps, glesv2_deps],

--- a/meson.options
+++ b/meson.options
@@ -10,6 +10,8 @@ option('multi_seat', type: 'feature', value: 'auto',
   description: 'Multi-seat support with systemd or elogind')
 option('elogind', type: 'feature', value: 'disabled',
   description: 'Prefer elogind over systemd')
+option('libseat', type: 'feature', value: 'auto',
+  description: 'Use libseat to integrate with systemd-logind, elogind, or seatd')
 
 # video backends
 option('video_fbdev', type: 'feature', value: 'auto',

--- a/scripts/etc/kmscon.conf.example
+++ b/scripts/etc/kmscon.conf.example
@@ -11,6 +11,7 @@
 ### Seat options (Usually setup in command line)
 #vt=1
 #switchvt
+#libseat
 
 ### Session Options
 #session-max=6

--- a/scripts/pam/kmscon
+++ b/scripts/pam/kmscon
@@ -1,0 +1,7 @@
+#%PAM-1.0
+
+auth     required   pam_permit.so
+account  required   pam_unix.so
+session  required   pam_env.so
+session  required   pam_unix.so
+-session  optional   pam_systemd.so type=tty class=greeter

--- a/scripts/systemd/kmscon.service.in
+++ b/scripts/systemd/kmscon.service.in
@@ -6,6 +6,7 @@ After=systemd-user-sessions.service
 After=rc-local.service
 
 [Service]
+@PAM_CFG@
 ExecStart=kmscon
 
 [Install]

--- a/scripts/systemd/kmsconvt@.service.in
+++ b/scripts/systemd/kmsconvt@.service.in
@@ -38,6 +38,7 @@ IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
 
 [Service]
+@PAM_CFG@
 ExecStart=kmscon --vt=%I --seats=seat0 --no-switchvt
 UtmpIdentifier=%I
 TTYPath=/dev/%I

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -76,6 +76,8 @@ static void print_help()
 		"\t    --vt <vt>               [auto]  Select which VT to run on\n"
 		"\t    --switchvt              [on]    Automatically switch to VT\n"
 		"\t    --seats <list,of,seats> [current] Select seats to run on\n"
+		"\t    --libseat               [on]    Use libseat for seat management,\n"
+		"\t                                    input and video devices\n"
 		"\n"
 		"Session Options:\n"
 		"\t    --session-max <max>         [50]  Maximum number of sessions\n"
@@ -758,6 +760,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION(0, 0, "vt", &conf_vt, aftercheck_vt, NULL, NULL, &conf->vt, NULL),
 		CONF_OPTION_BOOL(0, "switchvt", &conf->switchvt, true),
 		CONF_OPTION_STRING_LIST(0, "seats", &conf->seats, def_seats),
+		CONF_OPTION_BOOL(0, "libseat", &conf->libseat, true),
 
 		/* Session Options */
 		CONF_OPTION_UINT(0, "session-max", &conf->session_max, 50),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -75,6 +75,8 @@ struct kmscon_conf_t {
 	bool switchvt;
 	/* seats */
 	char **seats;
+	/* use libseat */
+	bool libseat;
 
 	/* Session Options */
 	/* sessions */

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -930,8 +930,8 @@ int kmscon_seat_new(struct kmscon_seat **out, struct conf_ctx *main_conf, struct
 		}
 	}
 
-	ret = uterm_vt_allocate(seat->vtm, &seat->vt, listen, seat->conf->libseat, seat->name,
-				seat->input, seat->conf->vt, seat_vt_event, seat);
+	ret = uterm_vt_allocate(seat->vtm, &seat->vt, listen, seat->conf->libseat, seat->input,
+				seat->conf->vt, seat_vt_event, seat);
 	if (ret)
 		goto err_input_cb;
 

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -930,8 +930,8 @@ int kmscon_seat_new(struct kmscon_seat **out, struct conf_ctx *main_conf, struct
 		}
 	}
 
-	ret = uterm_vt_allocate(seat->vtm, &seat->vt, listen, seat->name, seat->input,
-				seat->conf->vt, seat_vt_event, seat);
+	ret = uterm_vt_allocate(seat->vtm, &seat->vt, listen, seat->conf->libseat, seat->name,
+				seat->input, seat->conf->vt, seat_vt_event, seat);
 	if (ret)
 		goto err_input_cb;
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,6 +55,11 @@ uterm_dep = [
   video_deps,
 ]
 
+if enable_libseat
+  uterm_srcs += 'uterm_vt_libseat.c'
+  uterm_dep += libseat_deps
+endif
+
 if enable_multi_seat
   uterm_srcs += 'uterm_systemd.c'
   uterm_dep += libsystemd_deps

--- a/src/uterm_vt.c
+++ b/src/uterm_vt.c
@@ -99,7 +99,7 @@ int vt_call_deactivate(struct uterm_vt *vt, bool force)
 }
 
 SHL_EXPORT
-int uterm_vt_allocate(struct uterm_vt_master *vtm, struct uterm_vt **out, bool listen,
+int uterm_vt_allocate(struct uterm_vt_master *vtm, struct uterm_vt **out, bool listen, bool libseat,
 		      const char *seat, struct uterm_input *input, const char *vt_name,
 		      uterm_vt_cb cb, void *data)
 {
@@ -110,7 +110,8 @@ int uterm_vt_allocate(struct uterm_vt_master *vtm, struct uterm_vt **out, bool l
 	if (!seat)
 		seat = "seat0";
 
-	vt = uterm_vt_libseat_new(vtm, input, vt_name, cb, data);
+	if (libseat)
+		vt = uterm_vt_libseat_new(vtm, input, vt_name, cb, data);
 
 	if (!vt && !listen)
 		vt = uterm_vt_real_new(vtm, input, vt_name, cb, data);

--- a/src/uterm_vt.c
+++ b/src/uterm_vt.c
@@ -110,7 +110,9 @@ int uterm_vt_allocate(struct uterm_vt_master *vtm, struct uterm_vt **out, bool l
 	if (!seat)
 		seat = "seat0";
 
-	if (!listen)
+	vt = uterm_vt_libseat_new(vtm, input, vt_name, cb, data);
+
+	if (!vt && !listen)
 		vt = uterm_vt_real_new(vtm, input, vt_name, cb, data);
 
 	if (!vt)

--- a/src/uterm_vt.c
+++ b/src/uterm_vt.c
@@ -100,15 +100,12 @@ int vt_call_deactivate(struct uterm_vt *vt, bool force)
 
 SHL_EXPORT
 int uterm_vt_allocate(struct uterm_vt_master *vtm, struct uterm_vt **out, bool listen, bool libseat,
-		      const char *seat, struct uterm_input *input, const char *vt_name,
-		      uterm_vt_cb cb, void *data)
+		      struct uterm_input *input, const char *vt_name, uterm_vt_cb cb, void *data)
 {
 	struct uterm_vt *vt = NULL;
 
 	if (!vtm || !out)
 		return -EINVAL;
-	if (!seat)
-		seat = "seat0";
 
 	if (libseat)
 		vt = uterm_vt_libseat_new(vtm, input, vt_name, cb, data);

--- a/src/uterm_vt.h
+++ b/src/uterm_vt.h
@@ -65,8 +65,7 @@ void uterm_vt_master_unref(struct uterm_vt_master *vtm);
 int uterm_vt_master_deactivate_all(struct uterm_vt_master *vtm);
 
 int uterm_vt_allocate(struct uterm_vt_master *vt, struct uterm_vt **out, bool listen, bool libseat,
-		      const char *seat, struct uterm_input *input, const char *vt_name,
-		      uterm_vt_cb cb, void *data);
+		      struct uterm_input *input, const char *vt_name, uterm_vt_cb cb, void *data);
 void uterm_vt_deallocate(struct uterm_vt *vt);
 
 int uterm_vt_open_device(struct uterm_vt *vt, const char *device, int *fd_id);

--- a/src/uterm_vt.h
+++ b/src/uterm_vt.h
@@ -64,7 +64,7 @@ void uterm_vt_master_unref(struct uterm_vt_master *vtm);
 
 int uterm_vt_master_deactivate_all(struct uterm_vt_master *vtm);
 
-int uterm_vt_allocate(struct uterm_vt_master *vt, struct uterm_vt **out, bool listen,
+int uterm_vt_allocate(struct uterm_vt_master *vt, struct uterm_vt **out, bool listen, bool libseat,
 		      const char *seat, struct uterm_input *input, const char *vt_name,
 		      uterm_vt_cb cb, void *data);
 void uterm_vt_deallocate(struct uterm_vt *vt);

--- a/src/uterm_vt_internal.h
+++ b/src/uterm_vt_internal.h
@@ -46,5 +46,16 @@ struct uterm_vt *uterm_vt_real_new(struct uterm_vt_master *vtm, struct uterm_inp
 				   const char *vt_name, uterm_vt_cb cb, void *data);
 struct uterm_vt *uterm_vt_fake_new(struct uterm_vt_master *vtm, struct uterm_input *input,
 				   uterm_vt_cb cb, void *data);
+#ifdef BUILD_ENABLE_LIBSEAT
+struct uterm_vt *uterm_vt_libseat_new(struct uterm_vt_master *vtm, struct uterm_input *input,
+				      const char *vt_name, uterm_vt_cb cb, void *data);
+#else
+static inline struct uterm_vt *uterm_vt_libseat_new(struct uterm_vt_master *vtm,
+						    struct uterm_input *input, const char *vt_name,
+						    uterm_vt_cb cb, void *data)
+{
+	return NULL;
+}
+#endif /* BUILD_ENABLE_LIBSEAT */
 
 #endif /* UTERM_VT_INTERNAL_H */

--- a/src/uterm_vt_libseat.c
+++ b/src/uterm_vt_libseat.c
@@ -1,0 +1,388 @@
+/*
+ * uterm - Linux User-Space Terminal
+ *
+ * Copyright (c) 2026 Red Hat.
+ * Author: Jocelyn Falempe <jfalempe@redhat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <fcntl.h>
+#include <libseat.h>
+#include <linux/kd.h>
+#include <linux/major.h>
+#include <linux/vt.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include "shl/eloop.h"
+#include "shl/log.h"
+#include "shl/misc.h"
+#include "uterm_vt.h"
+#include "uterm_vt_internal.h"
+
+#define LOG_SUBSYSTEM "libseat"
+
+struct uterm_vt_libseat {
+	struct uterm_vt base;
+
+	struct libseat *libseat;
+	struct ev_fd *libseat_efd;
+	int tty_fd;
+	int tty_num;
+	int saved_kbmode;
+};
+
+static struct uterm_vt_libseat *to_libseat(struct uterm_vt *vt)
+{
+	return shl_offsetof(vt, struct uterm_vt_libseat, base);
+}
+
+/*
+ * Open the TTY for our VT. Called once after seat_wait_for_vt determines
+ * which VT seatd assigned to us. The fd is kept for the lifetime of the
+ * seat and used by activate/deactivate to toggle KD_GRAPHICS and K_OFF.
+ */
+static int open_tty(struct uterm_vt_libseat *vt, const char *vt_path)
+{
+	int fd, ret;
+	struct stat st;
+
+	fd = open(vt_path, O_RDWR | O_NOCTTY | O_CLOEXEC);
+	if (fd < 0) {
+		log_warning("cannot open VT %s: %m", vt_path);
+		return -errno;
+	}
+
+	vt->tty_fd = fd;
+
+	ret = fstat(fd, &st);
+	if (ret) {
+		log_error("cannot introspect tty %s (%d): %m", vt_path, errno);
+		close(fd);
+		return -errno;
+	}
+	vt->tty_num = minor(st.st_rdev);
+
+	ret = ioctl(fd, KDGKBMODE, &vt->saved_kbmode);
+	if (ret)
+		vt->saved_kbmode = K_UNICODE;
+	if (vt->saved_kbmode == K_OFF)
+		vt->saved_kbmode = K_UNICODE;
+
+	return 0;
+}
+
+static void close_tty(struct uterm_vt_libseat *vt)
+{
+	if (vt->tty_fd <= 0)
+		return;
+
+	ioctl(vt->tty_fd, KDSKBMODE, vt->saved_kbmode);
+	ioctl(vt->tty_fd, KDSETMODE, KD_TEXT);
+	close(vt->tty_fd);
+	vt->tty_fd = -1;
+}
+/*
+ * Set KD_GRAPHICS and K_OFF on our VT. Called when our session is enabled.
+ *
+ * Some libseat backends (elogind/logind) do not set K_OFF, so we
+ * always do it ourselves. It's harmless if seatd already set it.
+ */
+static void tty_activate(struct uterm_vt_libseat *vt)
+{
+	if (vt->tty_fd < 0)
+		return;
+
+	log_debug("activating VT %d", vt->tty_num);
+	ioctl(vt->tty_fd, KDSETMODE, KD_GRAPHICS);
+	ioctl(vt->tty_fd, KDSKBMODE, K_OFF);
+}
+
+/*
+ * Restore VT to text mode. Called when our session is disabled.
+ */
+static void tty_deactivate(struct uterm_vt_libseat *vt)
+{
+	if (vt->tty_fd < 0)
+		return;
+
+	log_debug("deactivating VT %d", vt->tty_num);
+	ioctl(vt->tty_fd, KDSKBMODE, vt->saved_kbmode);
+	ioctl(vt->tty_fd, KDSETMODE, KD_TEXT);
+}
+
+static void vt_libseat_enable(struct libseat *libseat, void *data)
+{
+	struct uterm_vt_libseat *vt = data;
+
+	log_debug("libseat: seat enabled");
+
+	tty_activate(vt);
+	vt_call_activate(&vt->base);
+}
+
+static void vt_libseat_disable(struct libseat *libseat, void *data)
+{
+	struct uterm_vt_libseat *vt = data;
+
+	log_debug("libseat: seat disabled");
+
+	vt_call_deactivate(&vt->base, false);
+	tty_deactivate(vt);
+}
+
+static void vt_libseat_event(struct ev_fd *fd, int mask, void *data)
+{
+	struct uterm_vt_libseat *vt = data;
+
+	if (libseat_dispatch(vt->libseat, 0) < 0)
+		log_warning("libseat dispatch failed: %m");
+}
+
+static const struct libseat_seat_listener libseat_listener = {
+	.enable_seat = vt_libseat_enable,
+	.disable_seat = vt_libseat_disable,
+};
+
+static void vt_libseat_destroy(struct uterm_vt *base)
+{
+	struct uterm_vt_libseat *vt = to_libseat(base);
+
+	close_tty(vt);
+	ev_eloop_rm_fd(vt->libseat_efd);
+	libseat_close_seat(vt->libseat);
+}
+
+static int vt_libseat_activate(struct uterm_vt *base)
+{
+	struct uterm_vt_libseat *vt = to_libseat(base);
+
+	tty_activate(vt);
+	return 0;
+}
+
+static int vt_libseat_deactivate(struct uterm_vt *base)
+{
+	struct uterm_vt_libseat *vt = to_libseat(base);
+
+	tty_deactivate(vt);
+	return 0;
+}
+
+static void vt_libseat_bell(struct uterm_vt *base)
+{
+	struct uterm_vt_libseat *vt = to_libseat(base);
+
+	if (vt->tty_fd <= 0)
+		return;
+
+	if (write(vt->tty_fd, "\a", 1) != 1)
+		log_warning("cannot write bell to VT (%d): %m", vt->tty_num);
+}
+
+static unsigned int vt_libseat_get_num(struct uterm_vt *base)
+{
+	struct uterm_vt_libseat *vt = to_libseat(base);
+	return vt->tty_num;
+}
+
+static int vt_libseat_open_device(struct uterm_vt *base, const char *node, int *fd_id)
+{
+	struct uterm_vt_libseat *vt = to_libseat(base);
+	int fd;
+
+	log_debug("opening device %s via libseat", node);
+
+	*fd_id = libseat_open_device(vt->libseat, node, &fd);
+	if (*fd_id < 0) {
+		log_warning("cannot open device %s via libseat (%d): %m", node, errno);
+		return -EFAULT;
+	}
+	return fd;
+}
+
+static void vt_libseat_close_device(struct uterm_vt *base, int fd, int fd_id)
+{
+	struct uterm_vt_libseat *vt = to_libseat(base);
+
+	log_debug("closing device %d via libseat", fd_id);
+
+	libseat_close_device(vt->libseat, fd_id);
+	close(fd);
+}
+
+static const struct uterm_vt_ops vt_libseat_ops = {
+	.destroy = vt_libseat_destroy,
+	.activate = vt_libseat_activate,
+	.deactivate = vt_libseat_deactivate,
+	.bell = vt_libseat_bell,
+	.get_num = vt_libseat_get_num,
+	.open_device = vt_libseat_open_device,
+	.close_device = vt_libseat_close_device,
+};
+
+static enum log_severity log_level(enum libseat_log_level level)
+{
+	switch (level) {
+	default:
+	case LIBSEAT_LOG_LEVEL_DEBUG:
+		return LOG_DEBUG;
+	case LIBSEAT_LOG_LEVEL_INFO:
+		return LOG_INFO;
+	case LIBSEAT_LOG_LEVEL_ERROR:
+		return LOG_ERROR;
+	}
+}
+
+static void log_libseat(enum libseat_log_level level, const char *fmt, va_list args)
+{
+	log_submit(LOG_DEFAULT, log_level(level), fmt, args);
+}
+
+static void vt_libseat_input(struct uterm_input *input, struct uterm_input_key_event *ev,
+			     void *data)
+{
+	struct uterm_vt_libseat *vt = data;
+	int id = 0;
+
+	if (ev->handled || !vt->base.active || vt->base.hup)
+		return;
+
+	if (SHL_HAS_BITS(ev->mods, SHL_CONTROL_MASK | SHL_ALT_MASK) &&
+	    ev->keysyms[0] >= XKB_KEY_F1 && ev->keysyms[0] <= XKB_KEY_F12) {
+		ev->handled = true;
+		id = ev->keysyms[0] - XKB_KEY_F1 + 1;
+		if (id == vt->tty_num)
+			return;
+	} else if (ev->keysyms[0] >= XKB_KEY_XF86Switch_VT_1 &&
+		   ev->keysyms[0] <= XKB_KEY_XF86Switch_VT_12) {
+		ev->handled = true;
+		id = ev->keysyms[0] - XKB_KEY_XF86Switch_VT_1 + 1;
+		if (id == vt->tty_num)
+			return;
+	}
+
+	if (!id || id == vt->tty_num)
+		return;
+
+	log_debug("switching to VT %d via libseat", id);
+	vt_call_deactivate(&vt->base, false);
+	libseat_switch_session(vt->libseat, id);
+}
+
+static int vt_libseat_open(const char *node, int *fd_id, void *data)
+{
+	struct uterm_vt_libseat *vt = data;
+	int fd;
+
+	log_debug("opening device %s via libseat", node);
+
+	*fd_id = libseat_open_device(vt->libseat, node, &fd);
+	if (*fd_id < 0) {
+		log_warning("cannot open device %s via libseat (%d): %m", node, errno);
+		return -EFAULT;
+	}
+	return fd;
+}
+
+static void vt_libseat_close(int fd, int fd_id, void *data)
+{
+	struct uterm_vt_libseat *vt = data;
+
+	log_debug("closing device %d via libseat", fd_id);
+
+	libseat_close_device(vt->libseat, fd_id);
+	close(fd);
+}
+
+struct uterm_vt *uterm_vt_libseat_new(struct uterm_vt_master *vtm, struct uterm_input *input,
+				      const char *vt_name, uterm_vt_cb cb, void *data)
+{
+	struct uterm_vt_libseat *vt;
+	int libseat_fd;
+	int ret;
+
+	vt = malloc(sizeof(*vt));
+	if (!vt)
+		return NULL;
+	memset(vt, 0, sizeof(*vt));
+	vt->base.vtm = vtm;
+	vt->base.input = input;
+	vt->base.cb = cb;
+	vt->base.data = data;
+	vt->base.ops = &vt_libseat_ops;
+
+	if (vt_name) {
+		if (open_tty(vt, vt_name) < 0)
+			goto err_free;
+	}
+	libseat_set_log_handler(log_libseat);
+	libseat_set_log_level(LIBSEAT_LOG_LEVEL_INFO);
+	/*
+	 * Open libseat. If another client is still being disabled (race
+	 * between VT_WAITACTIVE and seatd processing the switch), retry
+	 * briefly.
+	 */
+	for (int attempts = 0; attempts < 50; attempts++) {
+		vt->libseat = libseat_open_seat(&libseat_listener, vt);
+		if (vt->libseat)
+			break;
+		if (errno != EBUSY && errno != EBADF) {
+			log_error("cannot open libseat: %m");
+			ret = -errno;
+			goto err_close_tty;
+		}
+		if (attempts == 0)
+			log_info("seat busy, waiting for previous client to release...");
+		usleep(100000);
+	}
+	if (!vt->libseat) {
+		log_error("cannot open libseat after retries: %m");
+		ret = -errno;
+		goto err_close_tty;
+	}
+	log_notice("libseat seat opened successfully");
+
+	libseat_fd = libseat_get_fd(vt->libseat);
+	ret = ev_eloop_new_fd(vt->base.vtm->eloop, &vt->libseat_efd, libseat_fd, EV_READABLE,
+			      vt_libseat_event, vt);
+	if (ret) {
+		log_error("cannot register libseat fd with eloop: %d", ret);
+		goto err_libseat;
+	}
+
+	uterm_input_set_device_ops(input, vt_libseat_open, vt_libseat_close, vt);
+
+	ret = uterm_input_register_key_cb(input, vt_libseat_input, vt);
+	if (ret)
+		goto err_libseat_fd;
+
+	return &vt->base;
+
+err_libseat_fd:
+	ev_eloop_rm_fd(vt->libseat_efd);
+err_libseat:
+	libseat_close_seat(vt->libseat);
+err_close_tty:
+	close_tty(vt);
+err_free:
+	free(vt);
+	return NULL;
+}

--- a/tests/test_vt.c
+++ b/tests/test_vt.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 	if (ret)
 		goto err_vtm;
 
-	ret = uterm_vt_allocate(vtm, &vt, false, "seat0", input, vtpath, NULL, NULL);
+	ret = uterm_vt_allocate(vtm, &vt, false, false, "seat0", input, vtpath, NULL, NULL);
 	if (ret)
 		goto err_input;
 

--- a/tests/test_vt.c
+++ b/tests/test_vt.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 	if (ret)
 		goto err_vtm;
 
-	ret = uterm_vt_allocate(vtm, &vt, false, false, "seat0", input, vtpath, NULL, NULL);
+	ret = uterm_vt_allocate(vtm, &vt, false, false, input, vtpath, NULL, NULL);
 	if (ret)
 		goto err_input;
 


### PR DESCRIPTION
Use libseat, to open a seat, and get file descriptors for Video and Input devices.
This can allow kmscon to run as a unprivileged user.
The only problem remaning, is that to start /sbin/login, kmscon still need root privilege.