### PR TITLE
term: don't open pty when there are no screen

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -90,8 +90,7 @@ static int setup_seat(struct kmscon_app *app)
 	app->seat_ctx = kmscon_seat_get_conf(app->seat);
 	app->seat_conf = conf_ctx_get_mem(app->seat_ctx);
 
-	kmscon_seat_startup(app->seat);
-	return 0;
+	return kmscon_seat_startup(app->seat);
 }
 
 static void destroy_seat(struct kmscon_app *app)

--- a/src/seat.c
+++ b/src/seat.c
@@ -151,6 +151,8 @@ static void activate_display(struct kmscon_display *d)
 			s = shl_dlist_entry(iter, struct kmscon_session, list);
 			terminal_add_display(s->term, d->disp);
 		}
+		if (seat->current_sess)
+			terminal_activate(seat->current_sess->term);
 	}
 }
 
@@ -1054,24 +1056,24 @@ static void kmscon_seat_poll_video(void *data)
 	video_poll(vid->video);
 }
 
-void kmscon_seat_startup(struct kmscon_seat *seat)
+int kmscon_seat_startup(struct kmscon_seat *seat)
 {
-	struct kmscon_session *s;
-
 	if (!seat)
-		return;
+		return -ENODEV;
 
-	s = kmscon_seat_new_session(seat);
-	if (s)
-		seat_switch(seat, s);
-	else
+	seat->current_sess = kmscon_seat_new_session(seat);
+	if (!seat->current_sess) {
 		log_error("cannot create new session on seat %s", seat->name);
+		return -ENOMEM;
+	}
 
 	if (seat->conf->switchvt || uterm_vt_get_num(seat->vt) == 0)
 		uterm_vt_activate(seat->vt);
 
 	log_debug("scanning for devices...");
 	uterm_monitor_scan(seat->mon, seat->name);
+
+	return 0;
 }
 
 struct conf_ctx *kmscon_seat_get_conf(struct kmscon_seat *seat)

--- a/src/seat.h
+++ b/src/seat.h
@@ -52,7 +52,7 @@ int kmscon_seat_new(struct kmscon_seat **out, struct conf_ctx *main_conf,
 		    struct kmscon_conf_t *conf, struct ev_eloop *eloop, kmscon_seat_cb_t cb,
 		    void *data);
 void kmscon_seat_free(struct kmscon_seat *seat);
-void kmscon_seat_startup(struct kmscon_seat *seat);
+int kmscon_seat_startup(struct kmscon_seat *seat);
 int kmscon_seat_update_xkb_layout(struct kmscon_seat *seat, const char *model, const char *layout,
 				  const char *variant, const char *options);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1160,6 +1160,10 @@ void terminal_refresh_displays(struct kmscon_terminal *term)
 
 void terminal_activate(struct kmscon_terminal *term)
 {
+	// Don't open pty yet if there are no screens.
+	if (shl_dlist_empty(&term->screens))
+		return;
+
 	term->awake = true;
 	if (term->conf->blink)
 		ev_timer_enable(term->blink_timer);
@@ -1167,9 +1171,8 @@ void terminal_activate(struct kmscon_terminal *term)
 		terminal_open(term);
 	else
 		kmscon_asciinema_resume(term->asciinema);
-	if (term->pointer.visible)
-		hw_cursor_show(term, term->pointer.x, term->pointer.y);
-	redraw_all_text(term);
+
+	terminal_refresh_displays(term);
 }
 
 void terminal_deactivate(struct kmscon_terminal *term)


### PR DESCRIPTION
After the seat/session refactoring, the pty is opened before the first display is available.
This makes has_kms_display() returns false, and the env variable TERM_SESSION_TYPE is wrongly set to fb.

Fix #474 