### PR TITLE
Fix use-after-free crash in seat_go_foreground

### DIFF
--- a/src/seat.c
+++ b/src/seat.c
@@ -177,6 +177,7 @@ static int seat_go_foreground(struct kmscon_seat *seat)
 		if (!vid->video) {
 			ret = seat_video_init(vid);
 			if (ret) {
+				uterm_monitor_set_dev_data(vid->udev, NULL);
 				shl_dlist_unlink(&vid->list);
 				free(vid->node);
 				free(vid);


### PR DESCRIPTION
Fix use-after-free crash in seat_go_foreground when DRM device lacks dumb buffer support (e.g. RPi 4)

The RPi4 has two DRM devices: `/dev/dri/card0` (vc4, display output) and `/dev/dri/card1` (v3d, 3D-only, no dumb buffer support). When `seat_go_foreground` calls `seat_video_init` for the v3d device and it fails with `-EOPNOTSUPP`, the rror handling frees the `kmscon_video` struct and unlinks it from the seat's video list, but does not clear the monitor device's data pointer. This leaves a dangling pointer which causes free memory dereference and crash during shutdown.

See also: https://bugzilla.redhat.com/show_bug.cgi?id=2524448

Assisted-By: Claude Opus 4.6