### PR TITLE
Zoom in/out  with ctrl + mouse wheel

### DIFF
--- a/src/input/input.c
+++ b/src/input/input.c
@@ -685,6 +685,25 @@ void input_set_device_ops(struct input *input, uterm_open_cb open_cb, uterm_clos
 }
 
 SHL_EXPORT
+unsigned int input_get_mods(struct input *input)
+{
+	struct shl_dlist *iter;
+	struct input_dev *dev;
+	unsigned int mods = 0;
+
+	if (!input)
+		return 0;
+	shl_dlist_for_each(iter, &input->devices)
+	{
+		dev = shl_dlist_entry(iter, struct input_dev, list);
+		if (dev->capabilities & DEVICE_HAS_KEYS)
+			mods |= uxkb_dev_get_mods(dev);
+	}
+
+	return mods;
+}
+
+SHL_EXPORT
 void input_sleep(struct input *input)
 {
 	struct shl_dlist *iter;

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -113,6 +113,7 @@ void input_unregister_pointer_cb(struct input *input, input_pointer_cb cb, void 
 void input_set_device_ops(struct input *input, uterm_open_cb open_cb, uterm_close_cb close_cb,
 			  void *data);
 
+unsigned int input_get_mods(struct input *input);
 void input_sleep(struct input *input);
 void input_wake_up(struct input *input);
 bool input_is_awake(struct input *input);

--- a/src/input/input_internal.h
+++ b/src/input/input_internal.h
@@ -149,6 +149,7 @@ void uxkb_compose_table_destroy(struct input *input);
 int uxkb_dev_init(struct input_dev *dev);
 void uxkb_dev_destroy(struct input_dev *dev);
 int uxkb_dev_process(struct input_dev *dev, uint16_t key_state, uint16_t code);
+unsigned int uxkb_dev_get_mods(struct input_dev *dev);
 void uxkb_dev_wake_up(struct input_dev *dev);
 void uxkb_dev_set_leds(struct input_dev *dev, unsigned int scroll_lock, unsigned int num_lock,
 		       unsigned int caps_lock);

--- a/src/input/input_uxkb.c
+++ b/src/input/input_uxkb.c
@@ -546,6 +546,14 @@ int uxkb_dev_process(struct input_dev *dev, uint16_t key_state, uint16_t code)
 	return 0;
 }
 
+unsigned int uxkb_dev_get_mods(struct input_dev *dev)
+{
+	if (!dev || !dev->state)
+		return 0;
+
+	return xkb_state_serialize_mods(dev->state, XKB_STATE_MODS_EFFECTIVE);
+}
+
 void uxkb_dev_wake_up(struct input_dev *dev)
 {
 	xkb_mod_mask_t locked_mods;

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -776,6 +776,27 @@ void terminal_rm_display(struct kmscon_terminal *term, struct display *disp)
 	free_screen(scr, true);
 }
 
+static void zoom_in(struct kmscon_terminal *term)
+{
+	if (term->font_attr.height > 150) // don't allow zoom in beyond 150
+		return;
+
+	term->font_attr.height += term->font->increase_step;
+	if (font_set(term))
+		term->font_attr.height -= term->font->increase_step;
+}
+
+static void zoom_out(struct kmscon_terminal *term)
+{
+	if (term->font_attr.height <= term->font->increase_step)
+		return;
+	if (term->font_attr.height - term->font->increase_step < 10)
+		return;
+	term->font_attr.height -= term->font->increase_step;
+	if (font_set(term))
+		term->font_attr.height += term->font->increase_step;
+}
+
 static void input_event(struct input *input, struct input_key_event *ev, void *data)
 {
 	struct kmscon_terminal *term = data;
@@ -813,22 +834,12 @@ static void input_event(struct input *input, struct input_key_event *ev, void *d
 	}
 	if (conf_grab_matches(term->conf->grab_zoom_in, ev->mods, ev->num_syms, ev->keysyms)) {
 		ev->handled = true;
-		if (term->font_attr.height + term->font->increase_step < term->font_attr.height)
-			return;
-
-		term->font_attr.height += term->font->increase_step;
-		if (font_set(term))
-			term->font_attr.height -= term->font->increase_step;
+		zoom_in(term);
 		return;
 	}
 	if (conf_grab_matches(term->conf->grab_zoom_out, ev->mods, ev->num_syms, ev->keysyms)) {
 		ev->handled = true;
-		if (term->font_attr.height <= term->font->increase_step)
-			return;
-
-		term->font_attr.height -= term->font->increase_step;
-		if (font_set(term))
-			term->font_attr.height += term->font->increase_step;
+		zoom_out(term);
 		return;
 	}
 	if (conf_grab_matches(term->conf->grab_rotate_cw, ev->mods, ev->num_syms, ev->keysyms)) {
@@ -1035,11 +1046,17 @@ static void pointer_event(struct input *input, struct input_pointer_event *ev, v
 		handle_pointer_button(term, ev);
 		break;
 	case POINTER_WHEEL:
-		tsm_screen_selection_reset(term->console);
-		if (term->conf->natural_scrolling != (ev->wheel > 0))
-			tsm_screen_sb_up(term->console, 3);
-		else
-			tsm_screen_sb_down(term->console, 3);
+		if (input_get_mods(term->input) & INPUT_CONTROL_MASK) {
+			if (ev->wheel > 0)
+				zoom_in(term);
+			else
+				zoom_out(term);
+		} else {
+			if (term->conf->natural_scrolling != (ev->wheel > 0))
+				tsm_screen_sb_up(term->console, 3);
+			else
+				tsm_screen_sb_down(term->console, 3);
+		}
 		break;
 	case POINTER_SYNC:
 		redraw_all(term);


### PR DESCRIPTION
This is a common default behavior.

However it is currently not configurable, because mouse wheel event are not keyboard event.
So you can bind other keyboard shortcut for Zoom in/out, but you can't have  shortcut with mouse wheel, nor disable zoom with ctrl+mouse wheel.

Fix #420 