### PR TITLE
Update external links, use HTTPS where applicable

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -68,7 +68,7 @@ The wcwidth() implementation in ./external/wcwidth.c is from:
 	for any purpose and without fee is hereby granted. The author
 	disclaims all warranties with regard to this software.
 
-	Latest version: http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
+	Latest version: https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
 
 The vt.c source file is based on the VT handling of the wayland demo
 compositor:
@@ -142,7 +142,7 @@ The "solarized" color palettes in vte.c are from:
 	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 	THE SOFTWARE.
 
-The Unifont-Font is from http://unifoundry.com/unifont.html and licensed under
+The Unifont-Font is from https://unifoundry.com/unifont/index.html and licensed under
 the terms of the GNU GPL. So if you enable this font backend, then kmscon will
 also be released under the terms of the GNU GPL. Copyrights are:
 

--- a/docs/vte.txt
+++ b/docs/vte.txt
@@ -30,8 +30,8 @@ Implementations:
 	XTerm:
 		https://invisible-island.net/xterm/
 	libVTE:
-		http://developer.gnome.org/vte/unstable/
+		https://gitlab.gnome.org/GNOME/vte
 	Google JavaScript HTerm:
-		http://git.chromium.org/gitweb/?p=chromiumos/platform/assets.git;a=tree;f=chromeapps/hterm/js;hb=HEAD
+		https://chromium.googlesource.com/apps/libapps/+/HEAD/hterm
 	Wayland Terminal Widget:
 		https://cgit.freedesktop.org/wayland/weston/tree/clients/terminal.c

--- a/docs/vte.txt
+++ b/docs/vte.txt
@@ -12,26 +12,26 @@ Resources:
 	Linux Console Codes:
 		man console_codes
 	VT100 User Manual:
-		http://vt100.net/docs/vt100-ug/chapter3.html
+		https://vt100.net/docs/vt100-ug/chapter3.html
 	VT510 User Manual:
-		http://vt100.net/docs/vt510-rm/contents
+		https://vt100.net/docs/vt510-rm/contents
 	XTerm Escape Sequences:
-		http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+		https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 	C0 and C1 Control Codes:
-		http://en.wikipedia.org/wiki/C0_and_C1_control_codes
+		https://en.wikipedia.org/wiki/C0_and_C1_control_codes
 	ANSI Escape Sequences / Control Sequence Introducer (CSI)
-		http://en.wikipedia.org/wiki/Control_Sequence_Introducer
+		https://en.wikipedia.org/wiki/ANSI_escape_code#Fe_Escape_sequences
 	vttest Terminal Tests:
-		http://invisible-island.net/vttest/
+		https://invisible-island.net/vttest/
 	vt100-vt520 docs:
-		http://vt100.net/
+		https://vt100.net/
 
 Implementations:
 	XTerm:
-		http://invisible-island.net/xterm/
+		https://invisible-island.net/xterm/
 	libVTE:
 		http://developer.gnome.org/vte/unstable/
 	Google JavaScript HTerm:
 		http://git.chromium.org/gitweb/?p=chromiumos/platform/assets.git;a=tree;f=chromeapps/hterm/js;hb=HEAD
 	Wayland Terminal Widget:
-		http://cgit.freedesktop.org/wayland/weston/tree/clients/terminal.c
+		https://cgit.freedesktop.org/wayland/weston/tree/clients/terminal.c

--- a/src/font/font_unifont.c
+++ b/src/font/font_unifont.c
@@ -33,7 +33,7 @@
  * statically compiled into the file. This bitmap font has 8x16 and 16x16
  * glyphs. This can statically compile in any font defined as a unifont style
  * hex format. This font is from the GNU unifont project available at:
- *   http://unifoundry.com/unifont.html
+ *   https://unifoundry.com/unifont/index.html
  *
  * This file is heavily based on font_8x16.c
  */


### PR DESCRIPTION
The external links were all HTTP which is not quite state of the art. I checked and updated all of them to HTTPS, except for the docbook DTDs and styleheet which I think should be left alone.