### PR TITLE
terminal: change COLORTERM default to truecolor

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -1222,7 +1222,7 @@ int kmscon_terminal_register(struct kmscon_session **out, struct kmscon_seat *se
 	if (ret)
 		goto err_font;
 
-	ret = kmscon_pty_set_conf(term->pty, term->conf->term, "kmscon", term->conf->argv,
+	ret = kmscon_pty_set_conf(term->pty, term->conf->term, "truecolor", term->conf->argv,
 				  kmscon_seat_get_name(seat), vtnr, term->conf->reset_env,
 				  term->conf->backspace_delete);
 	if (ret)


### PR DESCRIPTION
It's currently set to "kmscon", but some TUI like helix want it to be "truecolor", to enable 24-bit colors.

Fix #397 