### PR TITLE
misc fixes around libtsm

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -29,21 +29,6 @@ jobs:
     - name: Install dependencies on Ubuntu
       run: sudo apt-get update && sudo apt-get install -y meson check libudev-dev libxkbcommon-dev libdrm-dev libgbm-dev libegl1-mesa-dev libgles-dev libpango1.0-dev libsystemd-dev jq libseat-dev
 
-    - name: Compile and install libtsm
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        LIBTSM: "https://api.github.com/repos/kmscon/libtsm/releases/latest"
-      run: |
-        tar_url=$(curl -s --request GET --header "Authorization: Bearer $GH_TOKEN" --url $LIBTSM | jq -r .tarball_url)
-        curl --request GET -s -L -o libtsm.tar.gz --header "Authorization: Bearer $GH_TOKEN" --url $tar_url
-        mkdir libtsm
-        tar -xf libtsm.tar.gz -C libtsm --strip 1
-        cd libtsm
-        meson setup build
-        cd build
-        meson compile
-        sudo meson install
-
     - name: Configure Meson
       run: meson setup build
 

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -7,7 +7,7 @@ misc_srcs = [
   'issue_network.c',
   'pty.c',
 ]
-misc_deps = [xkbcommon_deps, shl_deps]
+misc_deps = [xkbcommon_deps, shl_deps, libtsm_deps]
 
 if enable_dbus
   misc_srcs += 'dbus.c'

--- a/subprojects/libtsm.wrap
+++ b/subprojects/libtsm.wrap
@@ -2,7 +2,7 @@
 directory = libtsm
 
 url = https://github.com/kmscon/libtsm
-revision = v4.4.2
+revision = v4.5.0
 depth = 1
 
 [provide]

--- a/subprojects/libtsm.wrap
+++ b/subprojects/libtsm.wrap
@@ -2,7 +2,7 @@
 directory = libtsm
 
 url = https://github.com/kmscon/libtsm
-revision = v4.5.0
+revision = v4.6.0
 depth = 1
 
 [provide]


### PR DESCRIPTION
@kdj0c reminder that when you bump the dependency in `meson.build`, you need to also bump the meson subproject wrap to provide at least that version :P

Question: should we delete the `Compile and install libtsm` CI step so that this meson code path gets exercised, instead of manually doing the same thing in CI? I think this would lead to a better experience if CI does the same thing as the developers/packagers :)