### PR TITLE
Fix EBUSY error handling in pageflip

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -59,7 +59,6 @@ struct screen {
 	struct display *disp;
 	struct kmscon_text *txt;
 
-	bool swapping;
 	bool pending;
 	bool hw_cursor;
 	bool enabled;
@@ -274,7 +273,7 @@ static void disable_screen(struct screen *scr)
 	int ret;
 
 	log_debug("Disabling screen %s", display_name(scr->disp));
-	if (scr->swapping)
+	if (display_is_swapping(scr->disp))
 		scr->pending = true;
 	else {
 		log_info("Disabling screen %s", display_name(scr->disp));
@@ -290,7 +289,6 @@ static void disable_screen(struct screen *scr)
 				scr->pending = true;
 			}
 		}
-		scr->swapping = true;
 	}
 	scr->enabled = false;
 }
@@ -319,13 +317,8 @@ static void do_redraw_screen(struct screen *scr)
 	kmscon_text_render(scr->txt);
 
 	ret = display_swap(scr->disp);
-	if (ret) {
-		if (ret != -EBUSY)
-			log_warning("cannot swap display [%s] %d", display_name(scr->disp), ret);
-		return;
-	}
-
-	scr->swapping = true;
+	if (ret && ret != -EBUSY)
+		log_warning("cannot swap display [%s] %d", display_name(scr->disp), ret);
 }
 
 static void redraw_screen(struct screen *scr)
@@ -333,7 +326,7 @@ static void redraw_screen(struct screen *scr)
 	if (!scr->term->awake || !scr->enabled)
 		return;
 
-	if (scr->swapping)
+	if (display_is_swapping(scr->disp))
 		scr->pending = true;
 	else
 		do_redraw_screen(scr);
@@ -420,8 +413,6 @@ static void redraw_all_text(struct kmscon_terminal *term)
 	shl_dlist_for_each(iter, &term->screens)
 	{
 		scr = shl_dlist_entry(iter, struct screen, list);
-		if (display_is_swapping(scr->disp))
-			scr->swapping = true;
 		redraw_screen(scr);
 	}
 }
@@ -430,7 +421,6 @@ static void display_pageflip(void *unused, void *unused2, void *data)
 {
 	struct screen *scr = data;
 
-	scr->swapping = false;
 	if (scr->pending)
 		do_redraw_screen(scr);
 }

--- a/src/video/drm_shared.c
+++ b/src/video/drm_shared.c
@@ -1268,6 +1268,7 @@ int drm_video_init(struct video *video, int fd, const struct display_ops *displa
 	version = drmGetVersion(fd);
 	log_info("new drm device via %s, using driver %s\n", vdrm->name,
 		 version ? version->name : "Unknown");
+	drmFreeVersion(version);
 
 	ret = drmSetClientCap(vdrm->fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
 	if (ret) {
@@ -1280,12 +1281,6 @@ int drm_video_init(struct video *video, int fd, const struct display_ops *displa
 		log_warn("Device %s doesn't support atomic modesetting, using legacy", vdrm->name);
 		vdrm->legacy = true;
 	}
-	/* Force legacy pageflip on vmwgfx, as atomic modesetting freeze with vmwgfx */
-	if (version && !strcmp(version->name, "vmwgfx")) {
-		log_warn("Using legacy pageflip with vmwgfx on device %s", vdrm->name);
-		vdrm->legacy = true;
-	}
-	drmFreeVersion(version);
 
 	/* support hardware cursor on VM */
 	ret = drmSetClientCap(vdrm->fd, DRM_CLIENT_CAP_CURSOR_PLANE_HOTSPOT, 1);


### PR DESCRIPTION
When a pageflip returns -EBUSY, scr->swapping can stay true, and the
display is then never refreshed.
So remove scr->swapping and directly call display_is_swapping().

This caused kmscon to freeze on vmwgfx, as this driver returns -EBUSY
regularly.
