### PR TITLE
misc: Fix modifiers check for keyboard shortcut

### DIFF
--- a/src/shl/misc.h
+++ b/src/shl/misc.h
@@ -556,7 +556,7 @@ static inline bool shl_grab_matches(unsigned int ev_mods, unsigned int ev_num_sy
 				    const uint32_t *ev_syms, unsigned int grab_mods,
 				    unsigned int grab_num_syms, const uint32_t *grab_syms)
 {
-	if (!SHL_HAS_BITS(ev_mods, grab_mods))
+	if (ev_mods != grab_mods)
 		return false;
 
 	if (grab_num_syms != 0) {


### PR DESCRIPTION
The current check is too permissive. It only checks that the required modifier are pressed, but ignore the others.
So if you bind shift+up, it will also match ctrl+shift+up and shift+logo+up Fix it by checking that the mods match exactly the shortcut.

Fix #491 