### PR TITLE
freetype: Enable light hinting

### DIFF
--- a/src/font/font_freetype.c
+++ b/src/font/font_freetype.c
@@ -114,7 +114,7 @@ static int font_get_width(FT_Face face)
 {
 	FT_UInt glyph_index = FT_Get_Char_Index(face, 'M');
 
-	if (FT_Load_Glyph(face, glyph_index, FT_LOAD_DEFAULT))
+	if (FT_Load_Glyph(face, glyph_index, FT_LOAD_TARGET_LIGHT))
 		return -1;
 
 	if (FT_Render_Glyph(face->glyph, FT_RENDER_MODE_NORMAL))
@@ -377,7 +377,7 @@ static struct kmscon_glyph *render_glyph(FT_Face face, FT_UInt index, const uint
 	if (!cwidth)
 		return NULL;
 
-	if (FT_Load_Glyph(face, index, FT_LOAD_NO_HINTING)) {
+	if (FT_Load_Glyph(face, index, FT_LOAD_TARGET_LIGHT)) {
 		log_err("Failed to load glyph\n");
 		return NULL;
 	}


### PR DESCRIPTION
Not hinting at all results in blurry edges, especially visible with straight lines in common characters such as "-[]".

Light hinting in FreeType has the nice property that it only tries to align edges vertically, so the width of glyphs does not change, preserving monospaceness.

Before:

<img width="839" height="338" alt="Bildschirmfoto_20260602_123620" src="https://github.com/user-attachments/assets/90f5bc09-9489-42b9-b076-ab7c68bfb764" />

After:

<img width="839" height="338" alt="Bildschirmfoto_20260602_123534" src="https://github.com/user-attachments/assets/ee81c245-4399-44d6-a3a7-dedc3659689d" />

| Before | After |
|-----------|---------|
|<img width="387" height="87" alt="Bildschirmfoto_20260602_124221" src="https://github.com/user-attachments/assets/780ee417-f5b8-416f-9c83-039f875d4e9c" />|<img width="387" height="87" alt="Bildschirmfoto_20260602_123917" src="https://github.com/user-attachments/assets/c13cfb2d-31c8-4930-8974-09aafb9e7db6" />|
|<img width="387" height="87" alt="Bildschirmfoto_20260602_124348" src="https://github.com/user-attachments/assets/a44cbcf1-1b08-4054-b41e-c4dc823b5a31" />|<img width="387" height="87" alt="Bildschirmfoto_20260602_124418" src="https://github.com/user-attachments/assets/06d9d14a-8a52-4404-8ae8-28bcab9c691b" />|
