### PR TITLE
dbus: silence DBUS_ERROR_SERVICE_UNKNOWN errors

### DIFF
--- a/src/misc/dbus.c
+++ b/src/misc/dbus.c
@@ -78,7 +78,8 @@ static void set_env_from_locale1_properties(DBusConnection *conn, const char *pr
 	dbus_message_unref(msg);
 
 	if (dbus_error_has_name(&error, DBUS_ERROR_UNKNOWN_INTERFACE) ||
-	    dbus_error_has_name(&error, DBUS_ERROR_UNKNOWN_PROPERTY)) {
+	    dbus_error_has_name(&error, DBUS_ERROR_UNKNOWN_PROPERTY) ||
+	    dbus_error_has_name(&error, DBUS_ERROR_SERVICE_UNKNOWN)) {
 		/* This is normal if the interface is not supported by the system */
 		dbus_error_free(&error);
 		return;


### PR DESCRIPTION
When on a system without systemd, org.freedesktop.locale1 isn't a valid service, which can cause pointless warning messages on startup. We can just silence DBUS_ERROR_SERVICE_UNKNOWN errors when making those initial method calls.

Fixes×2 #213.
