### PR TITLE
Update keyboard layout

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -25,15 +25,33 @@
  */
 
 #include <dbus/dbus.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "dbus.h"
+#include "shl/eloop.h"
 #include "shl/log.h"
 
 #define LOG_SUBSYSTEM "dbus"
 
-static void dbus_set_locale_property(DBusConnection *conn, const char *property_name,
-				     const char *env_name)
+struct rmlvo {
+	const char *model;
+	const char *layout;
+	const char *variant;
+	const char *options;
+};
+
+struct kmscon_dbus {
+	DBusConnection *conn;
+	struct ev_eloop *eloop;
+	struct ev_fd *watch_fd;
+	dbus_update_xkb_layout_cb cb;
+	void *data;
+};
+
+static void set_env_from_locale1_properties(DBusConnection *conn, const char *property_name,
+					    const char *env_name)
 {
 	DBusError error;
 	DBusMessage *msg;
@@ -101,29 +119,250 @@ static bool is_xkb_env_set(void)
 	       getenv("XKB_DEFAULT_VARIANT") || getenv("XKB_DEFAULT_OPTIONS");
 }
 
-void dbus_set_xkb_env_from_locale(void)
+/* This is called once at startup to set the XKB environment variables from the locale1 properties.
+ */
+void kmscon_dbus_set_xkb_env_from_locale1(struct kmscon_dbus *dbus)
 {
 	DBusError error;
-	DBusConnection *conn;
 
 	if (is_xkb_env_set())
 		return;
 
 	dbus_error_init(&error);
 
-	conn = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
+	set_env_from_locale1_properties(dbus->conn, "X11Model", "XKB_DEFAULT_MODEL");
+	set_env_from_locale1_properties(dbus->conn, "X11Layout", "XKB_DEFAULT_LAYOUT");
+	set_env_from_locale1_properties(dbus->conn, "X11Variant", "XKB_DEFAULT_VARIANT");
+	set_env_from_locale1_properties(dbus->conn, "X11Options", "XKB_DEFAULT_OPTIONS");
+}
+
+struct kmscon_dbus *kmscon_dbus_new(struct ev_eloop *eloop)
+{
+	struct kmscon_dbus *dbus;
+	DBusError error;
+
+	dbus = malloc(sizeof(*dbus));
+	if (!dbus)
+		return NULL;
+	memset(dbus, 0, sizeof(*dbus));
+
+	dbus->eloop = eloop;
+
+	dbus_error_init(&error);
+	dbus->conn = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 	if (dbus_error_is_set(&error)) {
 		log_debug("Connection Error: %s\n", error.message);
 		dbus_error_free(&error);
+		return NULL;
+	}
+	return dbus;
+}
+
+void kmscon_dbus_free(struct kmscon_dbus *dbus)
+{
+	if (!dbus)
+		return;
+	dbus_connection_unref(dbus->conn);
+	free(dbus);
+}
+
+static void set_rmlvo_property(struct rmlvo *rmlvo, const char *property_name,
+			       const char *property_value)
+{
+	if (!strcmp(property_name, "X11Model")) {
+		rmlvo->model = property_value;
+	} else if (!strcmp(property_name, "X11Layout")) {
+		rmlvo->layout = property_value;
+	} else if (!strcmp(property_name, "X11Variant")) {
+		rmlvo->variant = property_value;
+	} else if (!strcmp(property_name, "X11Options")) {
+		rmlvo->options = property_value;
+	}
+}
+
+/* Parse the locale1 properties changed message and update the rmlvo struct */
+void parse_locale_properties(DBusMessage *msg, struct rmlvo *rmlvo)
+{
+	DBusMessageIter root_iter;
+	DBusMessageIter dict_iter;
+	DBusMessageIter entry_iter;
+	DBusMessageIter variant_iter;
+	char *property_name;
+	char *property_value;
+
+	if (!dbus_message_iter_init(msg, &root_iter)) {
+		log_debug("Message has no arguments.\n");
 		return;
 	}
-	if (!conn)
+
+	dbus_message_iter_next(&root_iter);
+	if (dbus_message_iter_get_arg_type(&root_iter) != DBUS_TYPE_ARRAY) {
+		log_debug("Not the container type we expect\n");
+		return;
+	}
+
+	dbus_message_iter_recurse(&root_iter, &dict_iter);
+	while (dbus_message_iter_get_arg_type(&dict_iter) == DBUS_TYPE_DICT_ENTRY) {
+
+		dbus_message_iter_recurse(&dict_iter, &entry_iter);
+
+		dbus_message_iter_get_basic(&entry_iter, &property_name);
+
+		dbus_message_iter_next(&entry_iter);
+
+		if (dbus_message_iter_get_arg_type(&entry_iter) == DBUS_TYPE_VARIANT) {
+
+			dbus_message_iter_recurse(&entry_iter, &variant_iter);
+
+			if (dbus_message_iter_get_arg_type(&variant_iter) == DBUS_TYPE_STRING) {
+				dbus_message_iter_get_basic(&variant_iter, &property_value);
+				set_rmlvo_property(rmlvo, property_name, property_value);
+				log_debug("property %s: %s\n", property_name, property_value);
+			}
+		}
+		dbus_message_iter_next(&dict_iter);
+	}
+}
+
+static void handle_dispatch_status(DBusConnection *conn, DBusDispatchStatus status, void *data)
+{
+	struct kmscon_dbus *dbus = data;
+	struct rmlvo rmlvo = {NULL, NULL, NULL, NULL};
+
+	if (status == DBUS_DISPATCH_DATA_REMAINS) {
+		DBusMessage *msg = dbus_connection_pop_message(dbus->conn);
+		if (msg) {
+			log_debug("Received message %s\n", dbus_message_get_signature(msg));
+			if (dbus_message_is_signal(msg, "org.freedesktop.DBus.Properties",
+						   "PropertiesChanged")) {
+				parse_locale_properties(msg, &rmlvo);
+				if (dbus->cb)
+					dbus->cb(rmlvo.model, rmlvo.layout, rmlvo.variant,
+						 rmlvo.options, dbus->data);
+			}
+			dbus_message_unref(msg);
+		}
+	}
+}
+
+static void locale1_properties_changed(struct ev_fd *fd, int mask, void *data)
+{
+	struct DBusWatch *watch = data;
+	struct kmscon_dbus *dbus = dbus_watch_get_data(watch);
+
+	unsigned int flags = 0;
+
+	log_debug("locale1 property changed\n");
+
+	if (mask & EV_READABLE)
+		flags |= DBUS_WATCH_READABLE;
+	if (mask & EV_WRITEABLE)
+		flags |= DBUS_WATCH_WRITABLE;
+
+	dbus_watch_handle(watch, flags);
+
+	while (dbus_connection_get_dispatch_status(dbus->conn) == DBUS_DISPATCH_DATA_REMAINS) {
+		dbus_connection_dispatch(dbus->conn);
+		// DBUS-1 API is a pain, but at least that works for this simple use case
+		handle_dispatch_status(dbus->conn, DBUS_DISPATCH_DATA_REMAINS, dbus);
+	}
+}
+
+/* Only register one read watch, as we're not interested in writes */
+static unsigned int dbus_add_watch(DBusWatch *watch, void *data)
+{
+	struct kmscon_dbus *dbus = data;
+	int fd = dbus_watch_get_unix_fd(watch);
+	unsigned int flags = dbus_watch_get_flags(watch);
+	unsigned int ev_flags = 0;
+	int ret = 0;
+
+	log_debug("Adding watch for fd %d with flags %d %p %d\n", fd, flags, watch,
+		  dbus_watch_get_enabled(watch));
+
+	if (!dbus_watch_get_enabled(watch))
+		return TRUE;
+
+	if (dbus->watch_fd) {
+		log_warning("dbus watch already registered");
+		return TRUE;
+	}
+	if (flags & DBUS_WATCH_WRITABLE)
+		ev_flags |= EV_WRITEABLE;
+	if (flags & DBUS_WATCH_READABLE)
+		ev_flags |= EV_READABLE;
+
+	ret = ev_eloop_new_fd(dbus->eloop, &dbus->watch_fd, fd, ev_flags,
+			      locale1_properties_changed, watch);
+
+	dbus_watch_set_data(watch, dbus, NULL);
+
+	if (ret)
+		log_error("cannot add watch for fd %d: %d %d %p", fd, ret, ev_flags, watch);
+	return TRUE;
+}
+
+static void dbus_remove_watch(DBusWatch *watch, void *data)
+{
+	struct kmscon_dbus *dbus = data;
+	log_debug("Removing watch for fd %d\n", dbus_watch_get_unix_fd(watch));
+
+	if (dbus_watch_get_data(watch) != dbus)
 		return;
 
-	dbus_set_locale_property(conn, "X11Model", "XKB_DEFAULT_MODEL");
-	dbus_set_locale_property(conn, "X11Layout", "XKB_DEFAULT_LAYOUT");
-	dbus_set_locale_property(conn, "X11Variant", "XKB_DEFAULT_VARIANT");
-	dbus_set_locale_property(conn, "X11Options", "XKB_DEFAULT_OPTIONS");
+	ev_eloop_rm_fd(dbus->watch_fd);
+	dbus->watch_fd = NULL;
+	dbus_watch_set_data(watch, NULL, NULL);
+	return;
+}
 
-	dbus_connection_unref(conn);
+static void dbus_toggle_watch(DBusWatch *watch, void *data)
+{
+	log_debug("Toggling watch for fd %d\n", dbus_watch_get_unix_fd(watch));
+
+	if (dbus_watch_get_enabled(watch))
+		dbus_add_watch(watch, data);
+	else
+		dbus_remove_watch(watch, data);
+}
+
+/* Listen to locale1 properties changed, and update the XKB layout if needed */
+int kmscon_dbus_listen_locale1(struct kmscon_dbus *dbus, dbus_update_xkb_layout_cb cb, void *data)
+{
+	DBusError error;
+
+	log_debug("Listening to locale1\n");
+
+	if (!cb)
+		return -EINVAL;
+
+	dbus->cb = cb;
+	dbus->data = data;
+
+	dbus_error_init(&error);
+
+	dbus_connection_set_watch_functions(dbus->conn, dbus_add_watch, dbus_remove_watch,
+					    dbus_toggle_watch, dbus, NULL);
+
+	dbus_connection_set_dispatch_status_function(dbus->conn, handle_dispatch_status, dbus,
+						     NULL);
+
+	const char *match_rule = "type='signal',"
+				 "sender='org.freedesktop.locale1',"
+				 "path='/org/freedesktop/locale1',"
+				 "interface='org.freedesktop.DBus.Properties',"
+				 "member='PropertiesChanged'";
+
+	dbus_bus_add_match(dbus->conn, match_rule, &error);
+
+	if (dbus_error_is_set(&error)) {
+		log_debug("Error adding match: %s\n", error.message);
+		dbus_error_free(&error);
+		return -EIO;
+	}
+	dbus_connection_flush(dbus->conn);
+
+	log_info("Listening to locale1 changes");
+
+	return 0;
 }

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -27,12 +27,35 @@
 #ifndef _KMSCON_DBUS_H
 #define _KMSCON_DBUS_H
 
+struct ev_eloop;
+struct kmscon_dbus;
+
+typedef void (*dbus_update_xkb_layout_cb)(const char *model, const char *layout,
+					  const char *variant, const char *options, void *data);
+
 #ifdef BUILD_ENABLE_DBUS
-void dbus_set_xkb_env_from_locale(void);
+void kmscon_dbus_set_xkb_env_from_locale1(struct kmscon_dbus *dbus);
+struct kmscon_dbus *kmscon_dbus_new(struct ev_eloop *eloop);
+void kmscon_dbus_free(struct kmscon_dbus *dbus);
+int kmscon_dbus_listen_locale1(struct kmscon_dbus *dbus, dbus_update_xkb_layout_cb cb, void *data);
+
 #else
-static inline void dbus_set_xkb_env_from_locale(void)
+static inline void kmscon_dbus_set_xkb_env_from_locale1(struct kmscon_dbus *dbus)
 {
 	return;
+}
+static inline struct kmscon_dbus *kmscon_dbus_new(struct ev_eloop *eloop)
+{
+	return NULL;
+}
+static inline void kmscon_dbus_free(struct kmscon_dbus *dbus)
+{
+	return;
+}
+static inline int kmscon_dbus_listen_locale1(struct kmscon_dbus *dbus, dbus_update_xkb_layout_cb cb,
+					     void *data)
+{
+	return 0;
 }
 #endif /* BUILD_ENABLE_DBUS */
 #endif /* _KMSCON_DBUS_H */

--- a/src/input/input.c
+++ b/src/input/input.c
@@ -506,18 +506,6 @@ SHL_EXPORT
 int input_set_keymap(struct input *input, const char *model, const char *layout,
 		     const char *variant, const char *options, const char *keymap)
 {
-	/* xkbcommon won't use the XKB_DEFAULT_OPTIONS environment
-	 * variable if options is an empty string.
-	 * So if all variables are empty, use NULL instead.
-	 */
-	if (model && *model == 0 && layout && *layout == 0 && variant && *variant == 0 && options &&
-	    *options == 0) {
-		model = NULL;
-		layout = NULL;
-		variant = NULL;
-		options = NULL;
-	}
-
 	return uxkb_layout_init(input, model, layout, variant, options, keymap);
 }
 
@@ -534,18 +522,6 @@ int input_update_keymap(struct input *input, const char *model, const char *layo
 {
 	struct shl_dlist *iter;
 	struct input_dev *dev;
-
-	/* xkbcommon won't use the XKB_DEFAULT_OPTIONS environment
-	 * variable if options is an empty string.
-	 * So if all variables are empty, use NULL instead.
-	 */
-	if (model && *model == 0 && layout && *layout == 0 && variant && *variant == 0 && options &&
-	    *options == 0) {
-		model = NULL;
-		layout = NULL;
-		variant = NULL;
-		options = NULL;
-	}
 
 	if (input->ctx) {
 		shl_dlist_for_each(iter, &input->devices)

--- a/src/input/input.c
+++ b/src/input/input.c
@@ -504,8 +504,7 @@ err_free:
 
 SHL_EXPORT
 int input_set_keymap(struct input *input, const char *model, const char *layout,
-		     const char *variant, const char *options, const char *locale,
-		     const char *keymap, const char *compose_file, size_t compose_file_len)
+		     const char *variant, const char *options, const char *keymap)
 {
 	/* xkbcommon won't use the XKB_DEFAULT_OPTIONS environment
 	 * variable if options is an empty string.
@@ -519,8 +518,14 @@ int input_set_keymap(struct input *input, const char *model, const char *layout,
 		options = NULL;
 	}
 
-	return uxkb_desc_init(input, model, layout, variant, options, locale, keymap, compose_file,
-			      compose_file_len);
+	return uxkb_layout_init(input, model, layout, variant, options, keymap);
+}
+
+SHL_EXPORT
+void input_set_compose(struct input *input, const char *locale, const char *compose_file,
+		       size_t compose_file_len)
+{
+	uxkb_compose_table_init(input, compose_file, compose_file_len, locale);
 }
 
 SHL_EXPORT
@@ -565,7 +570,8 @@ void input_unref(struct input *input)
 		input_free_dev(dev);
 	}
 
-	uxkb_desc_destroy(input);
+	uxkb_compose_table_destroy(input);
+	uxkb_layout_destroy(input);
 	shl_hook_free(input->key_hook);
 	shl_hook_free(input->pointer_hook);
 	ev_eloop_rm_timer(input->hide_pointer);

--- a/src/input/input.c
+++ b/src/input/input.c
@@ -529,6 +529,50 @@ void input_set_compose(struct input *input, const char *locale, const char *comp
 }
 
 SHL_EXPORT
+int input_update_keymap(struct input *input, const char *model, const char *layout,
+			const char *variant, const char *options)
+{
+	struct shl_dlist *iter;
+	struct input_dev *dev;
+
+	/* xkbcommon won't use the XKB_DEFAULT_OPTIONS environment
+	 * variable if options is an empty string.
+	 * So if all variables are empty, use NULL instead.
+	 */
+	if (model && *model == 0 && layout && *layout == 0 && variant && *variant == 0 && options &&
+	    *options == 0) {
+		model = NULL;
+		layout = NULL;
+		variant = NULL;
+		options = NULL;
+	}
+
+	if (input->ctx) {
+		shl_dlist_for_each(iter, &input->devices)
+		{
+			dev = shl_dlist_entry(iter, struct input_dev, list);
+			if (dev->capabilities & DEVICE_HAS_KEYS) {
+				input_sleep_dev(dev);
+				input_exit_keyboard(dev);
+			}
+		}
+	}
+	uxkb_compose_table_destroy(input);
+	uxkb_layout_destroy(input);
+	uxkb_layout_init(input, model, layout, variant, options, NULL);
+	shl_dlist_for_each(iter, &input->devices)
+	{
+		dev = shl_dlist_entry(iter, struct input_dev, list);
+		if (dev->capabilities & DEVICE_HAS_KEYS) {
+			input_init_keyboard(dev);
+			if (input->awake)
+				input_wake_up_dev(dev);
+		}
+	}
+	return 0;
+}
+
+SHL_EXPORT
 void input_set_conf(struct input *input, unsigned int repeat_delay, unsigned int repeat_rate,
 		    bool mouse_enabled)
 {

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -95,6 +95,8 @@ int input_set_keymap(struct input *input, const char *model, const char *layout,
 		     const char *variant, const char *options, const char *keymap);
 void input_set_compose(struct input *input, const char *locale, const char *compose_file,
 		       size_t compose_file_len);
+int input_update_keymap(struct input *input, const char *model, const char *layout,
+			const char *variant, const char *options);
 void input_set_conf(struct input *input, unsigned int repeat_delay, unsigned int repeat_rate,
 		    bool mouse_enabled);
 void input_ref(struct input *input);

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -92,8 +92,9 @@ typedef void (*uterm_close_cb)(int fd, int fd_id, void *data);
 
 int input_new(struct input **out, struct ev_eloop *eloop);
 int input_set_keymap(struct input *input, const char *model, const char *layout,
-		     const char *variant, const char *options, const char *locale,
-		     const char *keymap, const char *compose_file, size_t compose_file_len);
+		     const char *variant, const char *options, const char *keymap);
+void input_set_compose(struct input *input, const char *locale, const char *compose_file,
+		       size_t compose_file_len);
 void input_set_conf(struct input *input, unsigned int repeat_delay, unsigned int repeat_rate,
 		    bool mouse_enabled);
 void input_ref(struct input *input);

--- a/src/input/input_internal.h
+++ b/src/input/input_internal.h
@@ -140,10 +140,12 @@ static inline bool input_bit_is_set(const unsigned long *array, int bit)
 	return !!(array[bit / LONG_BIT] & (1UL << (bit % LONG_BIT)));
 }
 
-int uxkb_desc_init(struct input *input, const char *model, const char *layout, const char *variant,
-		   const char *options, const char *locale, const char *keymap,
-		   const char *compose_file, size_t compose_file_len);
-void uxkb_desc_destroy(struct input *input);
+int uxkb_layout_init(struct input *input, const char *model, const char *layout,
+		     const char *variant, const char *options, const char *keymap);
+void uxkb_compose_table_init(struct input *input, const char *compose_file, size_t compose_file_len,
+			     const char *locale);
+void uxkb_layout_destroy(struct input *input);
+void uxkb_compose_table_destroy(struct input *input);
 
 int uxkb_dev_init(struct input_dev *dev);
 void uxkb_dev_destroy(struct input_dev *dev);

--- a/src/input/input_uxkb.c
+++ b/src/input/input_uxkb.c
@@ -69,11 +69,10 @@ static void uxkb_log(struct xkb_context *context, enum xkb_log_level level, cons
 	log_submit(LOG_DEFAULT, sev, format, args);
 }
 
-int uxkb_desc_init(struct input *input, const char *model, const char *layout, const char *variant,
-		   const char *options, const char *locale, const char *keymap,
-		   const char *compose_file, size_t compose_file_len)
+int uxkb_layout_init(struct input *input, const char *model, const char *layout,
+		     const char *variant, const char *options, const char *keymap)
 {
-	int ret;
+	int ret = 0;
 	struct xkb_rule_names rmlvo = {
 		.rules = "evdev",
 		.model = model,
@@ -140,7 +139,15 @@ int uxkb_desc_init(struct input *input, const char *model, const char *layout, c
 		log_debug("new keyboard description (%s, %s, %s, %s)", model, layout, variant,
 			  options);
 	}
+	return 0;
+err_ctx:
+	xkb_context_unref(input->ctx);
+	return ret;
+}
 
+void uxkb_compose_table_init(struct input *input, const char *compose_file, size_t compose_file_len,
+			     const char *locale)
+{
 	if (compose_file && *compose_file) {
 		input->compose_table = xkb_compose_table_new_from_buffer(
 			input->ctx, compose_file, compose_file_len, locale,
@@ -161,19 +168,20 @@ int uxkb_desc_init(struct input *input, const char *model, const char *layout, c
 				 "table, disabling compose support");
 		}
 	}
-
-	return 0;
-
-err_ctx:
-	xkb_context_unref(input->ctx);
-	return ret;
 }
 
-void uxkb_desc_destroy(struct input *input)
+void uxkb_compose_table_destroy(struct input *input)
 {
 	xkb_compose_table_unref(input->compose_table);
+	input->compose_table = NULL;
+}
+
+void uxkb_layout_destroy(struct input *input)
+{
 	xkb_keymap_unref(input->keymap);
 	xkb_context_unref(input->ctx);
+	input->keymap = NULL;
+	input->ctx = NULL;
 }
 
 static void timer_event(struct ev_timer *timer, uint64_t num, void *data)
@@ -218,6 +226,9 @@ void uxkb_dev_destroy(struct input_dev *dev)
 	xkb_compose_state_unref(dev->compose_state);
 	xkb_state_unref(dev->state);
 	ev_eloop_rm_timer(dev->repeat_timer);
+	dev->compose_state = NULL;
+	dev->state = NULL;
+	dev->repeat_timer = NULL;
 }
 
 #define EVDEV_KEYCODE_OFFSET 8

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -736,12 +736,12 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_BOOL(0, "bell", &conf->bell, false),
 
 		/* Input Options */
-		CONF_OPTION_STRING(0, "xkb-model", &conf->xkb_model, ""),
-		CONF_OPTION_STRING(0, "xkb-layout", &conf->xkb_layout, ""),
-		CONF_OPTION_STRING(0, "xkb-variant", &conf->xkb_variant, ""),
-		CONF_OPTION_STRING(0, "xkb-options", &conf->xkb_options, ""),
-		CONF_OPTION_STRING(0, "xkb-keymap", &conf->xkb_keymap, ""),
-		CONF_OPTION_STRING(0, "xkb-compose-file", &conf->xkb_compose_file, ""),
+		CONF_OPTION_STRING(0, "xkb-model", &conf->xkb_model, NULL),
+		CONF_OPTION_STRING(0, "xkb-layout", &conf->xkb_layout, NULL),
+		CONF_OPTION_STRING(0, "xkb-variant", &conf->xkb_variant, NULL),
+		CONF_OPTION_STRING(0, "xkb-options", &conf->xkb_options, NULL),
+		CONF_OPTION_STRING(0, "xkb-keymap", &conf->xkb_keymap, NULL),
+		CONF_OPTION_STRING(0, "xkb-compose-file", &conf->xkb_compose_file, NULL),
 		CONF_OPTION_UINT(0, "xkb-repeat-delay", &conf->xkb_repeat_delay, 250),
 		CONF_OPTION_UINT(0, "xkb-repeat-rate", &conf->xkb_repeat_rate, 50),
 		CONF_OPTION_BOOL(0, "mouse", &conf->mouse, true),

--- a/src/kmscon_main.c
+++ b/src/kmscon_main.c
@@ -52,6 +52,7 @@ struct kmscon_app {
 	struct conf_ctx *seat_ctx;
 	struct kmscon_conf_t *seat_conf;
 	struct kmscon_seat *seat;
+	struct kmscon_dbus *dbus;
 };
 
 static int app_seat_event(struct kmscon_seat *s, unsigned int event, void *data)
@@ -115,6 +116,30 @@ static void destroy_app(struct kmscon_app *app)
 	ev_eloop_unregister_signal_cb(app->eloop, SIGINT, app_sig_generic, app);
 	ev_eloop_unregister_signal_cb(app->eloop, SIGTERM, app_sig_generic, app);
 	ev_eloop_unref(app->eloop);
+	kmscon_dbus_free(app->dbus);
+}
+
+static void update_xkb_layout(const char *model, const char *layout, const char *variant,
+			      const char *options, void *data)
+{
+	struct kmscon_app *app = data;
+
+	log_debug("updating xkb layout: %s, %s, %s, %s", model, layout, variant, options);
+	if (kmscon_seat_update_xkb_layout(app->seat, model, layout, variant, options))
+		log_error("cannot update xkb layout");
+}
+
+static void listen_to_dbus_locale1(struct kmscon_app *app)
+{
+	int ret;
+
+	if (app->conf->xkb_keymap || app->conf->xkb_model || app->conf->xkb_layout ||
+	    app->conf->xkb_variant || app->conf->xkb_options)
+		return;
+
+	ret = kmscon_dbus_listen_locale1(app->dbus, update_xkb_layout, app);
+	if (ret)
+		log_warning("cannot listen to locale1: %d", ret);
 }
 
 static int setup_app(struct kmscon_app *app)
@@ -145,6 +170,11 @@ static int setup_app(struct kmscon_app *app)
 		goto err_app;
 	}
 
+	app->dbus = kmscon_dbus_new(app->eloop);
+	if (app->dbus) {
+		kmscon_dbus_set_xkb_env_from_locale1(app->dbus);
+		listen_to_dbus_locale1(app);
+	}
 	return 0;
 
 err_app:
@@ -174,7 +204,6 @@ int main(int argc, char **argv)
 		kmscon_conf_free(conf_ctx);
 		return 0;
 	}
-	dbus_set_xkb_env_from_locale();
 
 	kmscon_load_modules();
 	kmscon_font_register(&kmscon_font_8x16_ops);

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -640,6 +640,21 @@ static void kmscon_seat_set_compose(struct kmscon_seat *seat)
 	input_set_compose(seat->input, locale, compose_file, compose_file_len);
 }
 
+int kmscon_seat_update_xkb_layout(struct kmscon_seat *seat, const char *model, const char *layout,
+				  const char *variant, const char *options)
+{
+	int ret;
+
+	ret = input_update_keymap(seat->input, model, layout, variant, options);
+	if (ret) {
+		log_error("cannot update keymap: %d", ret);
+		return ret;
+	}
+	/* Compose table is lost when updating the keymap, so we need to set it again */
+	kmscon_seat_set_compose(seat);
+	return ret;
+}
+
 static void kmscon_seat_add_input(struct kmscon_seat *seat, struct uterm_monitor_dev *udev,
 				  const char *node)
 {

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -595,12 +595,9 @@ static const char *find_locale(void)
 
 static int kmscon_seat_set_keymap(struct kmscon_seat *seat)
 {
-	const char *locale;
-	char *keymap, *compose_file;
-	size_t compose_file_len;
-	int ret;
 
-	locale = find_locale();
+	char *keymap;
+	int ret;
 
 	/* TODO: The XKB-API currently requires zero-terminated strings as
 	 * keymap input. Hence, we have to read it in instead of using mmap().
@@ -612,22 +609,35 @@ static int kmscon_seat_set_keymap(struct kmscon_seat *seat)
 			log_error("cannot read keymap file %s: %d", seat->conf->xkb_keymap, ret);
 	}
 
-	compose_file = NULL;
-	compose_file_len = 0;
-	if (seat->conf->xkb_compose_file && *seat->conf->xkb_compose_file) {
-		ret = shl_read_file(seat->conf->xkb_compose_file, &compose_file, &compose_file_len);
-		if (ret)
-			log_error("cannot read compose file %s: %d", seat->conf->xkb_compose_file,
-				  ret);
-	}
 	ret = input_set_keymap(seat->input, seat->conf->xkb_model, seat->conf->xkb_layout,
-			       seat->conf->xkb_variant, seat->conf->xkb_options, locale, keymap,
-			       compose_file, compose_file_len);
+			       seat->conf->xkb_variant, seat->conf->xkb_options, keymap);
 	if (ret)
 		log_error("cannot set keymap: %d", ret);
 
 	free(keymap);
 	return ret;
+}
+
+static void kmscon_seat_set_compose(struct kmscon_seat *seat)
+{
+	const char *locale;
+	char *compose_file;
+	size_t compose_file_len;
+	int ret;
+
+	locale = find_locale();
+
+	compose_file = NULL;
+	compose_file_len = 0;
+	if (seat->conf->xkb_compose_file && *seat->conf->xkb_compose_file) {
+		ret = shl_read_file(seat->conf->xkb_compose_file, &compose_file, &compose_file_len);
+		if (ret) {
+			log_error("cannot read compose file %s: %d", seat->conf->xkb_compose_file,
+				  ret);
+			return;
+		}
+	}
+	input_set_compose(seat->input, locale, compose_file, compose_file_len);
 }
 
 static void kmscon_seat_add_input(struct kmscon_seat *seat, struct uterm_monitor_dev *udev,
@@ -758,6 +768,8 @@ int kmscon_seat_new(struct kmscon_seat **out, struct conf_ctx *main_conf,
 	ret = kmscon_seat_set_keymap(seat);
 	if (ret)
 		goto err_conf;
+
+	kmscon_seat_set_compose(seat);
 
 	ret = uterm_monitor_new(&seat->mon, seat->eloop, &seat_monitor_cb, seat);
 	if (ret) {

--- a/src/kmscon_seat.h
+++ b/src/kmscon_seat.h
@@ -53,6 +53,8 @@ int kmscon_seat_new(struct kmscon_seat **out, struct conf_ctx *main_conf,
 		    void *data);
 void kmscon_seat_free(struct kmscon_seat *seat);
 void kmscon_seat_startup(struct kmscon_seat *seat);
+int kmscon_seat_update_xkb_layout(struct kmscon_seat *seat, const char *model, const char *layout,
+				  const char *variant, const char *options);
 
 struct conf_ctx *kmscon_seat_get_conf(struct kmscon_seat *seat);
 

--- a/tests/test_input.c
+++ b/tests/test_input.c
@@ -128,11 +128,12 @@ static void setup_input(struct uterm_monitor *mon)
 	if (ret)
 		return;
 	ret = input_set_keymap(input, input_conf.xkb_model, input_conf.xkb_layout,
-			       input_conf.xkb_variant, input_conf.xkb_options, input_conf.locale,
-			       input_conf.xkb_keymap, input_conf.xkb_compose_file,
-			       compose_file_len);
+			       input_conf.xkb_variant, input_conf.xkb_options,
+			       input_conf.xkb_keymap);
 	if (ret)
 		return;
+
+	input_set_compose(input, input_conf.locale, compose_file, compose_file_len);
 	input_set_conf(input, 250, 50, true);
 	ret = input_register_key_cb(input, input_arrived, NULL);
 	if (ret)


### PR DESCRIPTION
dbus: Listen to locale1 property changes

And update the keyboard layout accordingly.

Don't listen to locale1 property changes if the keyboard layout was
set in the config file or in command line argument.

This allows to use `localectl set-keymap` to change the keyboard
layout at runtime.
One difference from "loadkeys" is that this is a system-wide setting,
and that it will affect all kmscon instance on all tty.
    
