### PR TITLE
Meson: Add an option to set the default $TERM environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ explicitly enable it via command line:
 |`session_dummy`| `auto` | Dummy fallback session |
 |`session_terminal`| `auto` | Terminal-emulator sessions |
 |`docs`|`auto`| Build manpages and documentation |
+|`term`|`kmscon`| Default $TERM value |
 
 
 ## Running

--- a/meson.build
+++ b/meson.build
@@ -126,6 +126,9 @@ config.set('BUILD_ENABLE_DEBUG', get_option('extra_debug'))
 config.set_quoted('BUILD_MODULE_DIR', prefix / moduledir)
 config.set_quoted('BUILD_CONFIG_DIR', prefix / sysconfdir)
 
+# Default $TERM value
+config.set_quoted('BUILD_DEFAULT_TERM', get_option('term'))
+
 # Make all files include "config.h" by default. This shouldn't cause any
 # problems and we cannot forget to include it anymore.
 config_h = configure_file(configuration: config, output: 'config.h')

--- a/meson.options
+++ b/meson.options
@@ -38,3 +38,7 @@ option('session_terminal', type: 'feature', value: 'auto',
 # dbus integration
 option('dbus', type: 'feature', value: 'auto',
   description: 'dbus integration')
+
+# TERM default value
+option('term', type: 'string', value: 'kmscon',
+  description: 'default $TERM value')

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -96,7 +96,7 @@ static void print_help()
 		"\t                              argv to this process. No more options\n"
 		"\t                              after '--' will be parsed so use it at\n"
 		"\t                              the end of the argument string\n"
-		"\t-t, --term <TERM>           [kmscon]\n"
+		"\t-t, --term <TERM>           [" BUILD_DEFAULT_TERM "]\n"
 		"\t                              Value of the TERM environment variable\n"
 		"\t                              for the child process\n"
 		"\t    --reset-env             [on]\n"
@@ -736,7 +736,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_STRING(0, "issue-path", &conf->issue_path, ISSUE_DEFAULT_PATH),
 		CONF_OPTION(0, 'l', "login", &conf_login, aftercheck_login, NULL, file_login,
 			    &conf->login, false),
-		CONF_OPTION_STRING('t', "term", &conf->term, "kmscon"),
+		CONF_OPTION_STRING('t', "term", &conf->term, BUILD_DEFAULT_TERM),
 		CONF_OPTION_BOOL(0, "reset-env", &conf->reset_env, true),
 		CONF_OPTION_BOOL(0, "backspace-delete", &conf->backspace_delete, true),
 		CONF_OPTION_UINT(0, "sb-size", &conf->sb_size, 1000),


### PR DESCRIPTION
So packager can choose the $TERM value for their distribution.

"kmscon" is the future, but some might prefer "linux" or "xterm-256color" until kmscon terminfo is released in the ncurses database.

Fix #411 