### PR TITLE
freetype: Fix top if it may crop the glyph for bitmap fonts

### DIFF
--- a/src/font/font.c
+++ b/src/font/font.c
@@ -221,7 +221,7 @@ int kmscon_font_find(struct kmscon_font **out, const struct kmscon_font_attr *at
 		goto err_free;
 
 	log_debug("using: be: %s nm: %s b: %d size %ux%u", font->ops->name, font->attr.name,
-		  font->attr.bold, font->attr.height, font->attr.width);
+		  font->attr.bold, font->attr.width, font->attr.height);
 	*out = font;
 	return 0;
 

--- a/src/font/font_freetype.c
+++ b/src/font/font_freetype.c
@@ -287,6 +287,8 @@ static void copy_mono(struct video_buffer *buf, FT_GlyphSlot glyph, unsigned int
 	uint8_t *dst = buf->data;
 	int i, j, w, h;
 
+	if (top + map->rows > buf->height)
+		top = buf->height - map->rows;
 	if (top < 0)
 		top = 0;
 	if (left < 0)


### PR DESCRIPTION
Try to not crop the glyph if possible, but respect ascender and bitmap_top otherwise

Fix #438 