### PR TITLE
issue: handle unavailable network addresses

### DIFF
--- a/src/misc/issue.c
+++ b/src/misc/issue.c
@@ -376,9 +376,15 @@ static void expand_ip(const char **ppos, const char *end, FILE *out, struct addr
 		      bool ipv6)
 {
 	char interface_name[IFNAMSIZ];
+	const char *address;
 
 	get_parameter(ppos, end, interface_name, sizeof(interface_name));
-	fputs(issue_network_get_best_ip(book, interface_name, ipv6), out);
+	if (!book)
+		return;
+
+	address = issue_network_get_best_ip(book, interface_name, ipv6);
+	if (address)
+		fputs(address, out);
 }
 
 static void expand_all_ip(const char **ppos, const char *end, FILE *out, struct addr_book *book,
@@ -386,8 +392,12 @@ static void expand_all_ip(const char **ppos, const char *end, FILE *out, struct 
 {
 	char *text;
 
+	if (!book)
+		return;
+
 	text = issue_network_get_all_ip(book, filter);
-	fputs(text, out);
+	if (text)
+		fputs(text, out);
 	free(text);
 }
 

--- a/tests/test_issue.c
+++ b/tests/test_issue.c
@@ -1,18 +1,58 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "issue.h"
 #include "issue_network.h"
 
 struct kmscon_pty;
 
+static int test_missing_interface(void)
+{
+	static const char issue[] = "\\4{no-such-if}\n";
+	char path[] = "/tmp/kmscon-test-issue-XXXXXX";
+	char *buf;
+	size_t buf_len = 0;
+	ssize_t len;
+	int fd;
+
+	fd = mkstemp(path);
+	if (fd < 0) {
+		perror("mkstemp");
+		return EXIT_FAILURE;
+	}
+
+	len = write(fd, issue, sizeof(issue) - 1);
+	close(fd);
+	if (len < 0 || (size_t)len != sizeof(issue) - 1) {
+		perror("write");
+		unlink(path);
+		return EXIT_FAILURE;
+	}
+
+	buf = kmscon_issue_get_buffer(path, "faketty1", &buf_len);
+	unlink(path);
+	if (!buf || buf_len != 2 || memcmp(buf, "\r\n", 2)) {
+		fprintf(stderr, "missing-interface expansion failed\n");
+		free(buf);
+		return EXIT_FAILURE;
+	}
+
+	free(buf);
+	return EXIT_SUCCESS;
+}
+
 int main()
 {
 	char *search_path = ISSUE_DEFAULT_PATH;
+	const char *ip;
 	size_t buf_len;
 	struct addr_book *book;
 	char *buf = kmscon_issue_get_buffer(search_path, "faketty1", &buf_len);
+
+	if (test_missing_interface())
+		return EXIT_FAILURE;
 
 	printf("%s\n", buf);
 	free(buf);
@@ -21,8 +61,10 @@ int main()
 
 	book = issue_network_gen_book();
 
-	printf("ipv4: %s\n", issue_network_get_best_ip(book, NULL, false));
-	printf("ipv6: %s\n", issue_network_get_best_ip(book, NULL, true));
+	ip = issue_network_get_best_ip(book, NULL, false);
+	printf("ipv4: %s\n", ip ? ip : "(none)");
+	ip = issue_network_get_best_ip(book, NULL, true);
+	printf("ipv6: %s\n", ip ? ip : "(none)");
 	printf("good ips: %s\n", issue_network_get_all_ip(book, true));
 	printf("all ips: %s\n", issue_network_get_all_ip(book, false));
 


### PR DESCRIPTION
## Summary

- avoid passing a null address to `fputs()` when an issue escape cannot resolve an address
- handle failures while building the network address book
- add a regression test for `\4{no-such-if}`

## Background

When `/etc/issue` requests an address for an interface that is temporarily unavailable, `issue_network_get_best_ip()` returns `NULL`. Passing that value to `fputs()` crashes kmscon while rendering the login issue.

## Testing

- `meson compile -C build`
- `meson test -C build --print-errorlogs` (5/5 passed)
