### PR TITLE
seat: Fix seat startup in background

### DIFF
--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -1101,8 +1101,6 @@ void kmscon_seat_startup(struct kmscon_seat *seat)
 	if (!seat)
 		return;
 
-	seat_go_awake(seat);
-
 	s = kmscon_seat_new_session(seat);
 	if (s)
 		seat_switch(seat, s);


### PR DESCRIPTION
If VT 2 is active, and you run systemctl restart kmsconvt@tty3

Then the session will try to directly take the GPU, and fails. So don't awake the seat on startup, but wait for the tty be be activated.

Fix: 0dffbd7 session: Simplify session management