### PR TITLE
tests/meson: fix formatting

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -67,9 +67,12 @@ test_issue = executable(
 )
 test('test_issue', test_issue)
 
-test_issue_parameter = executable('test_issue_parameter', 'test_issue_parameter.c',
-  '../src/misc/issue.c', '../src/misc/issue_network.c',
-  include_directories: misc_inc,
-  dependencies: [libtsm_deps, shl_deps],
+test_issue_parameter = executable(
+    'test_issue_parameter',
+    'test_issue_parameter.c',
+    '../src/misc/issue.c',
+    '../src/misc/issue_network.c',
+    include_directories: misc_inc,
+    dependencies: [libtsm_deps, shl_deps],
 )
 test('test_issue_parameter', test_issue_parameter)


### PR DESCRIPTION
@kdj0c this will fix all the PR that can't be merged right now

This was caused by https://github.com/kmscon/kmscon/pull/473 not being properly rebased after https://github.com/kmscon/kmscon/pull/470 was merged. I'm guessing there's a setting in github for that and it's set to not rebase, which leads to this sort of problems; given the tiny number of PRs that this project has and the quick CI run time (less than a minute), the cost of having to rebase before merging (wait for CI to run again) won't be noticable.