### PR TITLE
terminfo: update with fixes from ncurses

### DIFF
--- a/scripts/terminfo/kmscon.ti
+++ b/scripts/terminfo/kmscon.ti
@@ -1,61 +1,47 @@
-# kmscon terminal emulator description
+# Name        : kmscon
+# Version     : 10.0.0
+# Kmscon is a simple terminal emulator based on linux kernel mode setting (KMS).
+# It is an attempt to replace the in-kernel VT implementation with a userspace
+# console.
+#
+# The terminal emulation is implemented in a related libtsm.
+#
+# vttest:
+# - identifies as a VT220 (according to secondary DA), but uses nonstandard
+#   primary DA
+#     \E[?60;1;6;9;15c
+#   i.e. (60 is nonstandard), and the features are
+#     1 = 132 columns
+#     6 = selective erase
+#     9 = national replacement character-sets
+#     15 = DEC technical set
+#   but it actually supports none of those features.
+# - supports VT100 line-drawing
+# - does not support DECALN, failing the ECH and alternate-screen tests.
+# - supports X10 and X11 normal mouse events
+# - supports CBT, CHA, CHT, VPA, CNL, CPL, VPR but not HPA, HPR
+# - implements REP in a nonstandard manner
+# - supports SD and SU
+# - freezes console on SL; does not implement SR
 kmscon|KMS Console,
-  am, bce, km, mir, msgr,
-  colors#256, pairs#32767,
-  cols#80, lines#24,
-
-# Character Set Mapping (VT100 style)
-  acsc=``aaffggiijjkkllmmnnooppqqrrssttuuvvwwxxyyzz{{||}}~~,
-# Basic Controls
-  bel=^G, cr=\r, cud1=\n, ht=^I, ind=\n,
-
-# Cursor Movement
-  cub1=^H, cuf1=\E[C, cuu1=\E[A,
-  cub=\E[%p1%dD, cud=\E[%p1%dB, cuf=\E[%p1%dC, cuu=\E[%p1%dA,
-  cup=\E[%i%p1%d;%p2%dH, home=\E[H,
-  hpa=\E[%i%p1%dG, vpa=\E[%i%p1%dd,
-
-# Erasure
-  clear=\E[H\E[2J, ed=\E[J, el=\E[K, el1=\E[1K,
-  ech=\E[%p1%dX,
-
-# Insert/Delete
-  dch1=\E[P, dch=\E[%p1%dP,
-  dl1=\E[M, dl=\E[%p1%dM,
-  ch1=\E[@, ich=\E[%p1%d@,
-  il1=\E[L, il=\E[%p1%dL,
-
-# Rendition (SGR)
-  sgr=%?%p9%t\E(0%e\E(B%;\E[0%?%p6%t;1%;%?%p5%t;2%;%?%p2%t;4%;%?%p1%p3%|%t;7%;%?%p4%t;5%;%?%p7%t;8%;m,
-  sgr0=\E(B\E[m, bold=\E[1m, smul=\E[4m,
-  rev=\E[7m, smso=\E[7m, rmso=\E[27m,
-  rmul=\E[24m, smacs=\E(0, rmacs=\E(B,
-
-# Color Support (xterm-256color style)
-  setab=\E[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48;5;%p1%d%;m,
-  setaf=\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m,
-  op=\E[39;49m,
-
-# Scrolling and Margins
-  csr=\E[%i%p1%d;%p2%dr,
-  indn=\E[%p1%dS, rin=\E[%p1%dT,
-  ri=\EM,
-
-# Alternate Buffer
-  smcup=\E[?1049h, rmcup=\E[?1049l,
-
-# Cursor Visibility
-  civis=\E[?25l, cnorm=\E[?25h,
-
-# Input Keys
-  kbs=^H, kcub1=\E[D, kcud1=\E[B,
-  kcuf1=\E[C, kcuu1=\E[A,
-  khome=\E[H, kend=\E[F, knp=\E[6~, kpp=\E[5~,
-  kich1=\E[2~, kdch1=\E[3~,
-  kf1=\EOP, kf2=\EOQ, kf3=\EOR, kf4=\EOS,
-  kf5=\E[15~, kf6=\E[17~, kf7=\E[18~, kf8=\E[19~,
-  kf9=\E[20~, kf10=\E[21~, kf11=\E[23~, kf12=\E[24~,
-
-# Miscellaneous
-  sc=\E7, rc=\E8, rs2=\Ec, tbc=\E[3g, hts=\EH, 
-  rep=%p1%c\E[%p2%{1}%-%db,
+        am, bce, km, mir, msgr, npc, xenl,
+        cols#80, lines#24, pairs#0x7fff,
+        acsc=``aaffggiijjkkllmmnnooppqqrrssttuuvvwwxxyyzz{{||}}~~,
+        bel=^G, bold=\E[1m, civis=\E[?25l, clear=\E[H\E[2J,
+        cnorm=\E[?25h, cr=\r, csr=\E[%i%p1%d;%p2%dr, cub1=^H,
+        cud1=\n, dch=\E[%p1%dP, dch1=\E[P, ech=\E[%p1%dX, ed=\E[J,
+        el=\E[K, el1=\E[1K, flash=\E[?5h$<200/>\E[?5l,
+        ich=\E[%p1%d@, ich1=\E[@, ind=\n, kLFT=\E[1;2D,
+        kRIT=\E[1;2C, kbs=^?, kcbt=\E[Z, kf21=\E[23;2~,
+        kf22=\E[24;2~, kf5=\E[15~, kmous=\E[M, rc=\E8,
+        rep=%p1%c\E[%p2%{1}%-%db, rev=\E[7m, ri=\EM, rmacs=\E(B,
+        rmcup=\E[?1049l, rs2=\Ec, sc=\E7,
+        sgr=%?%p9%t\E(0%e\E(B%;\E[0%?%p6%t;1%;%?%p5%t;2%;%?%p2%t;4%;
+            %?%p1%p3%|%t;7%;%?%p4%t;5%;%?%p7%t;8%;m,
+        sgr0=\E(B\E[m, smacs=\E(0, smcup=\E[?1049h, use=ansi+enq,
+        use=ansi+arrows, use=ansi+cup, use=ansi+idl,
+        use=ansi+local, use=ansi+rca2, use=ansi+tabs,
+        use=ecma+index, use=ecma+standout, use=ecma+underline,
+        use=report+da2, use=vt100+noapp, use=vt100+pf1-pf4,
+        use=vt220+pcedit, use=vt220+sfkeys, use=vt220+ufkeys,
+        use=xterm+256setaf,


### PR DESCRIPTION
Terminfo for kmscon is now in ncurses repository.
Thomas Dickey fixed a few issues, so using his version is better. This should be kept in sync with the version in ncurses upstream at: https://invisible-island.net/ncurses/terminfo.src.html#tic-kmscon

Fix #434 