### PR TITLE
input: ignore button repeat and other event

### DIFF
--- a/src/input/input_pointer.c
+++ b/src/input/input_pointer.c
@@ -180,6 +180,10 @@ void pointer_dev_button(struct input_dev *dev, uint16_t code, int32_t value)
 	bool pressed = (value == 1);
 	bool dbl_click = false;
 
+	/* Only handle press and release events */
+	if (value > 1)
+		return;
+
 	switch (code) {
 	case BTN_LEFT:
 		if (pressed) {


### PR DESCRIPTION
Input only handle button press and button release. Ignore all other events, as they were incorrectly interpreted as button release.

Fix #433 
