### PR TITLE
pty: Add --oneshot argument.

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -215,6 +215,14 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--oneshot</option></term>
+        <listitem>
+          <para>When the login process exits, exit kmscon. This is useful for
+                setup scripts, or asking for disk encryption. (default: off)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>-t {term}</option></term>
         <term><option>--term {term}</option></term>
         <listitem>

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -95,6 +95,11 @@ static void print_help()
 		"\t                              argv to this process. No more options\n"
 		"\t                              after '--' will be parsed so use it at\n"
 		"\t                              the end of the argument string\n"
+		"\t    --oneshot                [off]\n"
+		"\t                              When the login process exits, exit kmscon\n"
+		"\t                              This is useful for setup scripts, or asking\n"
+		"\t                              for disk encryption.\n"
+		"\t                              (default: off)\n"
 		"\t-t, --term <TERM>           [" BUILD_DEFAULT_TERM "]\n"
 		"\t                              Value of the TERM environment variable\n"
 		"\t                              for the child process\n"
@@ -729,6 +734,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_STRING(0, "issue-path", &conf->issue_path, ISSUE_DEFAULT_PATH),
 		CONF_OPTION(0, 'l', "login", &conf_login, aftercheck_login, NULL, file_login,
 			    &conf->login, false),
+		CONF_OPTION_BOOL(0, "oneshot", &conf->oneshot, false),
 		CONF_OPTION_STRING('t', "term", &conf->term, BUILD_DEFAULT_TERM),
 		CONF_OPTION_BOOL(0, "reset-env", &conf->reset_env, true),
 		CONF_OPTION_BOOL(0, "backspace-delete", &conf->backspace_delete, true),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -89,6 +89,8 @@ struct kmscon_conf_t {
 	bool login;
 	/* argv for login process */
 	char **argv;
+	/* when the login process exits, exit kmscon */
+	bool oneshot;
 	/* TERM value */
 	char *term;
 	/* reset environment */

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -265,6 +265,8 @@ static void seat_switch(struct kmscon_seat *seat, struct kmscon_session *new)
 			seat_go_background(seat);
 		}
 		terminal_activate(new->term);
+	} else {
+		seat_go_background(seat);
 	}
 	seat->current_sess = new;
 }

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -1126,13 +1126,24 @@ static void pty_input(struct kmscon_pty *pty, const char *u8, size_t len, void *
 {
 	struct kmscon_terminal *term = data;
 
-	if (!len) {
-		terminal_close(term);
-		terminal_open(term);
-	} else {
+	if (len) {
 		tsm_vte_input(term->vte, u8, len);
 		redraw_all(term);
 	}
+}
+
+static void pty_exit(struct kmscon_pty *pty, bool restart, void *data)
+{
+	struct kmscon_terminal *term = data;
+
+	terminal_close(term);
+
+	if (restart) {
+		terminal_open(term);
+		return;
+	}
+
+	ev_eloop_exit(term->eloop);
 }
 
 static void pty_event(struct ev_fd *fd, int mask, void *data)
@@ -1201,13 +1212,13 @@ struct kmscon_terminal *terminal_new(struct kmscon_session *session, unsigned in
 	if (ret)
 		goto err_vte;
 
-	ret = kmscon_pty_new(&term->pty, pty_input, term);
+	ret = kmscon_pty_new(&term->pty, pty_input, pty_exit, term);
 	if (ret)
 		goto err_font;
 
 	ret = kmscon_pty_set_conf(term->pty, term->conf->term, "truecolor", term->conf->argv,
 				  seat_name, vtnr, term->conf->reset_env,
-				  term->conf->backspace_delete);
+				  term->conf->backspace_delete, term->conf->oneshot);
 	if (ret)
 		goto err_pty;
 

--- a/src/pty.c
+++ b/src/pty.c
@@ -61,6 +61,7 @@ struct kmscon_pty {
 	char io_buf[KMSCON_NREAD];
 
 	kmscon_pty_input_cb input_cb;
+	kmscon_pty_exit_cb exit_cb;
 	void *data;
 
 	char *term;
@@ -70,12 +71,14 @@ struct kmscon_pty {
 	char *vtnr;
 	bool env_reset;
 	bool backspace_delete;
+	bool oneshot;
 
 	time_t last_spawn_time;
 	int retry_count;
 };
 
-int kmscon_pty_new(struct kmscon_pty **out, kmscon_pty_input_cb input_cb, void *data)
+int kmscon_pty_new(struct kmscon_pty **out, kmscon_pty_input_cb input_cb,
+		   kmscon_pty_exit_cb exit_cb, void *data)
 {
 	struct kmscon_pty *pty;
 	int ret;
@@ -91,6 +94,7 @@ int kmscon_pty_new(struct kmscon_pty **out, kmscon_pty_input_cb input_cb, void *
 	pty->fd = -1;
 	pty->ref = 1;
 	pty->input_cb = input_cb;
+	pty->exit_cb = exit_cb;
 	pty->last_spawn_time = time(NULL);
 	pty->retry_count = 0;
 	pty->data = data;
@@ -141,7 +145,7 @@ void kmscon_pty_unref(struct kmscon_pty *pty)
 
 int kmscon_pty_set_conf(struct kmscon_pty *pty, const char *term, const char *colorterm,
 			char **argv, const char *seat, unsigned int vtnr, bool do_reset,
-			bool backspace)
+			bool backspace, bool oneshot)
 {
 	char *vt;
 
@@ -150,6 +154,7 @@ int kmscon_pty_set_conf(struct kmscon_pty *pty, const char *term, const char *co
 
 	pty->env_reset = do_reset;
 	pty->backspace_delete = backspace;
+	pty->oneshot = oneshot;
 
 	if (term) {
 		pty->term = strdup(term);
@@ -485,7 +490,14 @@ static void sig_child(struct ev_eloop *eloop, struct ev_child_data *chld, void *
 	log_info("child exited: pid: %u status: %d", chld->pid, chld->status);
 
 	if (pty->retry_count == MAX_RETRY_COUNT) {
-		log_err("reached max retry attempts for login process");
+		log_err("reached max retry attempts for login process %d retries in %d seconds",
+			MAX_RETRY_COUNT, MAX_RETRY_TIME);
+		pty->exit_cb(pty, false, pty->data);
+		return;
+	}
+	if (pty->oneshot) {
+		log_info("oneshot is enabled, exiting kmscon...");
+		pty->exit_cb(pty, false, pty->data);
 		return;
 	}
 
@@ -497,8 +509,7 @@ static void sig_child(struct ev_eloop *eloop, struct ev_child_data *chld, void *
 	} else {
 		pty->retry_count = 0;
 	}
-
-	pty->input_cb(pty, NULL, 0, pty->data);
+	pty->exit_cb(pty, true, pty->data);
 }
 
 int kmscon_pty_open(struct kmscon_pty *pty, unsigned short width, unsigned short height, bool drm)

--- a/src/pty.h
+++ b/src/pty.h
@@ -48,13 +48,15 @@
 struct kmscon_pty;
 
 typedef void (*kmscon_pty_input_cb)(struct kmscon_pty *pty, const char *u8, size_t len, void *data);
+typedef void (*kmscon_pty_exit_cb)(struct kmscon_pty *pty, bool restart, void *data);
 
-int kmscon_pty_new(struct kmscon_pty **out, kmscon_pty_input_cb input_cb, void *data);
+int kmscon_pty_new(struct kmscon_pty **out, kmscon_pty_input_cb input_cb,
+		   kmscon_pty_exit_cb exit_cb, void *data);
 void kmscon_pty_ref(struct kmscon_pty *pty);
 void kmscon_pty_unref(struct kmscon_pty *pty);
 int kmscon_pty_set_conf(struct kmscon_pty *pty, const char *term, const char *colorterm,
 			char **argv, const char *seat, unsigned int vtnr, bool do_reset,
-			bool backspace);
+			bool backspace, bool oneshot);
 
 int kmscon_pty_get_fd(struct kmscon_pty *pty);
 void kmscon_pty_dispatch(struct kmscon_pty *pty);


### PR DESCRIPTION
Exit kmscon when the login process exits. This is useful for setup scripts, or asking for disk encryption password in a bash script.