### PR TITLE
terminal: Add blink support

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -99,7 +99,12 @@ struct kmscon_terminal {
 	struct kmscon_font *font;
 
 	struct kmscon_pointer pointer;
+
+	struct ev_timer *blink_timer;
+	bool blinking;
 };
+
+#define BLINK_TIMER_NS (500 * 1000 * 1000)
 
 static int font_set(struct kmscon_terminal *term);
 
@@ -302,7 +307,7 @@ static void do_redraw_screen(struct screen *scr)
 	scr->pending = false;
 
 	tsm_vte_get_def_attr(scr->term->vte, &attr);
-	kmscon_text_prepare(scr->txt, &attr);
+	kmscon_text_prepare(scr->txt, &attr, scr->term->blinking);
 	kmscon_text_draw(scr->txt, scr->term->console);
 	draw_pointer(scr);
 	kmscon_text_render(scr->txt);
@@ -422,6 +427,17 @@ static void display_pageflip(void *unused, void *unused2, void *data)
 	scr->swapping = false;
 	if (scr->pending)
 		do_redraw_screen(scr);
+}
+
+static void blink_event(struct ev_timer *timer, uint64_t count, void *data)
+{
+	struct kmscon_terminal *term = data;
+
+	if (!term->awake)
+		return;
+
+	term->blinking = !term->blinking;
+	redraw_all(term);
 }
 
 static void osc_event(struct tsm_vte *vte, const char *osc_string, size_t osc_len, void *data)
@@ -1090,6 +1106,7 @@ void terminal_refresh_displays(struct kmscon_terminal *term)
 void terminal_activate(struct kmscon_terminal *term)
 {
 	term->awake = true;
+	ev_timer_enable(term->blink_timer);
 	if (!term->opened)
 		terminal_open(term);
 	if (term->pointer.visible)
@@ -1101,6 +1118,7 @@ void terminal_deactivate(struct kmscon_terminal *term)
 {
 	term->awake = false;
 	hw_cursor_hide(term);
+	ev_timer_disable(term->blink_timer);
 }
 
 void terminal_destroy(struct kmscon_terminal *term)
@@ -1109,6 +1127,7 @@ void terminal_destroy(struct kmscon_terminal *term)
 
 	terminal_close(term);
 	rm_all_screens(term);
+	ev_eloop_rm_timer(term->blink_timer);
 	input_unregister_pointer_cb(term->input, pointer_event, term);
 	input_unregister_key_cb(term->input, input_event, term);
 	ev_eloop_rm_fd(term->ptyfd);
@@ -1165,6 +1184,10 @@ struct kmscon_terminal *terminal_new(struct kmscon_session *session, unsigned in
 				     struct input *input, const char *seat_name)
 {
 	struct kmscon_terminal *term;
+	struct itimerspec blink_interval = {
+		.it_interval = {0, BLINK_TIMER_NS},
+		.it_value = {0, BLINK_TIMER_NS},
+	};
 	int ret;
 
 	term = malloc(sizeof(*term));
@@ -1236,12 +1259,18 @@ struct kmscon_terminal *terminal_new(struct kmscon_session *session, unsigned in
 		if (ret)
 			goto err_input;
 	}
+	ret = ev_eloop_new_timer(term->eloop, &term->blink_timer, &blink_interval, blink_event,
+				 term);
+	if (ret)
+		goto err_pointer;
 
 	ev_eloop_ref(term->eloop);
 	input_ref(term->input);
 	log_debug("new terminal object %p", term);
 	return term;
 
+err_pointer:
+	input_unregister_pointer_cb(term->input, pointer_event, term);
 err_input:
 	input_unregister_key_cb(term->input, input_event, term);
 err_ptyfd:

--- a/src/render/bbulk.c
+++ b/src/render/bbulk.c
@@ -296,19 +296,17 @@ static struct kmscon_glyph *find_glyph(struct kmscon_text *txt, const struct tsm
 	struct bbulk *bb = txt->data;
 	struct kmscon_glyph *glyph;
 	struct kmscon_font *font = txt->font;
-
-	const uint32_t replacement_char = 0x25a1;
 	uint32_t ch = cell->ch ? cell->ch : ' ';
-	uint64_t id = kmscon_glyph_id(cell->ch, cell->attr2.u8);
+	uint64_t id;
 
 	font->attr.underline = !!cell->attr2.underline;
 	font->attr.italic = !!cell->attr2.italic;
 	font->attr.bold = !!cell->attr2.bold;
 
-	if (!kmscon_font_has_glyph(font, ch)) {
-		ch = replacement_char;
-		id = kmscon_glyph_id(ch, cell->attr2.u8);
-	}
+	if (!kmscon_font_has_glyph(font, ch))
+		ch = 0x25a1;
+
+	id = kmscon_glyph_id(cell->ch, cell->attr2.u8);
 
 	glyph = shl_lru_get(bb->glyphs, id);
 	if (glyph)
@@ -409,7 +407,7 @@ static int bbulk_draw_cell(struct kmscon_text *txt, const struct tsm_screen_cell
 
 	*cur_cell = *cell;
 
-	glyph = find_glyph(txt, cell);
+	glyph = find_glyph(txt, cur_cell);
 	if (!glyph)
 		return -ENOMEM;
 
@@ -432,34 +430,28 @@ static int bbulk_draw_cell(struct kmscon_text *txt, const struct tsm_screen_cell
 		set_coordinate(txt, &req->x, &req->y, posx, posy);
 
 	req->buf = &glyph->buf;
-	set_color(req, cell);
+	set_color(req, cur_cell);
 	return 0;
-}
-
-static int bbulk_draw_cursor(struct kmscon_text *txt, const struct tsm_screen_cell *cell,
-			     unsigned int cur_x, unsigned int cur_y)
-{
-	struct tsm_screen_cell cursor_cell = *cell;
-
-	cursor_cell.fg = cell->bg;
-	cursor_cell.bg = cell->fg;
-
-	return bbulk_draw_cell(txt, &cursor_cell, cur_x, cur_y);
 }
 
 static int bbulk_draw(struct kmscon_text *txt, const struct tsm_screen_cell *cells,
 		      unsigned int cur_x, unsigned int cur_y, bool cur_visible)
 {
 	unsigned int posx, posy;
+	struct tsm_screen_cell cell;
 
 	for (posy = 0; posy < txt->rows; posy++) {
 		for (posx = 0; posx < txt->cols; posx++) {
-			const struct tsm_screen_cell *cell = &cells[posx + posy * txt->cols];
-
-			if (posx == cur_x && posy == cur_y && cur_visible)
-				bbulk_draw_cursor(txt, cell, cur_x, cur_y);
-			else
-				bbulk_draw_cell(txt, cell, posx, posy);
+			cell = cells[posx + posy * txt->cols];
+			if (posx == cur_x && posy == cur_y && cur_visible) {
+				struct tsm_screen_color tmp;
+				tmp = cell.fg;
+				cell.fg = cell.bg;
+				cell.bg = tmp;
+			} else if (cell.attr2.blink && txt->blinking) {
+				cell.ch = ' ';
+			}
+			bbulk_draw_cell(txt, &cell, posx, posy);
 		}
 	}
 	return 0;
@@ -658,7 +650,7 @@ static int bbulk_render(struct kmscon_text *txt)
 	int ret;
 
 	ret = display_blendv(txt->disp, bb->reqs, bb->req_len);
-	// log_debug("bbulk, redraw %d cells", bb->req_len);
+	log_debug("bbulk, redraw %d cells", bb->req_len);
 	if (display_supports_damage(txt->disp)) {
 		bbulk_compute_damage(txt);
 		display_set_damage(txt->disp, bb->damage_rect_len, bb->damage_rects);

--- a/src/render/gltex.c
+++ b/src/render/gltex.c
@@ -420,16 +420,19 @@ static struct gl_glyph *find_glyph(struct kmscon_text *txt, const struct tsm_scr
 	unsigned int num;
 	struct kmscon_glyph *glyph;
 	uint32_t ch = cell->ch ? cell->ch : ' ';
-	uint64_t id = kmscon_glyph_id(ch, cell->attr2.u8);
+	uint64_t id;
 
 	font->attr.underline = !!cell->attr2.underline;
 	font->attr.italic = !!cell->attr2.italic;
 	font->attr.bold = !!cell->attr2.bold;
 
-	if (!kmscon_font_has_glyph(font, ch)) {
+	if (cell->attr2.blink && txt->blinking)
+		ch = ' ';
+
+	if (!kmscon_font_has_glyph(font, ch))
 		ch = 0x25a1;
-		id = kmscon_glyph_id(ch, cell->attr2.u8);
-	}
+
+	id = kmscon_glyph_id(ch, cell->attr2.u8);
 
 	if (shl_hashtable_find(gt->glyphs, (void **)&glglyph, id))
 		return glglyph;

--- a/src/render/text.c
+++ b/src/render/text.c
@@ -412,7 +412,7 @@ int kmscon_text_rotate(struct kmscon_text *txt, enum Orientation orientation)
  *
  * Returns: 0 on success, negative error code on failure.
  */
-int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr)
+int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr, bool blinking)
 {
 	int ret = 0;
 
@@ -420,6 +420,7 @@ int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr)
 		return -EINVAL;
 
 	txt->rendering = true;
+	txt->blinking = blinking;
 	if (txt->ops->prepare)
 		ret = txt->ops->prepare(txt, attr);
 	if (ret)
@@ -451,7 +452,7 @@ int kmscon_text_draw(struct kmscon_text *txt, struct tsm_screen *con)
 	cur_y = tsm_screen_get_cursor_y(con);
 	cur_visible = !(tsm_screen_get_flags(con) & TSM_SCREEN_HIDE_CURSOR);
 
-	return txt->ops->draw(txt, cells, cur_x, cur_y, cur_visible);
+	return txt->ops->draw(txt, cells, cur_x, cur_y, cur_visible && txt->blinking);
 }
 
 /**

--- a/src/render/text.h
+++ b/src/render/text.h
@@ -66,6 +66,7 @@ struct kmscon_text {
 	unsigned int max_rows;
 	bool rendering;
 	enum Orientation orientation;
+	bool blinking;
 };
 
 struct kmscon_text_ops {
@@ -104,7 +105,7 @@ enum Orientation kmscon_text_get_orientation(struct kmscon_text *txt);
 void kmscon_text_resize(struct kmscon_text *txt, unsigned int cols, unsigned int rows);
 int kmscon_text_rotate(struct kmscon_text *txt, enum Orientation orientation);
 
-int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr);
+int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr, bool blinking);
 int kmscon_text_draw(struct kmscon_text *txt, struct tsm_screen *con);
 int kmscon_text_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned int y);
 int kmscon_text_render(struct kmscon_text *txt);


### PR DESCRIPTION
Add support for blinking cursor, and blinking text. You can test it with:
printf '\e[5mTest\e[0m\n'

Fix #229 