### PR TITLE
RFC: Update default issue search path with util-linux defaults

### DIFF
--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -34,6 +34,7 @@
 #include <xkbcommon/xkbcommon-keysyms.h>
 #include "conf.h"
 #include "kmscon_conf.h"
+#include "kmscon_issue.h"
 #include "shl/githead.h"
 #include "shl/log.h"
 #include "shl/misc.h"
@@ -85,7 +86,7 @@ static void print_help()
 		"\t                              Display issue files before the\n"
 		"\t                              login prompt. Use --no-issue to\n"
 		"\t                              let the login process handle it.\n"
-		"\t    --issue-path <path>     [/etc/issue:/etc/issue.d]\n"
+		"\t    --issue-path <path>     [" ISSUE_DEFAULT_PATH "]\n"
 		"\t                              Colon-separated list of issue\n"
 		"\t                              files and directories to read\n"
 		"\t-l, --login                 [/bin/login -p]\n"
@@ -732,7 +733,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 
 		/* Terminal Options */
 		CONF_OPTION_BOOL(0, "issue", &conf->issue, true),
-		CONF_OPTION_STRING(0, "issue-path", &conf->issue_path, "/etc/issue:/etc/issue.d"),
+		CONF_OPTION_STRING(0, "issue-path", &conf->issue_path, ISSUE_DEFAULT_PATH),
 		CONF_OPTION(0, 'l', "login", &conf_login, aftercheck_login, NULL, file_login,
 			    &conf->login, false),
 		CONF_OPTION_STRING('t', "term", &conf->term, "kmscon"),

--- a/src/kmscon_issue.c
+++ b/src/kmscon_issue.c
@@ -36,16 +36,6 @@
 /* Cap total collected issue text to prevent runaway allocation. */
 #define ISSUE_MAX_SIZE (256u * 1024u)
 
-/*
- * Default search path, matching agetty's default:
- *   /etc/issue:/etc/issue.d
- *
- * Distros can override this with --issue-path or the issue-path config
- * option using a colon-separated list.  Plain files are read directly;
- * directories are scanned for *.issue files in lexicographic order.
- */
-#define ISSUE_DEFAULT_PATH "/etc/issue:/etc/issue.d"
-
 /* Color escape codes */
 // clang-format off
 #define UL_COLOR_RESET		"[0m"

--- a/src/kmscon_issue.h
+++ b/src/kmscon_issue.h
@@ -36,7 +36,8 @@
  * option using a colon-separated list.  Plain files are read directly;
  * directories are scanned for *.issue files in lexicographic order.
  */
-#define ISSUE_DEFAULT_PATH "/etc/issue:/etc/issue.d"
+#define ISSUE_DEFAULT_PATH                                                                         \
+	"/run/issue:/run/issue.d:/etc/issue:/etc/issue.d:/usr/lib/issue:/usr/lib/issue.d"
 
 void kmscon_issue_write(struct tsm_vte *vte, struct kmscon_pty *pty, const char *search_path);
 

--- a/src/kmscon_issue.h
+++ b/src/kmscon_issue.h
@@ -29,6 +29,15 @@
 #include <libtsm.h>
 #include "pty.h"
 
+/*
+ * Default search path, matching agetty's default.
+ *
+ * Distros can override this with --issue-path or the issue-path config
+ * option using a colon-separated list.  Plain files are read directly;
+ * directories are scanned for *.issue files in lexicographic order.
+ */
+#define ISSUE_DEFAULT_PATH "/etc/issue:/etc/issue.d"
+
 void kmscon_issue_write(struct tsm_vte *vte, struct kmscon_pty *pty, const char *search_path);
 
 #endif /* KMSCON_ISSUE_H */


### PR DESCRIPTION
agetty from util-linux supports the "uapi configuration files spec",
which includes support for files and drop-ins in /run and /usr/lib.

While kmscon does not do the merging of directories due to spec (yet),
adding the new locations already gets it fairly close.

This PR is marked as RFC due to ^

Addresses half of the first part of https://github.com/kmscon/kmscon/issues/407