### PR TITLE
Add cursor style support

### DIFF
--- a/src/font/font.h
+++ b/src/font/font.h
@@ -46,6 +46,10 @@ struct kmscon_font_ops;
 #define KMSCON_FONT_DEFAULT_NAME "monospace"
 #define KMSCON_FONT_DEFAULT_PPI 72
 
+#define FONT_REPLACEMENT_CHAR 0x25a1
+#define FONT_FULL_BLOCK 0x2588
+#define FONT_VBAR 0x258e
+
 struct kmscon_font_attr {
 	char name[KMSCON_FONT_MAX_NAME];
 	bool bold;

--- a/src/font/font_8x16.c
+++ b/src/font/font_8x16.c
@@ -137,6 +137,10 @@ static struct kmscon_glyph *kmscon_font_8x16_render(struct kmscon_font *font, ui
 {
 	unsigned int scale = font->attr.height / 16;
 
+	if (ch == FONT_FULL_BLOCK)
+		ch = 219;
+	else if (ch == FONT_VBAR)
+		ch = 179;
 	if (ch >= 256)
 		return new_glyph('?', &font->attr, scale);
 

--- a/src/font/font_freetype.c
+++ b/src/font/font_freetype.c
@@ -340,7 +340,7 @@ static void copy_glyph(struct video_buffer *buf, FT_Face face, FT_Bitmap *map, b
 	uint8_t *dst;
 
 	if (!map->width || !map->rows)
-		return;
+		goto underline;
 
 	if (top < 0) {
 		top_src = -top;
@@ -358,7 +358,7 @@ static void copy_glyph(struct video_buffer *buf, FT_Face face, FT_Bitmap *map, b
 	width = min((int)(buf->width - left), (int)(map->width - left_src));
 
 	if (width <= 0 || height <= 0)
-		return;
+		goto underline;
 
 	dst = buf->data + left + top * buf->stride;
 	for (i = 0; i < height; i++) {
@@ -366,6 +366,7 @@ static void copy_glyph(struct video_buffer *buf, FT_Face face, FT_Bitmap *map, b
 		dst += buf->stride;
 	}
 
+underline:
 	if (underline)
 		draw_underline(buf, face);
 }

--- a/src/render/bbulk.c
+++ b/src/render/bbulk.c
@@ -441,23 +441,23 @@ static int bbulk_draw_cell(struct kmscon_text *txt, const struct tsm_screen_cell
 }
 
 static int bbulk_draw(struct kmscon_text *txt, const struct tsm_screen_cell *cells,
-		      unsigned int cur_x, unsigned int cur_y, bool cur_visible)
+		      struct kmscon_cursor *cursor)
 {
-	unsigned int posx, posy;
-	struct tsm_screen_cell cell;
+	unsigned int posx, posy, off;
 
 	for (posy = 0; posy < txt->rows; posy++) {
 		for (posx = 0; posx < txt->cols; posx++) {
-			cell = cells[posx + posy * txt->cols];
-			if (posx == cur_x && posy == cur_y && cur_visible) {
-				struct tsm_screen_color tmp;
-				tmp = cell.fg;
-				cell.fg = cell.bg;
-				cell.bg = tmp;
-			} else if (cell.attr2.blink && txt->blinking) {
+			off = posx + posy * txt->cols;
+
+			if (cursor->visible && cursor->x == posx && cursor->y == posy)
+				bbulk_draw_cell(txt, &cursor->cell, posx, posy);
+			else if (cells[off].attr2.blink && txt->blinking) {
+				struct tsm_screen_cell cell = cells[off];
+
 				cell.ch = ' ';
-			}
-			bbulk_draw_cell(txt, &cell, posx, posy);
+				bbulk_draw_cell(txt, &cell, posx, posy);
+			} else
+				bbulk_draw_cell(txt, &cells[off], posx, posy);
 		}
 	}
 	return 0;

--- a/src/render/gltex.c
+++ b/src/render/gltex.c
@@ -647,30 +647,24 @@ static int gltex_draw_cell(struct kmscon_text *txt, const struct tsm_screen_cell
 	return 0;
 }
 
-static int gltex_draw_cursor(struct kmscon_text *txt, const struct tsm_screen_cell *cell,
-			     unsigned int cur_x, unsigned int cur_y)
-{
-	struct tsm_screen_cell cursor_cell = *cell;
-
-	cursor_cell.fg = cell->bg;
-	cursor_cell.bg = cell->fg;
-
-	return gltex_draw_cell(txt, &cursor_cell, cur_x, cur_y);
-}
-
 static int gltex_draw(struct kmscon_text *txt, const struct tsm_screen_cell *cells,
-		      unsigned int cur_x, unsigned int cur_y, bool cur_visible)
+		      struct kmscon_cursor *cursor)
 {
-	unsigned int posx, posy;
+	unsigned int posx, posy, off;
 
 	for (posy = 0; posy < txt->rows; posy++) {
 		for (posx = 0; posx < txt->cols; posx++) {
-			const struct tsm_screen_cell *cell = &cells[posx + posy * txt->cols];
+			off = posx + posy * txt->cols;
 
-			if (posx == cur_x && posy == cur_y && cur_visible)
-				gltex_draw_cursor(txt, cell, cur_x, cur_y);
-			else
-				gltex_draw_cell(txt, cell, posx, posy);
+			if (cursor->visible && cursor->x == posx && cursor->y == posy)
+				gltex_draw_cell(txt, &cursor->cell, posx, posy);
+			else if (cells[off].attr2.blink && txt->blinking) {
+				struct tsm_screen_cell cell = cells[off];
+
+				cell.ch = ' ';
+				gltex_draw_cell(txt, &cell, posx, posy);
+			} else
+				gltex_draw_cell(txt, &cells[off], posx, posy);
 		}
 	}
 	return 0;

--- a/src/render/text.c
+++ b/src/render/text.c
@@ -461,7 +461,7 @@ static const uint32_t cursor_char[CURSOR_STYLES] = {
  *
  * Returns: 0 on success or negative error code if this glyph couldn't be drawn.
  */
-int kmscon_text_draw(struct kmscon_text *txt, struct tsm_screen *con)
+int kmscon_text_draw(struct kmscon_text *txt, struct tsm_screen *con, bool cursor_blink)
 {
 	const struct tsm_screen_cell *cells;
 	struct kmscon_cursor cursor = {0};
@@ -481,7 +481,7 @@ int kmscon_text_draw(struct kmscon_text *txt, struct tsm_screen *con)
 	cursor.cell.fg = cells[offset].fg;
 	cursor.cell.bg = cells[offset].bg;
 	if (is_cursor_blinking(style))
-		cursor.visible = cursor.visible && !txt->blinking;
+		cursor.visible = cursor.visible && !cursor_blink;
 	if (is_underline(style)) {
 		cursor.cell.attr2.underline = !cells[offset].attr2.underline;
 		cursor.cell.ch = cells[offset].ch;

--- a/src/render/text.c
+++ b/src/render/text.c
@@ -36,6 +36,7 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include "font/font.h"
 #include "shl/log.h"
 #include "shl/misc.h"
 #include "shl/register.h"
@@ -429,6 +430,28 @@ int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr, b
 	return ret;
 }
 
+static bool is_cursor_blinking(enum tsm_screen_cursor_style style)
+{
+	return (!style || style & 1);
+}
+
+static bool is_underline(enum tsm_screen_cursor_style style)
+{
+	return (style == TSM_SCREEN_CURSOR_UNDERLINE_BLINK ||
+		style == TSM_SCREEN_CURSOR_UNDERLINE_STEADY);
+}
+
+#define CURSOR_STYLES 7
+static const uint32_t cursor_char[CURSOR_STYLES] = {
+	FONT_FULL_BLOCK, // default
+	FONT_FULL_BLOCK, // block blink
+	FONT_FULL_BLOCK, // block steady
+	0,		 // underline blink
+	0,		 // underline steady
+	FONT_VBAR,	 // vbar blink
+	FONT_VBAR,	 // vbar steady
+};
+
 /**
  * kmscon_text_draw:
  * @txt: valid text renderer
@@ -441,18 +464,31 @@ int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr, b
 int kmscon_text_draw(struct kmscon_text *txt, struct tsm_screen *con)
 {
 	const struct tsm_screen_cell *cells;
-	unsigned int cur_x, cur_y;
-	bool cur_visible;
+	struct kmscon_cursor cursor = {0};
+	enum tsm_screen_cursor_style style;
+	unsigned offset;
 
 	if (!txt || !con)
 		return -EINVAL;
 
 	cells = tsm_screen_draw2(con);
-	cur_x = tsm_screen_get_cursor_x(con);
-	cur_y = tsm_screen_get_cursor_y(con);
-	cur_visible = !(tsm_screen_get_flags(con) & TSM_SCREEN_HIDE_CURSOR);
+	cursor.x = tsm_screen_get_cursor_x(con);
+	cursor.y = tsm_screen_get_cursor_y(con);
+	style = tsm_screen_get_cursor_style(con);
 
-	return txt->ops->draw(txt, cells, cur_x, cur_y, cur_visible && !txt->blinking);
+	offset = cursor.x + cursor.y * txt->cols;
+	cursor.visible = !(tsm_screen_get_flags(con) & TSM_SCREEN_HIDE_CURSOR);
+	cursor.cell.fg = cells[offset].fg;
+	cursor.cell.bg = cells[offset].bg;
+	if (is_cursor_blinking(style))
+		cursor.visible = cursor.visible && !txt->blinking;
+	if (is_underline(style)) {
+		cursor.cell.attr2.underline = !cells[offset].attr2.underline;
+		cursor.cell.ch = cells[offset].ch;
+	} else if (style < CURSOR_STYLES)
+		cursor.cell.ch = cursor_char[style];
+
+	return txt->ops->draw(txt, cells, &cursor);
 }
 
 /**

--- a/src/render/text.h
+++ b/src/render/text.h
@@ -69,6 +69,13 @@ struct kmscon_text {
 	bool blinking;
 };
 
+struct kmscon_cursor {
+	struct tsm_screen_cell cell;
+	unsigned int x;
+	unsigned int y;
+	bool visible;
+};
+
 struct kmscon_text_ops {
 	const char *name;
 	struct shl_module *owner;
@@ -80,7 +87,7 @@ struct kmscon_text_ops {
 	int (*rotate)(struct kmscon_text *txt, enum Orientation orientation);
 	int (*prepare)(struct kmscon_text *txt, struct tsm_screen_attr *attr);
 	int (*draw)(struct kmscon_text *txt, const struct tsm_screen_cell *cells,
-		    unsigned int cur_x, unsigned int cur_y, bool cur_visible);
+		    struct kmscon_cursor *cursor);
 	int (*draw_pointer)(struct kmscon_text *txt, unsigned int x, unsigned int y);
 	int (*render)(struct kmscon_text *txt);
 	void (*abort)(struct kmscon_text *txt);

--- a/src/render/text.h
+++ b/src/render/text.h
@@ -113,7 +113,7 @@ void kmscon_text_resize(struct kmscon_text *txt, unsigned int cols, unsigned int
 int kmscon_text_rotate(struct kmscon_text *txt, enum Orientation orientation);
 
 int kmscon_text_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr, bool blinking);
-int kmscon_text_draw(struct kmscon_text *txt, struct tsm_screen *con);
+int kmscon_text_draw(struct kmscon_text *txt, struct tsm_screen *con, bool cursor_blink);
 int kmscon_text_draw_pointer(struct kmscon_text *txt, unsigned int x, unsigned int y);
 int kmscon_text_render(struct kmscon_text *txt);
 void kmscon_text_abort(struct kmscon_text *txt);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -102,11 +102,15 @@ struct kmscon_terminal {
 	struct kmscon_pointer pointer;
 
 	struct ev_timer *blink_timer;
+	struct ev_timer *blink_cursor;
 	bool blinking;
+	bool cursor_blinking;
+
 	struct kmscon_asciinema *asciinema;
 };
 
-#define BLINK_TIMER_NS (500 * 1000 * 1000)
+#define BLINK_TIMER_NS (500 * 1000 * 1000) // Blinking interval 500ms
+#define BLINK_CURSOR_TYPING 1		   // After keypress, wait 1s before blinking the cursor
 
 static int font_set(struct kmscon_terminal *term);
 
@@ -310,7 +314,7 @@ static void do_redraw_screen(struct screen *scr)
 
 	tsm_vte_get_def_attr(scr->term->vte, &attr);
 	kmscon_text_prepare(scr->txt, &attr, scr->term->blinking);
-	kmscon_text_draw(scr->txt, scr->term->console);
+	kmscon_text_draw(scr->txt, scr->term->console, scr->term->cursor_blinking);
 	draw_pointer(scr);
 	kmscon_text_render(scr->txt);
 
@@ -439,6 +443,17 @@ static void blink_event(struct ev_timer *timer, uint64_t count, void *data)
 		return;
 
 	term->blinking = !term->blinking;
+	redraw_all(term);
+}
+
+static void cursor_blink_event(struct ev_timer *timer, uint64_t count, void *data)
+{
+	struct kmscon_terminal *term = data;
+
+	if (!term->awake)
+		return;
+
+	term->cursor_blinking = !term->cursor_blinking;
 	redraw_all(term);
 }
 
@@ -820,6 +835,10 @@ static void zoom_out(struct kmscon_terminal *term)
 static void input_event(struct input *input, struct input_key_event *ev, void *data)
 {
 	struct kmscon_terminal *term = data;
+	struct itimerspec blink_interval = {
+		.it_interval = {0, BLINK_TIMER_NS},
+		.it_value = {BLINK_CURSOR_TYPING, 0},
+	};
 
 	if (!term->opened || !term->awake || ev->handled ||
 	    !kmscon_session_get_foreground(term->session))
@@ -828,6 +847,8 @@ static void input_event(struct input *input, struct input_key_event *ev, void *d
 	// reset mouse selection on keypress
 	tsm_screen_selection_reset(term->console);
 	kmscon_asciinema_stop(term->asciinema);
+	term->cursor_blinking = false;
+	ev_timer_update(term->blink_cursor, &blink_interval);
 
 	if (conf_grab_matches(term->conf->grab_scroll_up, ev->mods, ev->num_syms, ev->keysyms)) {
 		tsm_screen_sb_up(term->console, 1);
@@ -1166,8 +1187,10 @@ void terminal_activate(struct kmscon_terminal *term)
 		return;
 
 	term->awake = true;
-	if (term->conf->blink)
+	if (term->conf->blink) {
 		ev_timer_enable(term->blink_timer);
+		ev_timer_enable(term->blink_cursor);
+	}
 	if (!term->opened)
 		terminal_open(term);
 	else
@@ -1180,8 +1203,10 @@ void terminal_deactivate(struct kmscon_terminal *term)
 {
 	term->awake = false;
 	hw_cursor_hide(term);
-	if (term->conf->blink)
+	if (term->conf->blink) {
 		ev_timer_disable(term->blink_timer);
+		ev_timer_disable(term->blink_cursor);
+	}
 	kmscon_asciinema_pause(term->asciinema);
 }
 
@@ -1192,6 +1217,7 @@ void terminal_destroy(struct kmscon_terminal *term)
 	terminal_close(term);
 	rm_all_screens(term);
 	ev_eloop_rm_timer(term->blink_timer);
+	ev_eloop_rm_timer(term->blink_cursor);
 	kmscon_asciinema_free(term->asciinema);
 	input_unregister_pointer_cb(term->input, pointer_event, term);
 	input_unregister_key_cb(term->input, input_event, term);
@@ -1329,6 +1355,10 @@ struct kmscon_terminal *terminal_new(struct kmscon_session *session, unsigned in
 					 blink_event, term);
 		if (ret)
 			goto err_pointer;
+		ret = ev_eloop_new_timer(term->eloop, &term->blink_cursor, &blink_interval,
+					 cursor_blink_event, term);
+		if (ret)
+			goto err_blink;
 	}
 	if (term->conf->asciicast) {
 		ret = kmscon_asciinema_new(&term->asciinema, term->eloop, term->conf->asciicast,
@@ -1342,6 +1372,8 @@ struct kmscon_terminal *terminal_new(struct kmscon_session *session, unsigned in
 	log_debug("new terminal object %p", term);
 	return term;
 
+err_blink:
+	ev_eloop_rm_timer(term->blink_timer);
 err_pointer:
 	input_unregister_pointer_cb(term->input, pointer_event, term);
 err_input:

--- a/subprojects/libtsm.wrap
+++ b/subprojects/libtsm.wrap
@@ -2,7 +2,7 @@
 directory = libtsm
 
 url = https://github.com/kmscon/libtsm
-revision = v4.6.0
+revision = v4.7.0
 depth = 1
 
 [provide]


### PR DESCRIPTION
Now that libtsm supports it, with https://github.com/kmscon/libtsm/pull/58 
We can change the cursor style in kmscon.

3 cursor shape:
* block (default)
* vertical bar
* underline

Each shape can be blinking or steady.

To change the cursor style, use:
blinking underline: `printf "\e[3 q"`
steady underline: `printf "\e[4 q"`
blinking vbar : `printf "\e[5 q"`
steady vbar : `printf "\e[6 q"`

Adding a commit to Fix #483 in the same PR


