### PR TITLE
freetype: center the glyph if it is bigger

### DIFF
--- a/src/font/font_freetype.c
+++ b/src/font/font_freetype.c
@@ -348,6 +348,9 @@ static void copy_glyph(struct video_buffer *buf, FT_Face face, FT_Bitmap *map, b
 	}
 	height = min((int)(buf->height - top), (int)(map->rows - top_src));
 
+	if (left + map->width > buf->width)
+		left -= ((left + map->width) - buf->width) / 2;
+
 	if (left < 0) {
 		left_src = -left;
 		left = 0;


### PR DESCRIPTION
Center the glyph horizontally if it is bigger than the cell width.