### PR TITLE
drm: recover safely from failed atomic modesets

### DIFF
--- a/src/video/drm2d_video.c
+++ b/src/video/drm2d_video.c
@@ -175,7 +175,8 @@ static void display_done_modeset(struct display *disp, int status)
 {
 	struct drm2d_display *d2d = disp->data;
 	if (status) {
-		display_freefb(disp);
+		if (!display_is_online(disp))
+			display_freefb(disp);
 	} else {
 		d2d->current_rb = d2d->current_rb ^ 1;
 	}

--- a/src/video/drm3d_video.c
+++ b/src/video/drm3d_video.c
@@ -65,6 +65,7 @@ struct drm3d_display {
 	EGLSurface surface;
 	struct drm3d_rb *current;
 	struct drm3d_rb *next;
+	struct drm3d_rb *modeset;
 };
 
 struct drm3d_video {
@@ -136,6 +137,15 @@ static struct drm3d_rb *bo_to_rb(struct display *disp, struct gbm_bo *bo)
 	return rb;
 }
 
+static void release_rb(struct drm3d_display *d3d, struct drm3d_rb **rb)
+{
+	if (!*rb)
+		return;
+
+	gbm_surface_release_buffer(d3d->gbm, (*rb)->bo);
+	*rb = NULL;
+}
+
 static int display_allocfb(struct display *disp)
 {
 	struct video *video = disp->video;
@@ -155,6 +165,7 @@ static int display_allocfb(struct display *disp)
 
 	d3d->current = NULL;
 	d3d->next = NULL;
+	d3d->modeset = NULL;
 
 	d3d->gbm =
 		gbm_surface_create(v3d->gbm, minfo->hdisplay, minfo->vdisplay, GBM_FORMAT_XRGB8888,
@@ -208,8 +219,10 @@ err_noctx:
 	eglMakeCurrent(v3d->disp, EGL_NO_SURFACE, EGL_NO_SURFACE, v3d->ctx);
 err_surface:
 	eglDestroySurface(v3d->disp, d3d->surface);
+	d3d->surface = NULL;
 err_gbm:
 	gbm_surface_destroy(d3d->gbm);
+	d3d->gbm = NULL;
 err_saved:
 	disp->width = 0;
 	disp->height = 0;
@@ -229,19 +242,24 @@ static void display_freefb(struct display *disp)
 		eglMakeCurrent(v3d->disp, EGL_NO_SURFACE, EGL_NO_SURFACE, v3d->ctx);
 
 	if (d3d->current) {
-		gbm_surface_release_buffer(d3d->gbm, d3d->current->bo);
-		d3d->current = NULL;
+		release_rb(d3d, &d3d->current);
 	}
 	if (d3d->next) {
-		gbm_surface_release_buffer(d3d->gbm, d3d->next->bo);
-		d3d->next = NULL;
+		release_rb(d3d, &d3d->next);
+	}
+	if (d3d->modeset) {
+		release_rb(d3d, &d3d->modeset);
 	}
 	if (d3d->surface) {
 		eglDestroySurface(v3d->disp, d3d->surface);
 		d3d->surface = NULL;
 	}
-	if (d3d->gbm)
+	if (d3d->gbm) {
 		gbm_surface_destroy(d3d->gbm);
+		d3d->gbm = NULL;
+	}
+	disp->width = 0;
+	disp->height = 0;
 }
 
 static int display_prepare_modeset(struct display *disp, drmModeAtomicReqPtr req)
@@ -251,13 +269,17 @@ static int display_prepare_modeset(struct display *disp, drmModeAtomicReqPtr req
 	struct video *video = disp->video;
 	struct drm_video *vdrm = video->data;
 	struct drm3d_video *v3d = drm_video_get_data(video);
+	struct drm3d_rb *rb;
 	int ret;
 
 	if (!d3d->gbm) {
 		ret = display_allocfb(disp);
 		if (ret)
 			return ret;
+		rb = d3d->current;
 	} else {
+		release_rb(d3d, &d3d->modeset);
+
 		if (!gbm_surface_has_free_buffers(d3d->gbm))
 			return -EBUSY;
 
@@ -270,27 +292,24 @@ static int display_prepare_modeset(struct display *disp, drmModeAtomicReqPtr req
 			log_err("cannot swap EGL buffers");
 			return -EFAULT;
 		}
-		if (d3d->current) {
-			gbm_surface_release_buffer(d3d->gbm, d3d->current->bo);
-			d3d->current = NULL;
-		}
 		bo = gbm_surface_lock_front_buffer(d3d->gbm);
 		if (!bo) {
 			log_err("cannot lock front buffer");
 			return -EFAULT;
 		}
 
-		d3d->current = bo_to_rb(disp, bo);
-		if (!d3d->current) {
+		rb = bo_to_rb(disp, bo);
+		if (!rb) {
 			log_err("cannot lock front gbm buffer");
 			gbm_surface_release_buffer(d3d->gbm, bo);
 			return -EFAULT;
 		}
+		d3d->modeset = rb;
 	}
-	ret = drm_prepare_commit(vdrm->fd, &d3d->ddrm, req, d3d->current->id, disp->width,
-				 disp->height, vdrm->cursor_hotspot);
+	ret = drm_prepare_commit(vdrm->fd, &d3d->ddrm, req, rb->id, disp->width, disp->height,
+				 vdrm->cursor_hotspot);
 	if (ret) {
-		gbm_surface_release_buffer(d3d->gbm, d3d->current->bo);
+		release_rb(d3d, &d3d->modeset);
 		return ret;
 	}
 	return 0;
@@ -301,14 +320,22 @@ static void display_done_modeset(struct display *disp, int status)
 	struct drm3d_display *d3d = disp->data;
 
 	if (status) {
-		gbm_surface_release_buffer(d3d->gbm, d3d->current->bo);
-		d3d->current = NULL;
+		if (d3d->modeset)
+			release_rb(d3d, &d3d->modeset);
+		else if (!display_is_online(disp))
+			display_freefb(disp);
+		return;
+	}
+
+	if (d3d->modeset) {
+		release_rb(d3d, &d3d->next);
+		d3d->next = d3d->modeset;
+		d3d->modeset = NULL;
 		return;
 	}
 
 	if (d3d->next) {
-		gbm_surface_release_buffer(d3d->gbm, d3d->next->bo);
-		d3d->next = NULL;
+		release_rb(d3d, &d3d->next);
 	}
 }
 

--- a/src/video/drm_shared.c
+++ b/src/video/drm_shared.c
@@ -859,8 +859,11 @@ static int perform_modeset(struct video *video)
 	struct drm_video *vdrm = video->data;
 	struct display *disp;
 	struct drm_display *ddrm;
+	size_t num_prepared = 0;
+	size_t i = 0;
 	int flags;
 	int ret = 0;
+	bool refs_taken = false;
 
 	/* prepare modeset on all outputs */
 	req = drmModeAtomicAlloc();
@@ -882,10 +885,11 @@ static int perform_modeset(struct video *video)
 		ret = ddrm->prepare_modeset(disp, req);
 		if (ret < 0)
 			break;
+		++num_prepared;
 	}
 	if (ret < 0) {
 		log_err("prepare atomic commit failed, %d\n", ret);
-		return ret;
+		goto err_commit;
 	}
 
 	/* perform test-only atomic commit */
@@ -902,6 +906,7 @@ static int perform_modeset(struct video *video)
 		disp = shl_dlist_entry(iter, struct display, list);
 		display_ref(disp);
 	}
+	refs_taken = true;
 
 	/* initial modeset on all outputs */
 	flags = DRM_MODE_ATOMIC_ALLOW_MODESET | DRM_MODE_PAGE_FLIP_EVENT;
@@ -912,14 +917,17 @@ static int perform_modeset(struct video *video)
 err_commit:
 	drmModeAtomicFree(req);
 
+	i = 0;
 	shl_dlist_for_each(iter, &video->displays)
 	{
+		if (i++ >= num_prepared)
+			break;
 		disp = shl_dlist_entry(iter, struct display, list);
 		ddrm = disp->data;
 		ddrm->done_modeset(disp, ret);
 		if (ret) {
-			disp->flags &= ~DISPLAY_ONLINE;
-			display_unref(disp);
+			if (refs_taken)
+				display_unref(disp);
 		} else
 			disp->flags |= DISPLAY_ONLINE | DISPLAY_VSYNC | DISPLAY_NEED_REDRAW;
 	}
@@ -981,17 +989,32 @@ static int try_modeset(struct video *video)
 	if (ret != -EAGAIN)
 		return ret;
 
+	if (shl_dlist_empty(&video->displays))
+		return ret;
+
 	/* Retry with default mode for all display */
 	shl_dlist_for_each(iter, &video->displays)
 	{
 		disp = shl_dlist_entry(iter, struct display, list);
 		ddrm = disp->data;
+		ddrm->previous_mode = ddrm->current_mode;
 		ddrm->current_mode = &ddrm->default_mode;
 	}
 	if (vdrm->legacy)
-		return legacy_modeset(video);
+		ret = legacy_modeset(video);
 	else
-		return perform_modeset(video);
+		ret = perform_modeset(video);
+
+	shl_dlist_for_each(iter, &video->displays)
+	{
+		disp = shl_dlist_entry(iter, struct display, list);
+		ddrm = disp->data;
+		if (ret)
+			ddrm->current_mode = ddrm->previous_mode;
+		ddrm->previous_mode = NULL;
+	}
+
+	return ret;
 }
 
 static int legacy_pageflip(int fd, struct display *disp, uint32_t fb)

--- a/src/video/drm_shared.c
+++ b/src/video/drm_shared.c
@@ -1453,7 +1453,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 	struct drm_display *ddrm;
 	int ret, i, dpms;
 	struct shl_dlist *iter, *tmp;
-	bool new_display = false;
+	bool needs_modeset = modeset;
 
 	if (!video_is_awake(video) || !video_need_hotplug(video))
 		return 0;
@@ -1491,8 +1491,10 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 
 			disp->flags |= DISPLAY_AVAILABLE;
 
-			if (!display_is_online(disp))
+			if (!display_is_online(disp)) {
+				needs_modeset = true;
 				break;
+			}
 
 			if (read_dpms) {
 				dpms = drm_get_dpms(vdrm->fd, conn);
@@ -1505,7 +1507,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 		}
 
 		if (iter == &video->displays) {
-			new_display = true;
+			needs_modeset = true;
 			bind_display(video, res, conn);
 		}
 		drmModeFreeConnector(conn);
@@ -1525,7 +1527,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 		goto finish_hotplug;
 	}
 
-	if (modeset || new_display) {
+	if (needs_modeset) {
 		ret = try_modeset(video);
 		if (ret)
 			return ret;
@@ -1588,8 +1590,13 @@ void drm_video_sleep(struct video *video)
 
 int drm_video_poll(struct video *video)
 {
+	int ret;
+
 	video->flags |= VIDEO_HOTPLUG;
-	return drm_video_hotplug(video, false, false);
+	ret = drm_video_hotplug(video, false, false);
+	if (ret)
+		drm_video_arm_vt_timer(video);
+	return ret;
 }
 
 /* Waits for events on DRM fd for \mtimeout milliseconds and returns 0 if the

--- a/src/video/drm_shared_internal.h
+++ b/src/video/drm_shared_internal.h
@@ -76,6 +76,7 @@ struct drm_display {
 	uint32_t damage_blob_id;
 
 	drmModeModeInfoPtr current_mode;
+	drmModeModeInfoPtr previous_mode;
 	drmModeModeInfo default_mode;
 	drmModeModeInfo desired_mode;
 	drmModeModeInfo original_mode;


### PR DESCRIPTION
## Summary

- keep display references valid when an atomic modeset fails before page-flip references are acquired
- preserve the active mode and framebuffer when a replacement modeset fails
- retry modesetting a connected display that remains offline after a hotplug failure

## Root cause

When the test-only atomic commit failed, the common error path unconditionally dropped display references even though those references were only acquired after a successful test. This could free a display that was still linked in the video display list, causing the next modeset attempt to dereference cleared backend data.

The drm3d preparation path also replaced and released the active GBM buffer before the atomic transaction had succeeded. A non-crashing failure could therefore leave the connector present but the display offline, with no framebuffer available to restore the terminal.

This change keeps a candidate drm3d buffer separate until commit success, preserves the existing scanout state on failure, and restores the previous mode if the fallback modeset fails. Hotplug polling now forces a modeset for connected-but-offline displays and arms the existing retry timer after transient failure.

## Testing

- `git diff --check`
- `ninja -C build`
- `meson test -C build --print-errorlogs` (4/4 passed)
- deployed with drm3d/gltex on Intel i915 with an HDMI display
- tested across monitor power-off/wake cycles; no further crash or disappearing display observed since deployment

Fixes #440