### PR TITLE
font: Use U+25a1 character when a glyph is not present

### DIFF
--- a/src/font/font.c
+++ b/src/font/font.c
@@ -281,7 +281,7 @@ struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, uint64_t id, c
 					size_t len)
 {
 	uint32_t empty_char = ' ';
-	uint32_t replacement_char = 0xfffd;
+	uint32_t replacement_char = 0x25a1;
 	uint32_t invalid_char = '?';
 	struct kmscon_glyph *glyph;
 

--- a/src/font/font_8x16.c
+++ b/src/font/font_8x16.c
@@ -116,14 +116,8 @@ static bool kmscon_font_8x16_has_glyph(struct kmscon_font *font, const uint32_t 
 static struct kmscon_glyph *kmscon_font_8x16_render(struct kmscon_font *font, uint64_t id,
 						    const uint32_t *ch, size_t len)
 {
-	uint32_t c = *ch;
-
-	// Handle replacement character
-	if (c == 0xfffd)
-		c = '?';
-
 	if (len > 1 || *ch >= 256)
-		return NULL;
+		return new_glyph('?');
 
 	return new_glyph(*ch);
 }

--- a/src/render/bbulk.c
+++ b/src/render/bbulk.c
@@ -295,7 +295,7 @@ static struct kmscon_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, con
 	struct bbulk *bb = txt->data;
 	struct kmscon_glyph *glyph;
 	struct kmscon_font *font = txt->font;
-	const uint32_t replacement_char = 0xfffd;
+	const uint32_t replacement_char = 0x25a1;
 
 	font->attr.underline = !!attr->underline;
 	font->attr.italic = !!attr->italic;

--- a/src/render/gltex.c
+++ b/src/render/gltex.c
@@ -419,7 +419,7 @@ static struct gl_glyph *find_glyph(struct kmscon_text *txt, uint64_t id, const u
 	const uint8_t *src;
 	struct kmscon_font *font = txt->font;
 	unsigned int num;
-	const uint32_t replacement_char = 0xfffd;
+	const uint32_t replacement_char = 0x25a1;
 	struct kmscon_glyph *glyph;
 
 	font->attr.underline = !!attr->underline;


### PR DESCRIPTION
This is what the unicode standard requires.
Also this character is single width in all fonts I have tested. U+fffd is wide on some font.