### PR TITLE
cursor blinking rate feature

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -905,8 +905,9 @@ static void zoom_out(struct kmscon_terminal *term)
 static void input_event(struct input *input, struct input_key_event *ev, void *data)
 {
 	struct kmscon_terminal *term = data;
+	uint32_t ms = tsm_screen_get_cursor_blinking_rate_ms(term->console);
 	struct itimerspec blink_interval = {
-		.it_interval = {0, BLINK_TIMER_NS},
+		.it_interval = {ms / 1000, (ms % 1000) * 1000000L},
 		.it_value = {BLINK_CURSOR_TYPING, 0},
 	};
 

--- a/subprojects/libtsm.wrap
+++ b/subprojects/libtsm.wrap
@@ -2,7 +2,7 @@
 directory = libtsm
 
 url = https://github.com/kmscon/libtsm
-revision = v4.7.0
+revision = fd642c98c0fb1d245896ae9f09b5726551a58ab4
 depth = 1
 
 [provide]


### PR DESCRIPTION
New feature to change cursor blinking rate in runtime instead of hardcoded value, just like in agetty.

Even though it works, the blinking rate changes not immediately but after the next input event. I don't know how to fix that unfortunately. feedback/help is welcome

It depends on `tsm_screen_get_cursor_blinking_rate_ns` from kmscon/libtsm#68 (unmerged).
Closes #504