### PR TITLE
Remove trailing blank line in kmsconvt@.service.in

### DIFF
--- a/scripts/systemd/kmsconvt@.service.in
+++ b/scripts/systemd/kmsconvt@.service.in
@@ -48,6 +48,5 @@ TTYVTDisallocate=yes
 
 [Install]
 Alias=autovt@.service
-
 WantedBy=getty.target
 DefaultInstance=tty1


### PR DESCRIPTION
Remove the empty line at kmsconvt@.service.in#L51.
MINOR, just cosmetics and a bit readability: kmsconvt@.service.in#L51 is an empty line which I finds a bit disturbing.