### PR TITLE
input: Fix mouse button order

### DIFF
--- a/src/input/input_pointer.c
+++ b/src/input/input_pointer.c
@@ -199,14 +199,14 @@ void pointer_dev_button(struct input_dev *dev, uint16_t code, int32_t value)
 		pointer_dev_send_button(dev, 0, pressed, dbl_click);
 		break;
 	case BTN_RIGHT:
-		dev->pointer.pressed_button = pressed ? 1 : BUTTON_NONE; /* Button 1 = right */
-		pointer_dev_send_button(dev, 1, pressed, false);
+		dev->pointer.pressed_button = pressed ? 2 : BUTTON_NONE; /* Button 2 = right */
+		pointer_dev_send_button(dev, 2, pressed, false);
 		break;
 	case BTN_TOOL_DOUBLETAP:
 	case BTN_TOOL_TRIPLETAP:
 	case BTN_MIDDLE:
-		dev->pointer.pressed_button = pressed ? 2 : BUTTON_NONE; /* Button 2 = middle */
-		pointer_dev_send_button(dev, 2, pressed, false);
+		dev->pointer.pressed_button = pressed ? 1 : BUTTON_NONE; /* Button 1 = middle */
+		pointer_dev_send_button(dev, 1, pressed, false);
 		break;
 	case BTN_TOUCH:
 		dev->pointer.touchpaddown = pressed;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -976,15 +976,16 @@ static void handle_pointer_button(struct kmscon_terminal *term, struct input_poi
 		}
 		break;
 	case 1:
-		term->pointer.select = false;
-		tsm_screen_selection_reset(term->console);
-		break;
-	case 2:
 		if (ev->pressed) {
 			if (term->pointer.copy && term->pointer.copy_len)
 				tsm_vte_paste(term->vte, term->pointer.copy);
 			tsm_screen_selection_reset(term->console);
 		}
+		break;
+	case 2:
+		term->pointer.select = false;
+		tsm_screen_selection_reset(term->console);
+		break;
 	}
 }
 


### PR DESCRIPTION
In VT100, the mouse order is different from evdev. So button 1 is middle, and button 2 is right.

Fix #484 