### PR TITLE
Remove stride in glyph buffer

### DIFF
--- a/src/font/font_8x16.c
+++ b/src/font/font_8x16.c
@@ -115,14 +115,13 @@ static struct kmscon_glyph *new_glyph(uint32_t ch, const struct kmscon_font_attr
 	glyph->double_width = false;
 	glyph->buf.width = w;
 	glyph->buf.height = h;
-	glyph->buf.stride = w;
 
 	for (i = 0; i < h; i++) {
 		for (j = 0; j < w; j++) {
 			k = i / scale;
 			l = j / scale;
 			c = apply_attr((uint8_t)font_data[k], attr, k == 15);
-			glyph->buf.data[i * glyph->buf.stride + j] = unfold(c & (1 << (7 - l)));
+			glyph->buf.data[i * glyph->buf.width + j] = unfold(c & (1 << (7 - l)));
 		}
 	}
 	return glyph;

--- a/src/font/font_freetype.c
+++ b/src/font/font_freetype.c
@@ -299,15 +299,15 @@ static void copy_mono(struct video_buffer *buf, FT_GlyphSlot glyph, unsigned int
 
 	for (i = 0; i < h; i++) {
 		for (j = 0; j < w; j++)
-			dst[j + top * buf->stride + left] =
+			dst[j + top * buf->width + left] =
 				!!(src[j / 8] & (1 << (7 - (j % 8)))) * 0xff;
 
-		dst += buf->stride;
+		dst += buf->width;
 		src += map->pitch;
 	}
 	if (underline)
 		for (j = 0; j < buf->width; j++)
-			buf->data[(buf->height - 1) * buf->stride + j] = 0xff;
+			buf->data[(buf->height - 1) * buf->width + j] = 0xff;
 }
 
 static void draw_underline(struct video_buffer *buf, FT_Face face)
@@ -328,7 +328,7 @@ static void draw_underline(struct video_buffer *buf, FT_Face face)
 
 	for (i = position; i < position + thickness; i++)
 		for (j = 0; j < buf->width; j++)
-			buf->data[i * buf->stride + j] = 0xff;
+			buf->data[i * buf->width + j] = 0xff;
 }
 
 static void copy_glyph(struct video_buffer *buf, FT_Face face, FT_Bitmap *map, bool underline)
@@ -362,10 +362,10 @@ static void copy_glyph(struct video_buffer *buf, FT_Face face, FT_Bitmap *map, b
 	if (width <= 0 || height <= 0)
 		goto underline;
 
-	dst = buf->data + left + top * buf->stride;
+	dst = buf->data + left + top * buf->width;
 	for (i = 0; i < height; i++) {
 		memcpy(dst, &map->buffer[(i + top_src) * map->pitch + left_src], width);
-		dst += buf->stride;
+		dst += buf->width;
 	}
 
 underline:
@@ -404,7 +404,6 @@ static struct kmscon_glyph *render_glyph(FT_Face face, FT_UInt index, uint32_t c
 	glyph->double_width = cwidth == 2;
 	glyph->buf.width = attr->width * cwidth;
 	glyph->buf.height = attr->height;
-	glyph->buf.stride = glyph->buf.width;
 
 	if (face->glyph->bitmap.pixel_mode == FT_PIXEL_MODE_MONO)
 		copy_mono(&glyph->buf, face->glyph, face->size->metrics.ascender >> 6,

--- a/src/font/font_pango.c
+++ b/src/font/font_pango.c
@@ -180,11 +180,10 @@ static struct kmscon_glyph *get_glyph(struct face *face, const uint32_t ch,
 	glyph->double_width = cwidth == 2;
 	glyph->buf.width = face->real_attr.width * cwidth;
 	glyph->buf.height = face->real_attr.height;
-	glyph->buf.stride = glyph->buf.width;
 
 	bitmap.rows = glyph->buf.height;
 	bitmap.width = glyph->buf.width;
-	bitmap.pitch = glyph->buf.stride;
+	bitmap.pitch = glyph->buf.width;
 	bitmap.num_grays = 256;
 	bitmap.pixel_mode = FT_PIXEL_MODE_GRAY;
 	bitmap.buffer = glyph->buf.data;

--- a/src/font/font_psf.c
+++ b/src/font/font_psf.c
@@ -206,7 +206,6 @@ static struct kmscon_glyph *new_glyph(uint32_t ch, const struct kmscon_font *kfo
 	glyph->double_width = false;
 	glyph->buf.width = w;
 	glyph->buf.height = h;
-	glyph->buf.stride = w;
 
 	for (i = 0; i < h; i++) {
 		k = i / font->scale;
@@ -215,7 +214,7 @@ static struct kmscon_glyph *new_glyph(uint32_t ch, const struct kmscon_font *kfo
 
 		for (j = 0; j < w; j++) {
 			l = j / font->scale;
-			glyph->buf.data[i * glyph->buf.stride + j] =
+			glyph->buf.data[i * glyph->buf.width + j] =
 				unfold(c & (1 << (font->width - 1 - l)));
 		}
 	}

--- a/src/font/font_unifont.c
+++ b/src/font/font_unifont.c
@@ -131,7 +131,6 @@ static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const
 	g->double_width = (cwidth == 2);
 	g->buf.width = cwidth * attr->width;
 	g->buf.height = attr->height;
-	g->buf.stride = g->buf.width;
 
 	/* Unpack the glyph and apply scaling */
 	for (i = 0; i < 16; i++) {
@@ -148,9 +147,9 @@ static struct kmscon_glyph *new_glyph(const struct kmscon_font_attr *attr, const
 			}
 		}
 		for (k = 1; k < scale; k++) {
-			memcpy(&g->buf.data[off], &g->buf.data[i * scale * g->buf.stride],
-			       g->buf.stride);
-			off += g->buf.stride;
+			memcpy(&g->buf.data[off], &g->buf.data[i * scale * g->buf.width],
+			       g->buf.width);
+			off += g->buf.width;
 		}
 	}
 	return g;

--- a/src/render/bbulk.c
+++ b/src/render/bbulk.c
@@ -258,16 +258,16 @@ static struct kmscon_glyph *bbulk_rotate_glyph(struct kmscon_glyph *glyph,
 			for (j = 0; j < buf->width; j++) {
 				dst[j * width + (width - i - 1)] = src[j];
 			}
-			src += buf->stride;
+			src += buf->width;
 		}
 		break;
 	case OR_UPSIDE_DOWN:
-		src += (buf->height - 1) * buf->stride;
+		src += (buf->height - 1) * buf->width;
 		for (i = 0; i < buf->height; i++) {
 			for (j = 0; j < buf->width; j++)
 				dst[j] = src[buf->width - j - 1];
 			dst += width;
-			src -= buf->stride;
+			src -= buf->width;
 		}
 		break;
 	case OR_LEFT:
@@ -275,12 +275,11 @@ static struct kmscon_glyph *bbulk_rotate_glyph(struct kmscon_glyph *glyph,
 			for (j = 0; j < buf->width; j++) {
 				dst[(height - j - 1) * width + i] = src[j];
 			}
-			src += buf->stride;
+			src += buf->width;
 		}
 	}
 	rglyph->buf.width = width;
 	rglyph->buf.height = height;
-	rglyph->buf.stride = width;
 	rglyph->double_width = glyph->double_width;
 
 err_free:

--- a/src/render/gltex.c
+++ b/src/render/gltex.c
@@ -58,11 +58,6 @@
 
 #define LOG_SUBSYSTEM "text_gltex"
 
-/* thanks khronos for breaking backwards compatibility.. */
-#if !defined(GL_UNPACK_ROW_LENGTH) && defined(GL_UNPACK_ROW_LENGTH_EXT)
-#define GL_UNPACK_ROW_LENGTH GL_UNPACK_ROW_LENGTH_EXT
-#endif
-
 struct atlas {
 	struct shl_dlist list;
 
@@ -97,7 +92,6 @@ struct gl_glyph {
 struct gltex {
 	struct shl_hashtable *glyphs;
 	unsigned int max_tex_size;
-	bool supports_rowlen;
 	bool previous_overflow;
 
 	struct shl_dlist atlases;
@@ -188,7 +182,6 @@ static int gltex_set(struct kmscon_text *txt)
 	const char *vert, *frag;
 	static char *attr[] = {"position", "texture_position", "fgcolor", "bgcolor"};
 	GLint s;
-	const char *ext;
 
 	if (!display_has_opengl(txt->disp))
 		return -EINVAL;
@@ -249,15 +242,6 @@ static int gltex_set(struct kmscon_text *txt)
 	gt->max_tex_size = s;
 
 	gl_clear_error();
-
-	ext = (const char *)glGetString(GL_EXTENSIONS);
-	if (ext && strstr((const char *)ext, "GL_EXT_unpack_subimage")) {
-		gt->supports_rowlen = true;
-	} else {
-		log_warning("your GL implementation does not support GL_EXT_unpack_subimage, "
-			    "glyph-rendering may be slower than usual");
-	}
-
 	return 0;
 
 err_shader:
@@ -412,10 +396,7 @@ static struct gl_glyph *find_glyph(struct kmscon_text *txt, const struct tsm_scr
 	struct gltex *gt = txt->data;
 	struct atlas *atlas;
 	struct gl_glyph *glglyph;
-	int i;
 	GLenum err;
-	uint8_t *packed_data, *dst;
-	const uint8_t *src;
 	struct kmscon_font *font = txt->font;
 	unsigned int num;
 	struct kmscon_glyph *glyph;
@@ -453,49 +434,12 @@ static struct gl_glyph *find_glyph(struct kmscon_text *txt, const struct tsm_scr
 	if (!atlas)
 		goto err_free;
 
-	/* Funnily, not all OpenGLESv2 implementations support specifying the
-	 * stride of a texture. Therefore, we then need to create a
-	 * temporary image with a stride equal to the image width for loading
-	 * the texture. This may slow down loading new glyphs but doesn't affect
-	 * overall rendering performance. But driver developers should really
-	 * add this! */
-
 	gl_clear_error();
 
 	glBindTexture(GL_TEXTURE_2D, atlas->tex);
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-	if (!gt->supports_rowlen) {
-		if (GLYPH_STRIDE(glyph) == GLYPH_WIDTH(glyph)) {
-			glTexSubImage2D(GL_TEXTURE_2D, 0, FONT_WIDTH(txt) * atlas->fill, 0,
-					GLYPH_WIDTH(glyph), GLYPH_HEIGHT(glyph), GL_ALPHA,
-					GL_UNSIGNED_BYTE, GLYPH_DATA(glyph));
-		} else {
-			packed_data = malloc(GLYPH_WIDTH(glyph) * GLYPH_HEIGHT(glyph));
-			if (!packed_data) {
-				log_error("cannot allocate memory for glyph storage");
-				goto err_free;
-			}
-
-			src = GLYPH_DATA(glyph);
-			dst = packed_data;
-			for (i = 0; i < GLYPH_HEIGHT(glyph); ++i) {
-				memcpy(dst, src, GLYPH_WIDTH(glyph));
-				dst += GLYPH_WIDTH(glyph);
-				src += GLYPH_STRIDE(glyph);
-			}
-
-			glTexSubImage2D(GL_TEXTURE_2D, 0, FONT_WIDTH(txt) * atlas->fill, 0,
-					GLYPH_WIDTH(glyph), GLYPH_HEIGHT(glyph), GL_ALPHA,
-					GL_UNSIGNED_BYTE, packed_data);
-			free(packed_data);
-		}
-	} else {
-		glPixelStorei(GL_UNPACK_ROW_LENGTH, GLYPH_STRIDE(glyph));
-		glTexSubImage2D(GL_TEXTURE_2D, 0, FONT_WIDTH(txt) * atlas->fill, 0,
-				GLYPH_WIDTH(glyph), GLYPH_HEIGHT(glyph), GL_ALPHA, GL_UNSIGNED_BYTE,
-				GLYPH_DATA(glyph));
-		glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-	}
+	glTexSubImage2D(GL_TEXTURE_2D, 0, FONT_WIDTH(txt) * atlas->fill, 0, GLYPH_WIDTH(glyph),
+			GLYPH_HEIGHT(glyph), GL_ALPHA, GL_UNSIGNED_BYTE, GLYPH_DATA(glyph));
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 
 	/* Check for GL-errors

--- a/src/video/drm2d_render.c
+++ b/src/video/drm2d_render.c
@@ -112,7 +112,7 @@ int drm2d_display_blend(struct display *disp, const struct video_blend_req *req)
 			((uint32_t *)dst)[i] = out;
 		}
 		dst += rb->stride;
-		src += req->buf->stride;
+		src += req->buf->width;
 	}
 	return 0;
 }

--- a/src/video/fbdev_render.c
+++ b/src/video/fbdev_render.c
@@ -174,7 +174,7 @@ int fbdev_display_blend(struct display *disp, const struct video_blend_req *req)
 				((uint32_t *)dst)[i] = val;
 			}
 			dst += fbdev->stride;
-			src += req->buf->stride;
+			src += req->buf->width;
 		}
 	} else if (fbdev->Bpp == 2) {
 		while (height--) {
@@ -199,7 +199,7 @@ int fbdev_display_blend(struct display *disp, const struct video_blend_req *req)
 				((uint16_t *)dst)[i] = xrgb32_to_device(disp, val);
 			}
 			dst += fbdev->stride;
-			src += req->buf->stride;
+			src += req->buf->width;
 		}
 	} else if (fbdev->Bpp == 3) {
 		while (height--) {
@@ -225,7 +225,7 @@ int fbdev_display_blend(struct display *disp, const struct video_blend_req *req)
 				write_24bit(&dst[i * 3], full);
 			}
 			dst += fbdev->stride;
-			src += req->buf->stride;
+			src += req->buf->width;
 		}
 	} else if (fbdev->Bpp == 4) {
 		while (height--) {
@@ -250,7 +250,7 @@ int fbdev_display_blend(struct display *disp, const struct video_blend_req *req)
 				((uint32_t *)dst)[i] = xrgb32_to_device(disp, val);
 			}
 			dst += fbdev->stride;
-			src += req->buf->stride;
+			src += req->buf->width;
 		}
 	} else {
 		log_warning("invalid Bpp");

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -38,6 +38,7 @@
 #include "shl/eloop.h"
 #include "shl/hook.h"
 #include "shl/log.h"
+#include "shl/misc.h"
 #include "shl/module.h"
 #include "shl/register.h"
 #include "video.h"
@@ -54,6 +55,7 @@ static inline void video_destroy(void *data)
 	shl_module_unref(ops->owner);
 }
 
+SHL_EXPORT
 const char *dpms_to_name(enum display_dpms dpms)
 {
 	switch (dpms) {
@@ -107,6 +109,7 @@ err_free:
 	return ret;
 }
 
+SHL_EXPORT
 void display_ref(struct display *disp)
 {
 	if (!disp || !disp->ref)
@@ -115,6 +118,7 @@ void display_ref(struct display *disp)
 	++disp->ref;
 }
 
+SHL_EXPORT
 void display_unref(struct display *disp)
 {
 	if (!disp || !disp->ref || --disp->ref)
@@ -128,6 +132,7 @@ void display_unref(struct display *disp)
 	free(disp);
 }
 
+SHL_EXPORT
 int display_bind(struct display *disp)
 {
 	if (!disp || !disp->video)
@@ -139,6 +144,7 @@ int display_bind(struct display *disp)
 	return 0;
 }
 
+SHL_EXPORT
 void display_ready(struct display *disp)
 {
 	if (!disp || !disp->video || disp->flags & DISPLAY_INUSE)
@@ -148,6 +154,7 @@ void display_ready(struct display *disp)
 	disp->video->cb->new_disp(disp->video->cb_data, disp);
 }
 
+SHL_EXPORT
 void display_unbind(struct display *disp)
 {
 	if (!disp || !disp->video)
@@ -158,21 +165,25 @@ void display_unbind(struct display *disp)
 	display_unref(disp);
 }
 
+SHL_EXPORT
 bool display_is_drm(struct display *disp)
 {
 	return (disp->flags & DISPLAY_DITHERING) == 0;
 }
 
+SHL_EXPORT
 bool display_has_opengl(struct display *disp)
 {
 	return (disp->flags & DISPLAY_OPENGL) != 0;
 }
 
+SHL_EXPORT
 bool display_supports_damage(struct display *disp)
 {
 	return (disp->flags & DISPLAY_DAMAGE) != 0;
 }
 
+SHL_EXPORT
 const char *display_backend_name(struct display *disp)
 {
 	if (disp && disp->video && disp->video->ops)
@@ -180,6 +191,7 @@ const char *display_backend_name(struct display *disp)
 	return "Unknown";
 }
 
+SHL_EXPORT
 const char *display_name(struct display *disp)
 {
 	if (disp && disp->name)
@@ -187,6 +199,7 @@ const char *display_name(struct display *disp)
 	return "Unknown";
 }
 
+SHL_EXPORT
 struct video *display_video(struct display *disp)
 {
 	if (!disp)
@@ -194,6 +207,7 @@ struct video *display_video(struct display *disp)
 	return disp->video;
 }
 
+SHL_EXPORT
 int display_register_pageflip(struct display *disp, display_pageflip_cb cb, void *data)
 {
 	if (!disp)
@@ -202,6 +216,7 @@ int display_register_pageflip(struct display *disp, display_pageflip_cb cb, void
 	return shl_hook_add_cast(disp->hook, cb, data, false);
 }
 
+SHL_EXPORT
 void display_unregister_pageflip(struct display *disp, display_pageflip_cb cb, void *data)
 {
 	if (!disp)
@@ -210,6 +225,7 @@ void display_unregister_pageflip(struct display *disp, display_pageflip_cb cb, v
 	shl_hook_rm_cast(disp->hook, cb, data);
 }
 
+SHL_EXPORT
 unsigned int display_get_width(struct display *disp)
 {
 	if (!disp)
@@ -218,6 +234,7 @@ unsigned int display_get_width(struct display *disp)
 	return disp->width;
 }
 
+SHL_EXPORT
 unsigned int display_get_height(struct display *disp)
 {
 	if (!disp)
@@ -226,6 +243,7 @@ unsigned int display_get_height(struct display *disp)
 	return disp->height;
 }
 
+SHL_EXPORT
 int display_get_state(struct display *disp)
 {
 	if (!disp || !disp->video)
@@ -238,6 +256,7 @@ int display_get_state(struct display *disp)
 	return DISPLAY_ASLEEP;
 }
 
+SHL_EXPORT
 int display_set_dpms(struct display *disp, enum display_dpms dpms)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
@@ -247,6 +266,7 @@ int display_set_dpms(struct display *disp, enum display_dpms dpms)
 	return 0;
 }
 
+SHL_EXPORT
 enum display_dpms display_get_dpms(const struct display *disp)
 {
 	if (!disp || !disp->video)
@@ -255,6 +275,7 @@ enum display_dpms display_get_dpms(const struct display *disp)
 	return disp->dpms;
 }
 
+SHL_EXPORT
 int display_use(struct display *disp)
 {
 	if (!disp || !display_is_online(disp) || !disp->ops->use)
@@ -263,6 +284,7 @@ int display_use(struct display *disp)
 	return disp->ops->use(disp);
 }
 
+SHL_EXPORT
 int display_swap(struct display *disp)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
@@ -272,6 +294,7 @@ int display_swap(struct display *disp)
 	return 0;
 }
 
+SHL_EXPORT
 bool display_is_swapping(struct display *disp)
 {
 	if (!disp || !disp->ops->is_swapping)
@@ -280,6 +303,7 @@ bool display_is_swapping(struct display *disp)
 	return disp->ops->is_swapping(disp);
 }
 
+SHL_EXPORT
 int display_clear(struct display *disp, uint8_t r, uint8_t g, uint8_t b)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video) || !disp->ops->clear)
@@ -288,6 +312,7 @@ int display_clear(struct display *disp, uint8_t r, uint8_t g, uint8_t b)
 	return disp->ops->clear(disp, r, g, b);
 }
 
+SHL_EXPORT
 int display_blend(struct display *disp, const struct video_blend_req *req)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
@@ -298,6 +323,7 @@ int display_blend(struct display *disp, const struct video_blend_req *req)
 	return -EOPNOTSUPP;
 }
 
+SHL_EXPORT
 void display_set_need_redraw(struct display *disp)
 {
 	if (!disp || !display_is_online(disp))
@@ -306,6 +332,7 @@ void display_set_need_redraw(struct display *disp)
 	disp->flags |= DISPLAY_NEED_REDRAW;
 }
 
+SHL_EXPORT
 bool display_need_redraw(struct display *disp)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
@@ -314,6 +341,7 @@ bool display_need_redraw(struct display *disp)
 	return (disp->flags & DISPLAY_NEED_REDRAW) != 0;
 }
 
+SHL_EXPORT
 int display_setup_cursor(struct display *disp, const uint32_t *pixels, unsigned int width,
 			 unsigned int height, int hot_x, int hot_y)
 {
@@ -325,12 +353,14 @@ int display_setup_cursor(struct display *disp, const uint32_t *pixels, unsigned 
 	return -EOPNOTSUPP;
 }
 
+SHL_EXPORT
 void display_destroy_cursor(struct display *disp)
 {
 	if (disp && disp->ops->destroy_cursor)
 		disp->ops->destroy_cursor(disp);
 }
 
+SHL_EXPORT
 int display_show_cursor(struct display *disp, int32_t x, int32_t y)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
@@ -341,6 +371,7 @@ int display_show_cursor(struct display *disp, int32_t x, int32_t y)
 	return -EOPNOTSUPP;
 }
 
+SHL_EXPORT
 int display_hide_cursor(struct display *disp)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
@@ -351,6 +382,7 @@ int display_hide_cursor(struct display *disp)
 	return -EOPNOTSUPP;
 }
 
+SHL_EXPORT
 void display_set_cursor_offset(struct display *disp, int32_t x, int32_t y)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
@@ -360,6 +392,7 @@ void display_set_cursor_offset(struct display *disp, int32_t x, int32_t y)
 		disp->ops->set_cursor_offset(disp, x, y);
 }
 
+SHL_EXPORT
 void display_set_damage(struct display *disp, size_t n_rect, struct video_rect *damages)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
@@ -369,6 +402,7 @@ void display_set_damage(struct display *disp, size_t n_rect, struct video_rect *
 		disp->ops->set_damage(disp, n_rect, damages);
 }
 
+SHL_EXPORT
 bool display_has_damage(struct display *disp)
 {
 	if (!disp || !display_is_online(disp) || !video_is_awake(disp->video))
@@ -379,6 +413,7 @@ bool display_has_damage(struct display *disp)
 	return false;
 }
 
+SHL_EXPORT
 int video_new(struct video **out, struct ev_eloop *eloop, int fd, const char *backend,
 	      struct video_cb *cb, void *data, unsigned int desired_width,
 	      unsigned int desired_height, bool use_original)
@@ -436,6 +471,7 @@ err_unref:
 	return ret;
 }
 
+SHL_EXPORT
 void video_ref(struct video *video)
 {
 	if (!video || !video->ref)
@@ -444,6 +480,7 @@ void video_ref(struct video *video)
 	++video->ref;
 }
 
+SHL_EXPORT
 void video_unref(struct video *video)
 {
 	struct display *disp;
@@ -473,7 +510,7 @@ void video_unref(struct video *video)
  *
  * Returns: 0 on success, negative error code on failure
  */
-
+SHL_EXPORT
 int video_register(const struct video_ops *ops)
 {
 	int ret;
@@ -500,12 +537,14 @@ int video_register(const struct video_ops *ops)
  * This unregisters the video-backend that is registered with name @name. If
  * @name is not found, nothing is done.
  */
+SHL_EXPORT
 void video_unregister(const char *name)
 {
 	log_debug("unregister backend %s", name);
 	shl_register_remove(&video_reg, name);
 }
 
+SHL_EXPORT
 void video_sleep(struct video *video)
 {
 	if (!video || !video_is_awake(video))
@@ -517,6 +556,7 @@ void video_sleep(struct video *video)
 		video->ops->sleep(video);
 }
 
+SHL_EXPORT
 int video_wake_up(struct video *video)
 {
 	int ret = 0;
@@ -539,11 +579,13 @@ int video_wake_up(struct video *video)
 	return 0;
 }
 
+SHL_EXPORT
 bool video_is_awake(struct video *video)
 {
 	return video && (video->flags & VIDEO_AWAKE);
 }
 
+SHL_EXPORT
 void video_poll(struct video *video)
 {
 	if (video && video->ops->poll)

--- a/src/video/video.h
+++ b/src/video/video.h
@@ -84,10 +84,13 @@ struct video_cb {
 	video_remove_display_cb remove_disp;
 };
 
+/* All font rendering uses 1 byte of alpha per pixel
+ * It is then used to blend foreground and background colors
+ * So the stride is always equal to width
+ */
 struct video_buffer {
 	unsigned int width;
 	unsigned int height;
-	unsigned int stride;
 	uint8_t data[];
 };
 

--- a/tests/test_bbulk.c
+++ b/tests/test_bbulk.c
@@ -48,7 +48,6 @@ struct kmscon_glyph *kmscon_font_render(struct kmscon_font *font, const uint32_t
 	g = malloc(sizeof(*g) + FAKE_CELL_W * FAKE_CELL_W);
 	memset(g, 0, sizeof(*g) + FAKE_CELL_W * FAKE_CELL_W);
 	g->buf.width = g->buf.height = FAKE_CELL_W;
-	g->buf.stride = g->buf.width;
 	return g;
 }
 
@@ -67,9 +66,9 @@ int kmscon_rotate_glyph(struct kmscon_glyph *vb, const struct kmscon_glyph *glyp
 	if (!vb || !glyph)
 		return -EINVAL;
 	*vb = *glyph;
-	if (glyph->buf.stride == 0 || glyph->buf.height == 0)
+	if (glyph->buf.width == 0 || glyph->buf.height == 0)
 		return 0;
-	size_t buf_size = glyph->buf.stride * glyph->buf.height;
+	size_t buf_size = glyph->buf.width * glyph->buf.height;
 	memset(vb->buf.data, 0x11, buf_size);
 	return 0;
 }


### PR DESCRIPTION
 All font backends have the same format and the same stride.
This allows to simplify gltex rendering.

Also restore SHL_EXPORT in video.c, as it breaks the gltex module loading.