### PR TITLE
issue: consume oversized escape parameters

### DIFF
--- a/src/misc/issue.c
+++ b/src/misc/issue.c
@@ -258,14 +258,21 @@ static bool get_parameter(const char **ppos, const char *end, char *parameter, s
 	const char *pos = *ppos;
 	size_t l = 0;
 
+	if (!len)
+		return false;
+
 	parameter[0] = '\0';
 	if (pos >= end || *pos != '{')
 		return false;
 	pos++;
-	while (pos < end && *pos != '}' && l < len - 1)
-		parameter[l++] = *pos++;
-	parameter[l++] = '\0';
-	pos++;
+	while (pos < end && *pos != '}') {
+		if (l < len - 1)
+			parameter[l++] = *pos;
+		pos++;
+	}
+	parameter[l] = '\0';
+	if (pos < end)
+		pos++;
 	*ppos = pos;
 	return true;
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -51,3 +51,10 @@ test_issue = executable('test_issue', 'test_issue.c', '../src/misc/issue.c', '..
   dependencies: [libtsm_deps, shl_deps],
 )
 test('test_issue', test_issue)
+
+test_issue_parameter = executable('test_issue_parameter', 'test_issue_parameter.c',
+  '../src/misc/issue.c', '../src/misc/issue_network.c',
+  include_directories: misc_inc,
+  dependencies: [libtsm_deps, shl_deps],
+)
+test('test_issue_parameter', test_issue_parameter)

--- a/tests/test_issue_parameter.c
+++ b/tests/test_issue_parameter.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "issue.h"
+
+int main(void)
+{
+	static const char issue[] = "\\e{color-name-that-exceeds-buffer}suffix\n";
+	static const char expected[] = "\033suffix\r\n";
+	char path[] = "/tmp/kmscon-test-issue-parameter-XXXXXX";
+	char *buf;
+	size_t buf_len = 0;
+	ssize_t len;
+	int fd;
+
+	fd = mkstemp(path);
+	if (fd < 0) {
+		perror("mkstemp");
+		return EXIT_FAILURE;
+	}
+
+	len = write(fd, issue, sizeof(issue) - 1);
+	close(fd);
+	if (len < 0 || (size_t)len != sizeof(issue) - 1) {
+		perror("write");
+		unlink(path);
+		return EXIT_FAILURE;
+	}
+
+	buf = kmscon_issue_get_buffer(path, "faketty1", &buf_len);
+	unlink(path);
+	if (!buf || buf_len != sizeof(expected) - 1 ||
+	    memcmp(buf, expected, sizeof(expected) - 1)) {
+		fprintf(stderr, "long parameter expansion failed\n");
+		free(buf);
+		return EXIT_FAILURE;
+	}
+
+	free(buf);
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- keep scanning an escape parameter after its destination buffer is full
- consume the closing brace only when it is present
- reject zero-sized destination buffers safely
- add a regression test for an oversized escape parameter

## Background

`get_parameter()` stopped scanning as soon as the output buffer filled, then advanced by one byte. The unconsumed suffix of an oversized parameter was consequently rendered as literal issue text. An unterminated parameter could also advance the cursor past the input end.

## Testing

- `meson compile -C build`
- `meson test -C build --print-errorlogs` (6/6 passed)
