### PR TITLE
Fix dpms off

### DIFF
--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -657,7 +657,7 @@ static void seat_dpms_timeout(struct ev_timer *timer, uint64_t num, void *data)
 	struct kmscon_display *d;
 	int ret;
 
-	if (!seat->conf->dpms_timeout)
+	if (!seat->conf->dpms_timeout || !seat->awake)
 		return;
 
 	log_debug("DPMS: blanking screen due to inactivity");

--- a/src/render/bbulk.c
+++ b/src/render/bbulk.c
@@ -386,7 +386,6 @@ static int bbulk_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 	bool last_col = (posx == txt->cols - 1);
 	bool changed;
 
-
 	prev = &bb->prev[offset];
 
 	// left cell overflow on this cell.
@@ -435,7 +434,8 @@ static int bbulk_draw(struct kmscon_text *txt, uint64_t id, const uint32_t *ch, 
 
 	req = &bb->reqs[bb->req_len++];
 
-	if (glyph->double_width && !last_col && (txt->orientation == OR_LEFT || txt->orientation == OR_UPSIDE_DOWN))
+	if (glyph->double_width && !last_col &&
+	    (txt->orientation == OR_LEFT || txt->orientation == OR_UPSIDE_DOWN))
 		/*
 		 * In case of left or upside down orientation, we need to draw to the
 		 * next cell, as the glyph is already rotated, so start on the next cell


### PR DESCRIPTION
seat: Fix trying to set DPMS to OFF when VT is not awake

When you switch to another VT, and the dpms timeout kicks in, it
tries to set DPMS to OFF, and print a warning:

WARNING: seat: cannot set DPMS to OFF for display: -22

So only tries to blank the screen if kmscon is active.