### PR TITLE
fix zlib cross-compiling errors

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,7 @@ libudev_deps = dependency('libudev', version: '>=172')
 dl_deps = dependency('dl')
 threads_deps = dependency('threads')
 zlib_deps = dependency('zlib')
+zlib_deps_native = dependency('zlib', native: true)
 
 python = find_program('python3')
 

--- a/src/font/meson.build
+++ b/src/font/meson.build
@@ -22,7 +22,7 @@ font_deps = declare_dependency(
 # Unifont Generator
 # This generates the unifont sources from raw hex-encoded font data.
 #
-genunifont = executable('genunifont', 'genunifont.c', dependencies: [zlib_deps], native: true)
+genunifont = executable('genunifont', 'genunifont.c', dependencies: [zlib_deps_native], native: true)
 
 unifont_bin = custom_target('unifont-bin',
   input: ['font_unifont_data.hex'],


### PR DESCRIPTION
zlib compression was introduced in version 9.3.3. However, when cross-compiling kmscon for an architecture other than x86_64, the genunifont executable tries to use the build-systems zlib instead of the hosts zlib.

This leads to the following error during compiling: libz.so: error adding symbols: file in wrong format

Fix this by adding a new native zlib dependency specifically for the genunifont executable.