### PR TITLE
Add a terminfo file.

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -254,7 +254,7 @@
         <listitem>
           <para>Specify the <varname>$TERM</varname> environment variable
                 that is set on new terminal sessions.
-                (default: linux)</para>
+                (default: kmscon)</para>
         </listitem>
       </varlistentry>
 

--- a/docs/man/kmscon.conf.5.xml.in
+++ b/docs/man/kmscon.conf.5.xml.in
@@ -61,7 +61,7 @@ session-max=6
 session-control
 
 ### Terminal Options ###
-term=linux
+term=kmscon
 
 ### Input Options ###
 xkb-model=pc102
@@ -192,7 +192,7 @@ font-name=Ubuntu Mono
       <varlistentry>
         <term><option>term</option></term>
         <listitem>
-          <para>Value of the TERM environment variable for the child process. (default: linux)</para>
+          <para>Value of the TERM environment variable for the child process. (default: kmscon)</para>
         </listitem>
       </varlistentry>
 

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ add_project_arguments(
 #
 prefix = get_option('prefix')
 bindir = get_option('bindir')
+datadir= get_option('datadir')
 sysconfdir = get_option('sysconfdir') / meson.project_name()
 libexecdir = get_option('libexecdir') / meson.project_name()
 mandir = get_option('mandir')
@@ -82,6 +83,7 @@ freetype_deps = dependency('freetype2', disabler: true, required: get_option('fo
 fontconfig_deps = dependency('fontconfig', disabler: true, required: get_option('font_freetype'))
 xsltproc = find_program('xsltproc', native: true, disabler: true, required: get_option('docs'))
 check_deps = dependency('check', disabler: true, required: get_option('tests'))
+tic = find_program('tic', required: false)
 
 #
 # Handle feature options
@@ -234,4 +236,18 @@ if enable_libseat
     install_dir: get_option('sysconfdir') / 'pam.d',
     rename: 'kmscon',
   )
+endif
+
+# Terminfo
+terminfo_src = files('scripts/terminfo/kmscon.ti')
+
+if tic.found()
+    # Schedule the script to run during 'meson install'
+    meson.add_install_script(
+        'scripts/terminfo/build_terminfo.py',
+        prefix / datadir,
+        terminfo_src
+    )
+else
+    warning('The "tic" compiler was not found. Terminfo will not be installed.')
 endif

--- a/scripts/etc/kmscon.conf.example
+++ b/scripts/etc/kmscon.conf.example
@@ -90,7 +90,7 @@
 
 ## Terminal options
 ## value of the $TERM variable
-#term=linux
+#term=kmscon
 
 ## Reset environment [on]
 #reset-env

--- a/scripts/terminfo/build_terminfo.py
+++ b/scripts/terminfo/build_terminfo.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+# Meson passes DESTDIR automatically via the environment
+destdir = os.environ.get('DESTDIR', '')
+datadir = sys.argv[1]
+terminfo_src = sys.argv[2]
+
+# Standard destination is /usr/share/terminfo (or /usr/local/share/terminfo)
+# lstrip prevents os.path.join from treating datadir as an absolute path anchors
+target_dir = os.path.join(destdir, datadir.lstrip('/'), 'terminfo')
+
+# Ensure the base terminfo directory exists
+os.makedirs(target_dir, exist_ok=True)
+
+# Run the terminfo compiler
+# -x forces tic to handle non-standard/extended capabilities if present
+# -o defines the output directory root
+print(f'Compiling terminfo to {target_dir}...')
+subprocess.run(['tic', '-x', '-o', target_dir, terminfo_src], check=True)

--- a/scripts/terminfo/kmscon.ti
+++ b/scripts/terminfo/kmscon.ti
@@ -1,0 +1,61 @@
+# kmscon terminal emulator description
+kmscon|KMS Console,
+  am, bce, km, mir, msgr,
+  colors#256, pairs#32767,
+  cols#80, lines#24,
+
+# Character Set Mapping (VT100 style)
+  acsc=``aaffggiijjkkllmmnnooppqqrrssttuuvvwwxxyyzz{{||}}~~,
+# Basic Controls
+  bel=^G, cr=\r, cud1=\n, ht=^I, ind=\n,
+
+# Cursor Movement
+  cub1=^H, cuf1=\E[C, cuu1=\E[A,
+  cub=\E[%p1%dD, cud=\E[%p1%dB, cuf=\E[%p1%dC, cuu=\E[%p1%dA,
+  cup=\E[%i%p1%d;%p2%dH, home=\E[H,
+  hpa=\E[%i%p1%dG, vpa=\E[%i%p1%dd,
+
+# Erasure
+  clear=\E[H\E[2J, ed=\E[J, el=\E[K, el1=\E[1K,
+  ech=\E[%p1%dX,
+
+# Insert/Delete
+  dch1=\E[P, dch=\E[%p1%dP,
+  dl1=\E[M, dl=\E[%p1%dM,
+  ch1=\E[@, ich=\E[%p1%d@,
+  il1=\E[L, il=\E[%p1%dL,
+
+# Rendition (SGR)
+  sgr=%?%p9%t\E(0%e\E(B%;\E[0%?%p6%t;1%;%?%p5%t;2%;%?%p2%t;4%;%?%p1%p3%|%t;7%;%?%p4%t;5%;%?%p7%t;8%;m,
+  sgr0=\E(B\E[m, bold=\E[1m, smul=\E[4m,
+  rev=\E[7m, smso=\E[7m, rmso=\E[27m,
+  rmul=\E[24m, smacs=\E(0, rmacs=\E(B,
+
+# Color Support (xterm-256color style)
+  setab=\E[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48;5;%p1%d%;m,
+  setaf=\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m,
+  op=\E[39;49m,
+
+# Scrolling and Margins
+  csr=\E[%i%p1%d;%p2%dr,
+  indn=\E[%p1%dS, rin=\E[%p1%dT,
+  ri=\EM,
+
+# Alternate Buffer
+  smcup=\E[?1049h, rmcup=\E[?1049l,
+
+# Cursor Visibility
+  civis=\E[?25l, cnorm=\E[?25h,
+
+# Input Keys
+  kbs=^H, kcub1=\E[D, kcud1=\E[B,
+  kcuf1=\E[C, kcuu1=\E[A,
+  khome=\E[H, kend=\E[F, knp=\E[6~, kpp=\E[5~,
+  kich1=\E[2~, kdch1=\E[3~,
+  kf1=\EOP, kf2=\EOQ, kf3=\EOR, kf4=\EOS,
+  kf5=\E[15~, kf6=\E[17~, kf7=\E[18~, kf8=\E[19~,
+  kf9=\E[20~, kf10=\E[21~, kf11=\E[23~, kf12=\E[24~,
+
+# Miscellaneous
+  sc=\E7, rc=\E8, rs2=\Ec, tbc=\E[3g, hts=\EH, 
+  rep=%p1%c\E[%p2%{1}%-%db,

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -99,7 +99,7 @@ static void print_help()
 		"\t                              argv to this process. No more options\n"
 		"\t                              after '--' will be parsed so use it at\n"
 		"\t                              the end of the argument string\n"
-		"\t-t, --term <TERM>           [linux]\n"
+		"\t-t, --term <TERM>           [kmscon]\n"
 		"\t                              Value of the TERM environment variable\n"
 		"\t                              for the child process\n"
 		"\t    --reset-env             [on]\n"
@@ -772,7 +772,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_STRING(0, "issue-path", &conf->issue_path, "/etc/issue:/etc/issue.d"),
 		CONF_OPTION(0, 'l', "login", &conf_login, aftercheck_login, NULL, file_login,
 			    &conf->login, false),
-		CONF_OPTION_STRING('t', "term", &conf->term, "linux"),
+		CONF_OPTION_STRING('t', "term", &conf->term, "kmscon"),
 		CONF_OPTION_BOOL(0, "reset-env", &conf->reset_env, true),
 		CONF_OPTION_BOOL(0, "backspace-delete", &conf->backspace_delete, true),
 		CONF_OPTION_UINT(0, "sb-size", &conf->sb_size, 1000),


### PR DESCRIPTION
This will allow kmscon to set $TERM to "kmscon", and have ncurse based program work correctly.
It's generated by Gemini, as the terminfo format is quite obscure. Tested with top, and btop.

use tic -x kmscon.ti to generate the binary terminfo, and then you can test with:
$export TERM="kmscon"

Fix #286