### PR TITLE
terminal: add asciicast playback

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -223,6 +223,21 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--asciicast {path}</option></term>
+        <listitem>
+          <para>Play an asciicast animation after opening the terminal session.
+                The animation is stopped on keyboard input. (default: unset)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--asciicast-loop</option></term>
+        <listitem>
+          <para>Loop the asciicast animation. (default: off)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>-t {term}</option></term>
         <term><option>--term {term}</option></term>
         <listitem>

--- a/docs/man/kmscon.conf.5.xml.in
+++ b/docs/man/kmscon.conf.5.xml.in
@@ -169,6 +169,22 @@ font-name=Ubuntu Mono
       </varlistentry>
 
       <varlistentry>
+        <term><option>asciicast</option></term>
+        <listitem>
+          <para>Path to an asciicast animation to play after opening the
+                terminal session. The animation is stopped on keyboard input. (default:
+                unset)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>asciicast-loop</option></term>
+        <listitem>
+          <para>Loop the asciicast animation. (default: off)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>term</option></term>
         <listitem>
           <para>Value of the TERM environment variable for the child process. (default: kmscon)</para>

--- a/scripts/etc/kmscon.conf.example
+++ b/scripts/etc/kmscon.conf.example
@@ -88,6 +88,13 @@
 #dpms-timeout=600
 
 ## Terminal options
+## Play an asciicast animation after opening the terminal session.
+## The animation stops on keyboard input.
+#asciicast=/usr/share/kmscon/login.cast
+
+## Loop the asciicast animation.
+#asciicast-loop
+
 ## value of the $TERM variable
 #term=kmscon
 

--- a/src/asciinema.c
+++ b/src/asciinema.c
@@ -1,0 +1,493 @@
+/*
+ * kmscon - asciicast playback for terminal sessions
+ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <libtsm.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include "asciinema.h"
+#include "shl/eloop.h"
+#include "shl/log.h"
+
+#define LOG_SUBSYSTEM "asciinema"
+
+#define ASCIINEMA_MAX_LINE (256u * 1024u)
+#define ASCIINEMA_MAX_OUTPUT (2u * 1024u * 1024u)
+#define ASCIINEMA_MAX_EVENTS 16384u
+#define ASCIINEMA_MIN_TIMER_NS (1 * 1000 * 1000)
+
+struct asciinema_event {
+	uint64_t delay_ns;
+	char *data;
+	size_t len;
+};
+
+struct kmscon_asciinema {
+	struct asciinema_event *events;
+	size_t num;
+	size_t pos;
+	bool loop;
+	bool stopped;
+	struct ev_timer *timer;
+	kmscon_asciinema_write_cb write_cb;
+	void *data;
+};
+
+static const char *skip_ws(const char *p)
+{
+	while (*p && isspace((unsigned char)*p))
+		p++;
+	return p;
+}
+
+static int hex_val(char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'a' && c <= 'f')
+		return c - 'a' + 10;
+	if (c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+	return -1;
+}
+
+static int parse_hex4(const char *p, uint32_t *out)
+{
+	uint32_t v = 0;
+	int h;
+
+	for (size_t i = 0; i < 4; i++) {
+		h = hex_val(p[i]);
+		if (h < 0)
+			return -EINVAL;
+		v = (v << 4) | (uint32_t)h;
+	}
+
+	*out = v;
+	return 0;
+}
+
+static int append_utf8(char **dst, char *end, uint32_t cp)
+{
+	char *p = *dst;
+	char u8[4];
+	size_t len;
+
+	if (cp > 0x10ffff)
+		return -EINVAL;
+
+	len = tsm_ucs4_to_utf8(cp, u8);
+	if (!len || len > sizeof(u8))
+		return -EINVAL;
+	if (p + len > end)
+		return -ENOSPC;
+
+	memcpy(p, u8, len);
+	p += len;
+
+	*dst = p;
+	return 0;
+}
+
+static int parse_json_string(const char **ppos, char **out, size_t *out_len)
+{
+	const char *pos = skip_ws(*ppos);
+	const char *src;
+	char *buf, *dst, *end;
+	size_t alloc;
+	uint32_t cp;
+	int ret;
+
+	if (*pos != '"')
+		return -EINVAL;
+
+	src = ++pos;
+	while (*pos && *pos != '"') {
+		if (*pos == '\\' && pos[1])
+			pos++;
+		pos++;
+	}
+	if (*pos != '"')
+		return -EINVAL;
+
+	alloc = (size_t)(pos - src) + 1;
+	buf = malloc(alloc);
+	if (!buf)
+		return -ENOMEM;
+
+	dst = buf;
+	end = buf + alloc;
+	pos = src;
+	while (*pos && *pos != '"') {
+		if (*pos != '\\') {
+			if (dst + 1 > end) {
+				ret = -ENOSPC;
+				goto err;
+			}
+			*dst++ = *pos++;
+			continue;
+		}
+
+		pos++;
+		switch (*pos) {
+		case '"':
+		case '\\':
+		case '/':
+			*dst++ = *pos++;
+			break;
+		case 'b':
+			*dst++ = '\b';
+			pos++;
+			break;
+		case 'f':
+			*dst++ = '\f';
+			pos++;
+			break;
+		case 'n':
+			*dst++ = '\n';
+			pos++;
+			break;
+		case 'r':
+			*dst++ = '\r';
+			pos++;
+			break;
+		case 't':
+			*dst++ = '\t';
+			pos++;
+			break;
+		case 'u':
+			ret = parse_hex4(pos + 1, &cp);
+			if (ret)
+				goto err;
+			pos += 5;
+
+			if (cp >= 0xd800 && cp <= 0xdbff && pos[0] == '\\' && pos[1] == 'u') {
+				uint32_t low;
+
+				ret = parse_hex4(pos + 2, &low);
+				if (ret)
+					goto err;
+				if (low >= 0xdc00 && low <= 0xdfff) {
+					cp = 0x10000 + ((cp - 0xd800) << 10) + (low - 0xdc00);
+					pos += 6;
+				}
+			}
+
+			ret = append_utf8(&dst, end, cp);
+			if (ret)
+				goto err;
+			break;
+		default:
+			ret = -EINVAL;
+			goto err;
+		}
+	}
+
+	*out = buf;
+	*out_len = (size_t)(dst - buf);
+	*ppos = pos + 1;
+	return 0;
+
+err:
+	free(buf);
+	return ret;
+}
+
+static int parse_header_version(const char *line)
+{
+	const char *p = strstr(line, "\"version\"");
+
+	if (!p)
+		return -EINVAL;
+
+	p = strchr(p, ':');
+	if (!p)
+		return -EINVAL;
+	p = skip_ws(p + 1);
+	return (int)strtol(p, NULL, 10);
+}
+
+static uint64_t sec_to_ns(double sec)
+{
+	if (sec <= 0)
+		return 0;
+	if (sec > 3600.0)
+		sec = 3600.0;
+	return (uint64_t)(sec * 1000000000.0);
+}
+
+static int add_event(struct kmscon_asciinema *player, uint64_t delay_ns, char *data, size_t len,
+		     size_t *total_output)
+{
+	struct asciinema_event *events;
+
+	if (player->num >= ASCIINEMA_MAX_EVENTS)
+		return -E2BIG;
+	if (len > ASCIINEMA_MAX_OUTPUT || *total_output > ASCIINEMA_MAX_OUTPUT - len)
+		return -E2BIG;
+
+	events = realloc(player->events, (player->num + 1) * sizeof(*events));
+	if (!events)
+		return -ENOMEM;
+
+	player->events = events;
+	player->events[player->num].delay_ns = delay_ns;
+	player->events[player->num].data = data;
+	player->events[player->num].len = len;
+	player->num++;
+	*total_output += len;
+	return 0;
+}
+
+static void schedule_event(struct kmscon_asciinema *player, uint64_t delay_ns)
+{
+	struct itimerspec spec = {0};
+
+	if (!player || !player->timer || player->stopped)
+		return;
+
+	if (delay_ns < ASCIINEMA_MIN_TIMER_NS)
+		delay_ns = ASCIINEMA_MIN_TIMER_NS;
+
+	spec.it_value.tv_sec = delay_ns / 1000000000ULL;
+	spec.it_value.tv_nsec = delay_ns % 1000000000ULL;
+	ev_timer_update(player->timer, &spec);
+	ev_timer_enable(player->timer);
+}
+
+static void timer_event(struct ev_timer *timer, uint64_t count, void *data)
+{
+	struct kmscon_asciinema *player = data;
+	uint64_t delay_ns;
+
+	if (!player || player->stopped)
+		return;
+
+	if (kmscon_asciinema_advance(player, &delay_ns))
+		schedule_event(player, delay_ns);
+	else if (player->timer)
+		ev_timer_disable(player->timer);
+}
+
+static int parse_event_line(struct kmscon_asciinema *player, const char *line, int version,
+			    double *last_output_time, double *pending_interval,
+			    size_t *total_output)
+{
+	const char *pos = skip_ws(line);
+	char *code = NULL;
+	char *data = NULL;
+	size_t code_len = 0, data_len = 0;
+	double t, delay_sec;
+	uint64_t delay_ns;
+	int ret = 0;
+
+	if (*pos != '[')
+		return 0;
+	pos++;
+	errno = 0;
+	t = strtod(pos, (char **)&pos);
+	if (errno)
+		return -EINVAL;
+
+	pos = skip_ws(pos);
+	if (*pos != ',')
+		return -EINVAL;
+	pos++;
+
+	ret = parse_json_string(&pos, &code, &code_len);
+	if (ret)
+		return ret;
+
+	pos = skip_ws(pos);
+	if (*pos != ',') {
+		ret = -EINVAL;
+		goto out;
+	}
+	pos++;
+
+	ret = parse_json_string(&pos, &data, &data_len);
+	if (ret)
+		goto out;
+
+	if (code_len != 1 || code[0] != 'o') {
+		if (version == 3)
+			*pending_interval += t;
+		goto out;
+	}
+
+	if (version == 3) {
+		delay_sec = *pending_interval + t;
+		*pending_interval = 0;
+	} else {
+		delay_sec = t - *last_output_time;
+		if (delay_sec < 0)
+			delay_sec = 0;
+		*last_output_time = t;
+	}
+
+	delay_ns = sec_to_ns(delay_sec);
+	ret = add_event(player, delay_ns, data, data_len, total_output);
+	if (ret)
+		goto out;
+	data = NULL;
+
+out:
+	free(code);
+	free(data);
+	return ret;
+}
+
+int kmscon_asciinema_new(struct kmscon_asciinema **out, struct ev_eloop *eloop, const char *path,
+			 bool loop, kmscon_asciinema_write_cb write_cb, void *data)
+{
+	struct kmscon_asciinema *player;
+	char *line = NULL;
+	size_t cap = 0;
+	ssize_t len;
+	FILE *fp;
+	int version, ret = 0;
+	double last_output_time = 0;
+	double pending_interval = 0;
+	size_t total_output = 0;
+
+	if (!out || !eloop || !path || !write_cb)
+		return -EINVAL;
+	*out = NULL;
+
+	fp = fopen(path, "r");
+	if (!fp)
+		return -errno;
+
+	len = getline(&line, &cap, fp);
+	if (len < 0) {
+		ret = -EINVAL;
+		goto out_file;
+	}
+	if ((size_t)len > ASCIINEMA_MAX_LINE) {
+		ret = -E2BIG;
+		goto out_file;
+	}
+
+	version = parse_header_version(line);
+	if (version != 2 && version != 3) {
+		ret = -EINVAL;
+		goto out_file;
+	}
+
+	player = malloc(sizeof(*player));
+	if (!player) {
+		ret = -ENOMEM;
+		goto out_file;
+	}
+	memset(player, 0, sizeof(*player));
+	player->loop = loop;
+	player->write_cb = write_cb;
+	player->data = data;
+
+	while ((len = getline(&line, &cap, fp)) >= 0) {
+		if ((size_t)len > ASCIINEMA_MAX_LINE) {
+			ret = -E2BIG;
+			break;
+		}
+		if (version == 3 && line[0] == '#')
+			continue;
+		ret = parse_event_line(player, line, version, &last_output_time, &pending_interval,
+				       &total_output);
+		if (ret)
+			break;
+	}
+
+	if (!ret && !player->num)
+		ret = -ENODATA;
+	if (!ret)
+		ret = ev_eloop_new_timer(eloop, &player->timer, NULL, timer_event, player);
+	if (ret) {
+		kmscon_asciinema_free(player);
+		goto out_file;
+	}
+
+	log_debug("loaded asciicast %s with %zu output events", path, player->num);
+	*out = player;
+
+out_file:
+	free(line);
+	fclose(fp);
+	return ret;
+}
+
+void kmscon_asciinema_free(struct kmscon_asciinema *player)
+{
+	if (!player)
+		return;
+
+	for (size_t i = 0; i < player->num; i++)
+		free(player->events[i].data);
+	if (player->timer)
+		ev_eloop_rm_timer(player->timer);
+	free(player->events);
+	free(player);
+}
+
+bool kmscon_asciinema_start(struct kmscon_asciinema *player)
+{
+	if (!player || !player->num)
+		return false;
+
+	player->pos = 0;
+	player->stopped = false;
+	schedule_event(player, player->events[0].delay_ns);
+	return true;
+}
+
+bool kmscon_asciinema_advance(struct kmscon_asciinema *player, uint64_t *delay_ns)
+{
+	if (!player || !delay_ns || player->stopped || !player->num)
+		return false;
+
+	if (player->pos >= player->num) {
+		if (!player->loop)
+			return false;
+		player->pos = 0;
+	}
+
+	do {
+		struct asciinema_event *ev = &player->events[player->pos++];
+
+		player->write_cb(ev->data, ev->len, player->data);
+	} while (player->pos < player->num && player->events[player->pos].delay_ns == 0);
+
+	if (player->pos >= player->num) {
+		if (!player->loop)
+			return false;
+		player->pos = 0;
+	}
+
+	*delay_ns = player->events[player->pos].delay_ns;
+	return true;
+}
+
+void kmscon_asciinema_pause(struct kmscon_asciinema *player)
+{
+	if (player && player->timer)
+		ev_timer_disable(player->timer);
+}
+
+void kmscon_asciinema_resume(struct kmscon_asciinema *player)
+{
+	if (player && player->timer && !player->stopped)
+		ev_timer_enable(player->timer);
+}
+
+void kmscon_asciinema_stop(struct kmscon_asciinema *player)
+{
+	if (player) {
+		player->stopped = true;
+		kmscon_asciinema_pause(player);
+	}
+}

--- a/src/asciinema.h
+++ b/src/asciinema.h
@@ -1,0 +1,27 @@
+/*
+ * kmscon - asciicast playback for terminal sessions
+ */
+
+#ifndef ASCIINEMA_H
+#define ASCIINEMA_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct ev_eloop;
+struct kmscon_asciinema;
+
+typedef void (*kmscon_asciinema_write_cb)(const char *u8, size_t len, void *data);
+
+int kmscon_asciinema_new(struct kmscon_asciinema **out, struct ev_eloop *eloop, const char *path,
+			 bool loop, kmscon_asciinema_write_cb write_cb, void *data);
+void kmscon_asciinema_free(struct kmscon_asciinema *player);
+
+bool kmscon_asciinema_start(struct kmscon_asciinema *player);
+bool kmscon_asciinema_advance(struct kmscon_asciinema *player, uint64_t *delay_ns);
+void kmscon_asciinema_pause(struct kmscon_asciinema *player);
+void kmscon_asciinema_resume(struct kmscon_asciinema *player);
+void kmscon_asciinema_stop(struct kmscon_asciinema *player);
+
+#endif /* ASCIINEMA_H */

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -88,6 +88,11 @@ static void print_help()
 		"\t                              Colon-separated list of issue\n"
 		"\t                              files and directories to read\n"
 		"\t                              when using --issue\n"
+		"\t    --asciicast <path>\n"
+		"\t                              Play an asciicast animation after\n"
+		"\t                              opening the terminal session\n"
+		"\t    --asciicast-loop        [off]\n"
+		"\t                              Loop the asciicast animation\n"
 		"\t-l, --login                 [/bin/login -p]\n"
 		"\t                              Start the given login process instead\n"
 		"\t                              of the default process; all arguments\n"
@@ -732,6 +737,8 @@ int kmscon_conf_new(struct conf_ctx **out)
 		/* Terminal Options */
 		CONF_OPTION_BOOL(0, "issue", &conf->issue, false),
 		CONF_OPTION_STRING(0, "issue-path", &conf->issue_path, ISSUE_DEFAULT_PATH),
+		CONF_OPTION_STRING(0, "asciicast", &conf->asciicast, NULL),
+		CONF_OPTION_BOOL(0, "asciicast-loop", &conf->asciicast_loop, false),
 		CONF_OPTION(0, 'l', "login", &conf_login, aftercheck_login, NULL, file_login,
 			    &conf->login, false),
 		CONF_OPTION_BOOL(0, "oneshot", &conf->oneshot, false),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -85,6 +85,10 @@ struct kmscon_conf_t {
 	bool issue;
 	/* colon-separated issue search path */
 	char *issue_path;
+	/* asciicast animation to play after opening the terminal session */
+	char *asciicast;
+	/* loop asciicast animation */
+	bool asciicast_loop;
 	/* custom login process */
 	bool login;
 	/* argv for login process */

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "asciinema.h"
 #include "conf.h"
 #include "font/font.h"
 #include "input/input.h"
@@ -102,6 +103,7 @@ struct kmscon_terminal {
 
 	struct ev_timer *blink_timer;
 	bool blinking;
+	struct kmscon_asciinema *asciinema;
 };
 
 #define BLINK_TIMER_NS (500 * 1000 * 1000)
@@ -438,6 +440,24 @@ static void blink_event(struct ev_timer *timer, uint64_t count, void *data)
 
 	term->blinking = !term->blinking;
 	redraw_all(term);
+}
+
+static void asciinema_write(const char *u8, size_t len, void *data)
+{
+	struct kmscon_terminal *term = data;
+
+	if (!term->opened || !term->awake || !kmscon_session_get_foreground(term->session))
+		return;
+
+	tsm_vte_input(term->vte, u8, len);
+	redraw_all(term);
+}
+
+static void asciinema_start(struct kmscon_terminal *term)
+{
+	if (!term->asciinema)
+		return;
+	kmscon_asciinema_start(term->asciinema);
 }
 
 static void osc_event(struct tsm_vte *vte, const char *osc_string, size_t osc_len, void *data)
@@ -807,6 +827,7 @@ static void input_event(struct input *input, struct input_key_event *ev, void *d
 
 	// reset mouse selection on keypress
 	tsm_screen_selection_reset(term->console);
+	kmscon_asciinema_stop(term->asciinema);
 
 	if (conf_grab_matches(term->conf->grab_scroll_up, ev->mods, ev->num_syms, ev->keysyms)) {
 		tsm_screen_sb_up(term->console, 1);
@@ -1101,6 +1122,7 @@ static int terminal_open(struct kmscon_terminal *term)
 	term->opened = true;
 	if (term->conf->issue)
 		kmscon_issue_write(term->vte, term->pty, term->conf->issue_path);
+	asciinema_start(term);
 
 	update_pointer_max_all(term);
 	redraw_all(term);
@@ -1109,6 +1131,7 @@ static int terminal_open(struct kmscon_terminal *term)
 
 static void terminal_close(struct kmscon_terminal *term)
 {
+	kmscon_asciinema_pause(term->asciinema);
 	kmscon_pty_close(term->pty);
 	term->opened = false;
 }
@@ -1126,6 +1149,8 @@ void terminal_activate(struct kmscon_terminal *term)
 	ev_timer_enable(term->blink_timer);
 	if (!term->opened)
 		terminal_open(term);
+	else
+		kmscon_asciinema_resume(term->asciinema);
 	if (term->pointer.visible)
 		hw_cursor_show(term, term->pointer.x, term->pointer.y);
 	redraw_all_text(term);
@@ -1136,6 +1161,7 @@ void terminal_deactivate(struct kmscon_terminal *term)
 	term->awake = false;
 	hw_cursor_hide(term);
 	ev_timer_disable(term->blink_timer);
+	kmscon_asciinema_pause(term->asciinema);
 }
 
 void terminal_destroy(struct kmscon_terminal *term)
@@ -1145,6 +1171,7 @@ void terminal_destroy(struct kmscon_terminal *term)
 	terminal_close(term);
 	rm_all_screens(term);
 	ev_eloop_rm_timer(term->blink_timer);
+	kmscon_asciinema_free(term->asciinema);
 	input_unregister_pointer_cb(term->input, pointer_event, term);
 	input_unregister_key_cb(term->input, input_event, term);
 	ev_eloop_rm_fd(term->ptyfd);
@@ -1280,6 +1307,13 @@ struct kmscon_terminal *terminal_new(struct kmscon_session *session, unsigned in
 				 term);
 	if (ret)
 		goto err_pointer;
+
+	if (term->conf->asciicast) {
+		ret = kmscon_asciinema_new(&term->asciinema, term->eloop, term->conf->asciicast,
+					   term->conf->asciicast_loop, asciinema_write, term);
+		if (ret)
+			log_warn("cannot load asciicast %s: %d", term->conf->asciicast, ret);
+	}
 
 	ev_eloop_ref(term->eloop);
 	input_ref(term->input);

--- a/src/meson.build
+++ b/src/meson.build
@@ -84,6 +84,7 @@ conf_deps = declare_dependency(
 
 kmscon_srcs = [
   'pty.c',
+  'asciinema.c',
   'kmscon_seat.c',
   'kmscon_conf.c',
   'kmscon_issue.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -37,3 +37,11 @@ test_bbulk = executable('test_bbulk', 'test_bbulk.c',
   dependencies: [libtsm_deps, htable_deps],
 )
 test('test_bbulk', test_bbulk)
+
+test_asciinema = executable('test_asciinema',
+  'test_asciinema.c',
+  '../src/asciinema.c',
+  include_directories: src_inc,
+  dependencies: [libtsm_deps, shl_deps, eloop_deps],
+)
+test('test_asciinema', test_asciinema)

--- a/tests/test_asciinema.c
+++ b/tests/test_asciinema.c
@@ -1,0 +1,261 @@
+/*
+ * Lightweight tests for the asciicast player.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "asciinema.h"
+#include "shl/eloop.h"
+
+struct sink {
+	char buf[4096];
+	size_t len;
+	unsigned int calls;
+};
+
+static void sink_write(const char *u8, size_t len, void *data)
+{
+	struct sink *sink = data;
+
+	assert(sink->len + len < sizeof(sink->buf));
+	memcpy(sink->buf + sink->len, u8, len);
+	sink->len += len;
+	sink->buf[sink->len] = '\0';
+	sink->calls++;
+}
+
+static void assert_ns_near(uint64_t got, uint64_t expected)
+{
+	uint64_t delta = got > expected ? got - expected : expected - got;
+
+	assert(delta < 1000);
+}
+
+static void write_all(int fd, const char *buf, size_t len)
+{
+	while (len) {
+		ssize_t n = write(fd, buf, len);
+
+		assert(n > 0);
+		buf += n;
+		len -= (size_t)n;
+	}
+}
+
+static char *write_tmp(const char *content)
+{
+	char template[] = "/tmp/kmscon-asciinema-XXXXXX";
+	char *path;
+	int fd;
+
+	fd = mkstemp(template);
+	assert(fd >= 0);
+	write_all(fd, content, strlen(content));
+	assert(close(fd) == 0);
+
+	path = strdup(template);
+	assert(path);
+	return path;
+}
+
+static char *write_large_event_cast(unsigned int events)
+{
+	char template[] = "/tmp/kmscon-asciinema-XXXXXX";
+	FILE *fp;
+	char *path;
+	int fd;
+
+	fd = mkstemp(template);
+	assert(fd >= 0);
+	fp = fdopen(fd, "w");
+	assert(fp);
+
+	assert(fputs("{\"version\":2,\"width\":80,\"height\":24}\n", fp) >= 0);
+	for (unsigned int i = 0; i < events; i++)
+		assert(fputs("[0,\"o\",\"x\"]\n", fp) >= 0);
+	assert(fclose(fp) == 0);
+
+	path = strdup(template);
+	assert(path);
+	return path;
+}
+
+static void unlink_free(char *path)
+{
+	unlink(path);
+	free(path);
+}
+
+static struct ev_eloop *new_eloop(void)
+{
+	struct ev_eloop *eloop = NULL;
+	int ret;
+
+	ret = ev_eloop_new(&eloop);
+	assert(ret == 0);
+	assert(eloop);
+	return eloop;
+}
+
+static void test_v2_output_and_json_escapes(void)
+{
+	static const char cast[] = "{\"version\":2,\"width\":80,\"height\":24}\n"
+				   "[0.1,\"o\",\"A\"]\n"
+				   "[0.2,\"i\",\"ignored\"]\n"
+				   "[0.4,\"o\",\"B\\n\\u001b[31m\\ud83d\\ude03\"]\n";
+	struct kmscon_asciinema *player = NULL;
+	struct ev_eloop *eloop;
+	struct sink sink = {0};
+	uint64_t delay_ns;
+	char *path;
+	bool more;
+	int ret;
+
+	path = write_tmp(cast);
+	eloop = new_eloop();
+	ret = kmscon_asciinema_new(&player, eloop, path, false, sink_write, &sink);
+	unlink_free(path);
+	assert(ret == 0);
+	assert(player);
+
+	assert(kmscon_asciinema_start(player));
+
+	more = kmscon_asciinema_advance(player, &delay_ns);
+	assert(more);
+	assert_ns_near(delay_ns, 300000000ULL);
+	assert(sink.calls == 1);
+	assert(strcmp(sink.buf, "A") == 0);
+
+	more = kmscon_asciinema_advance(player, &delay_ns);
+	assert(!more);
+	assert(sink.calls == 2);
+	assert(strcmp(sink.buf, "AB\n\033[31m\xf0\x9f\x98\x83") == 0);
+
+	kmscon_asciinema_free(player);
+	ev_eloop_unref(eloop);
+}
+
+static void test_v3_intervals_and_ignored_events(void)
+{
+	static const char cast[] = "{\"version\":3,\"width\":80,\"height\":24}\n"
+				   "[0.1,\"o\",\"A\"]\n"
+				   "[0.2,\"m\",\"marker\"]\n"
+				   "[0.3,\"o\",\"B\"]\n";
+	struct kmscon_asciinema *player = NULL;
+	struct ev_eloop *eloop;
+	struct sink sink = {0};
+	uint64_t delay_ns;
+	char *path;
+	bool more;
+	int ret;
+
+	path = write_tmp(cast);
+	eloop = new_eloop();
+	ret = kmscon_asciinema_new(&player, eloop, path, false, sink_write, &sink);
+	unlink_free(path);
+	assert(ret == 0);
+
+	assert(kmscon_asciinema_start(player));
+	more = kmscon_asciinema_advance(player, &delay_ns);
+	assert(more);
+	assert_ns_near(delay_ns, 500000000ULL);
+	assert(strcmp(sink.buf, "A") == 0);
+
+	more = kmscon_asciinema_advance(player, &delay_ns);
+	assert(!more);
+	assert(strcmp(sink.buf, "AB") == 0);
+
+	kmscon_asciinema_free(player);
+	ev_eloop_unref(eloop);
+}
+
+static void test_loop_and_stop(void)
+{
+	static const char cast[] = "{\"version\":2,\"width\":80,\"height\":24}\n"
+				   "[0,\"o\",\"A\"]\n";
+	struct kmscon_asciinema *player = NULL;
+	struct ev_eloop *eloop;
+	struct sink sink = {0};
+	uint64_t delay_ns;
+	char *path;
+	int ret;
+
+	path = write_tmp(cast);
+	eloop = new_eloop();
+	ret = kmscon_asciinema_new(&player, eloop, path, true, sink_write, &sink);
+	unlink_free(path);
+	assert(ret == 0);
+
+	assert(kmscon_asciinema_start(player));
+	assert(kmscon_asciinema_advance(player, &delay_ns));
+	assert(strcmp(sink.buf, "A") == 0);
+
+	kmscon_asciinema_stop(player);
+	assert(!kmscon_asciinema_advance(player, &delay_ns));
+	assert(strcmp(sink.buf, "A") == 0);
+
+	kmscon_asciinema_free(player);
+	ev_eloop_unref(eloop);
+}
+
+static void test_invalid_casts(void)
+{
+	struct kmscon_asciinema *player = NULL;
+	struct ev_eloop *eloop;
+	struct sink sink = {0};
+	char *path;
+	int ret;
+
+	eloop = new_eloop();
+	path = write_tmp("{\"version\":1,\"width\":80,\"height\":24}\n[0,\"o\",\"A\"]\n");
+	ret = kmscon_asciinema_new(&player, eloop, path, false, sink_write, &sink);
+	unlink_free(path);
+	assert(ret == -EINVAL);
+	assert(player == NULL);
+
+	path = write_tmp("{\"version\":2,\"width\":80,\"height\":24}\n[0,\"o\",\"\\q\"]\n");
+	ret = kmscon_asciinema_new(&player, eloop, path, false, sink_write, &sink);
+	unlink_free(path);
+	assert(ret == -EINVAL);
+	assert(player == NULL);
+
+	path = write_tmp("{\"version\":2,\"width\":80,\"height\":24}\n[0,\"o\",\"\\ud800\"]\n");
+	ret = kmscon_asciinema_new(&player, eloop, path, false, sink_write, &sink);
+	unlink_free(path);
+	assert(ret == -EINVAL);
+	assert(player == NULL);
+	ev_eloop_unref(eloop);
+}
+
+static void test_event_limit(void)
+{
+	struct kmscon_asciinema *player = NULL;
+	struct ev_eloop *eloop;
+	struct sink sink = {0};
+	char *path;
+	int ret;
+
+	eloop = new_eloop();
+	path = write_large_event_cast(16385);
+	ret = kmscon_asciinema_new(&player, eloop, path, false, sink_write, &sink);
+	unlink_free(path);
+	assert(ret == -E2BIG);
+	assert(player == NULL);
+	ev_eloop_unref(eloop);
+}
+
+int main(void)
+{
+	test_v2_output_and_json_escapes();
+	test_v3_intervals_and_ignored_events();
+	test_loop_and_stop();
+	test_invalid_casts();
+	test_event_limit();
+	return 0;
+}


### PR DESCRIPTION
Add optional asciicast playback for terminal sessions.

Summary:
- add --asciicast and --asciicast-loop options
- play asciicast output through the terminal VTE
- stop playback on keyboard input
- suspend playback on terminal deactivation / DPMS
- add asciicast parser tests

Tests:
- ninja -C build
- meson test -C build --print-errorlogs
- git diff --check
- xmllint --noout docs/man/kmscon.1.xml.in docs/man/kmscon.conf.5.xml.in