### PR TITLE
seat: Fix segfault in uterm_monitor_set_dev_data()

### DIFF
--- a/src/seat.c
+++ b/src/seat.c
@@ -1010,6 +1010,7 @@ static int kmscon_seat_add_video(struct kmscon_seat *seat, enum uterm_monitor_de
 	return 0;
 
 err_node:
+	uterm_monitor_set_dev_data(udev, NULL);
 	free(vid->node);
 err_free:
 	free(vid);


### PR DESCRIPTION
In kmscon_seat_add_video(), if seat_video_init() fails, then the udev data pointer is still set to vid, which can lead to a use after free in kmscon_seat_remove_video(), and a segfault.

Fix #457 