### PR TITLE
Refactor dlist.h

### DIFF
--- a/src/input/input.c
+++ b/src/input/input.c
@@ -719,7 +719,7 @@ void input_sleep(struct input *input)
 SHL_EXPORT
 void input_wake_up(struct input *input)
 {
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 	struct input_dev *dev;
 	int ret;
 
@@ -733,10 +733,8 @@ void input_wake_up(struct input *input)
 	log_debug("waking up");
 
 	/* Wake up already-probed devices */
-	shl_dlist_for_each_safe(iter, tmp, &input->devices)
+	shl_dlist_for_each_entry_safe(dev, tmp, &input->devices, list)
 	{
-		dev = shl_dlist_entry(iter, struct input_dev, list);
-
 		if (!dev->initialized) {
 			ret = input_init_dev(input, dev);
 			if (ret)

--- a/src/input/input.c
+++ b/src/input/input.c
@@ -519,13 +519,11 @@ SHL_EXPORT
 int input_update_keymap(struct input *input, const char *model, const char *layout,
 			const char *variant, const char *options)
 {
-	struct shl_dlist *iter;
 	struct input_dev *dev;
 
 	if (input->ctx) {
-		shl_dlist_for_each(iter, &input->devices)
+		shl_dlist_for_each_entry(dev, &input->devices, list)
 		{
-			dev = shl_dlist_entry(iter, struct input_dev, list);
 			if (dev->capabilities & DEVICE_HAS_KEYS) {
 				input_sleep_dev(dev);
 				input_exit_keyboard(dev);
@@ -535,9 +533,8 @@ int input_update_keymap(struct input *input, const char *model, const char *layo
 	uxkb_compose_table_destroy(input);
 	uxkb_layout_destroy(input);
 	uxkb_layout_init(input, model, layout, variant, options, NULL);
-	shl_dlist_for_each(iter, &input->devices)
+	shl_dlist_for_each_entry(dev, &input->devices, list)
 	{
-		dev = shl_dlist_entry(iter, struct input_dev, list);
 		if (dev->capabilities & DEVICE_HAS_KEYS) {
 			input_init_keyboard(dev);
 			if (input->awake)
@@ -620,15 +617,13 @@ void *input_add_dev(struct input *input, const char *node)
 SHL_EXPORT
 void input_remove_dev(struct input *input, void *data)
 {
-	struct shl_dlist *iter;
 	struct input_dev *dev;
 
 	if (!input || !data)
 		return;
 
-	shl_dlist_for_each(iter, &input->devices)
+	shl_dlist_for_each_entry(dev, &input->devices, list)
 	{
-		dev = shl_dlist_entry(iter, struct input_dev, list);
 		if (dev == data) {
 			input_free_dev(dev);
 			return;
@@ -687,15 +682,13 @@ void input_set_device_ops(struct input *input, uterm_open_cb open_cb, uterm_clos
 SHL_EXPORT
 unsigned int input_get_mods(struct input *input)
 {
-	struct shl_dlist *iter;
 	struct input_dev *dev;
 	unsigned int mods = 0;
 
 	if (!input)
 		return 0;
-	shl_dlist_for_each(iter, &input->devices)
+	shl_dlist_for_each_entry(dev, &input->devices, list)
 	{
-		dev = shl_dlist_entry(iter, struct input_dev, list);
 		if (dev->capabilities & DEVICE_HAS_KEYS)
 			mods |= uxkb_dev_get_mods(dev);
 	}
@@ -706,7 +699,6 @@ unsigned int input_get_mods(struct input *input)
 SHL_EXPORT
 void input_sleep(struct input *input)
 {
-	struct shl_dlist *iter;
 	struct input_dev *dev;
 
 	if (!input)
@@ -718,9 +710,8 @@ void input_sleep(struct input *input)
 
 	log_debug("going to sleep");
 
-	shl_dlist_for_each(iter, &input->devices)
+	shl_dlist_for_each_entry(dev, &input->devices, list)
 	{
-		dev = shl_dlist_entry(iter, struct input_dev, list);
 		input_sleep_dev(dev);
 	}
 }
@@ -781,15 +772,13 @@ SHL_EXPORT
 void input_set_leds(struct input *input, unsigned int scroll_lock, unsigned int num_lock,
 		    unsigned int caps_lock)
 {
-	struct shl_dlist *iter;
 	struct input_dev *dev;
 
 	if (!input)
 		return;
 
-	shl_dlist_for_each(iter, &input->devices)
+	shl_dlist_for_each_entry(dev, &input->devices, list)
 	{
-		dev = shl_dlist_entry(iter, struct input_dev, list);
 		uxkb_dev_set_leds(dev, scroll_lock, num_lock, caps_lock);
 	}
 }

--- a/src/input/input.c
+++ b/src/input/input.c
@@ -370,7 +370,7 @@ static void input_free_dev(struct input_dev *dev)
 {
 	log_debug("free device %s", dev->node);
 	input_sleep_dev(dev);
-	shl_dlist_unlink(&dev->list);
+	dlist_unlink(&dev->list);
 	if (dev->capabilities & DEVICE_HAS_KEYS)
 		input_exit_keyboard(dev);
 	free(dev->node);
@@ -417,7 +417,7 @@ err_close:
 	ev_eloop_rm_fd(dev->fd);
 	input_close_dev(dev);
 err:
-	shl_dlist_unlink(&dev->list);
+	dlist_unlink(&dev->list);
 	free(dev->node);
 	free(dev);
 	return ret;
@@ -438,7 +438,7 @@ static struct input_dev *input_new_dev(struct input *input, const char *node)
 	if (!dev->node)
 		goto err_free;
 
-	shl_dlist_link(&input->devices, &dev->list);
+	dlist_link(&input->devices, &dev->list);
 	return dev;
 
 err_free:
@@ -471,7 +471,7 @@ int input_new(struct input **out, struct ev_eloop *eloop)
 	memset(input, 0, sizeof(*input));
 	input->ref = 1;
 	input->eloop = eloop;
-	shl_dlist_init(&input->devices);
+	dlist_init(&input->devices);
 
 	ret = shl_hook_new(&input->key_hook);
 	if (ret)
@@ -522,7 +522,7 @@ int input_update_keymap(struct input *input, const char *model, const char *layo
 	struct input_dev *dev;
 
 	if (input->ctx) {
-		shl_dlist_for_each_entry(dev, &input->devices, list)
+		dlist_for_each_entry(dev, &input->devices, list)
 		{
 			if (dev->capabilities & DEVICE_HAS_KEYS) {
 				input_sleep_dev(dev);
@@ -533,7 +533,7 @@ int input_update_keymap(struct input *input, const char *model, const char *layo
 	uxkb_compose_table_destroy(input);
 	uxkb_layout_destroy(input);
 	uxkb_layout_init(input, model, layout, variant, options, NULL);
-	shl_dlist_for_each_entry(dev, &input->devices, list)
+	dlist_for_each_entry(dev, &input->devices, list)
 	{
 		if (dev->capabilities & DEVICE_HAS_KEYS) {
 			input_init_keyboard(dev);
@@ -582,7 +582,7 @@ void input_unref(struct input *input)
 	log_debug("free object %p", input);
 
 	while (input->devices.next != &input->devices) {
-		dev = shl_dlist_entry(input->devices.next, struct input_dev, list);
+		dev = dlist_entry(input->devices.next, struct input_dev, list);
 		input_free_dev(dev);
 	}
 
@@ -622,7 +622,7 @@ void input_remove_dev(struct input *input, void *data)
 	if (!input || !data)
 		return;
 
-	shl_dlist_for_each_entry(dev, &input->devices, list)
+	dlist_for_each_entry(dev, &input->devices, list)
 	{
 		if (dev == data) {
 			input_free_dev(dev);
@@ -687,7 +687,7 @@ unsigned int input_get_mods(struct input *input)
 
 	if (!input)
 		return 0;
-	shl_dlist_for_each_entry(dev, &input->devices, list)
+	dlist_for_each_entry(dev, &input->devices, list)
 	{
 		if (dev->capabilities & DEVICE_HAS_KEYS)
 			mods |= uxkb_dev_get_mods(dev);
@@ -710,7 +710,7 @@ void input_sleep(struct input *input)
 
 	log_debug("going to sleep");
 
-	shl_dlist_for_each_entry(dev, &input->devices, list)
+	dlist_for_each_entry(dev, &input->devices, list)
 	{
 		input_sleep_dev(dev);
 	}
@@ -719,7 +719,7 @@ void input_sleep(struct input *input)
 SHL_EXPORT
 void input_wake_up(struct input *input)
 {
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 	struct input_dev *dev;
 	int ret;
 
@@ -733,7 +733,7 @@ void input_wake_up(struct input *input)
 	log_debug("waking up");
 
 	/* Wake up already-probed devices */
-	shl_dlist_for_each_entry_safe(dev, tmp, &input->devices, list)
+	dlist_for_each_entry_safe(dev, tmp, &input->devices, list)
 	{
 		if (!dev->initialized) {
 			ret = input_init_dev(input, dev);
@@ -775,7 +775,7 @@ void input_set_leds(struct input *input, unsigned int scroll_lock, unsigned int 
 	if (!input)
 		return;
 
-	shl_dlist_for_each_entry(dev, &input->devices, list)
+	dlist_for_each_entry(dev, &input->devices, list)
 	{
 		uxkb_dev_set_leds(dev, scroll_lock, num_lock, caps_lock);
 	}

--- a/src/input/input_internal.h
+++ b/src/input/input_internal.h
@@ -84,7 +84,7 @@ struct input_pointer {
 };
 
 struct input_dev {
-	struct shl_dlist list;
+	struct dlist list;
 	struct input *input;
 
 	bool initialized;
@@ -132,7 +132,7 @@ struct input {
 	int32_t pointer_max_y;
 	struct ev_timer *hide_pointer;
 
-	struct shl_dlist devices;
+	struct dlist devices;
 };
 
 static inline bool input_bit_is_set(const unsigned long *array, int bit)

--- a/src/misc/issue_network.c
+++ b/src/misc/issue_network.c
@@ -212,15 +212,13 @@ void issue_network_free_book(struct addr_book *book)
 
 const char *issue_network_get_best_ip(struct addr_book *book, const char *interface, bool ipv6)
 {
-	struct shl_dlist *iter;
 	struct ip_addr *ip;
 	struct ip_addr *best = NULL;
 	struct shl_dlist *head = ipv6 ? &book->ipv6 : &book->ipv4;
 	bool filter = (interface && *interface);
 
-	shl_dlist_for_each(iter, head)
+	shl_dlist_for_each_entry(ip, head, list)
 	{
-		ip = shl_dlist_entry(iter, struct ip_addr, list);
 		if (filter && strcmp(ip->interface, interface))
 			continue;
 		if (best) {
@@ -247,12 +245,10 @@ struct interface {
 
 static struct interface *get_interface(struct shl_dlist *ifaces, const char *name)
 {
-	struct shl_dlist *iter;
 	struct interface *iface;
 
-	shl_dlist_for_each(iter, ifaces)
+	shl_dlist_for_each_entry(iface, ifaces, list)
 	{
-		iface = shl_dlist_entry(iter, struct interface, list);
 		if (strcmp(iface->name, name) == 0)
 			return iface;
 	}
@@ -294,16 +290,14 @@ char *issue_network_get_all_ip(struct addr_book *book, bool filter)
 	if (book->best_quality == RAT_UNIVERSE)
 		book->best_quality = RAT_SITE;
 
-	shl_dlist_for_each(iter, &book->ipv4)
+	shl_dlist_for_each_entry(ip, &book->ipv4, list)
 	{
-		ip = shl_dlist_entry(iter, struct ip_addr, list);
 		if (filter && ip->quality < book->best_quality)
 			continue;
 		add_ip_to_interface(&head, ip);
 	}
-	shl_dlist_for_each(iter, &book->ipv6)
+	shl_dlist_for_each_entry(ip, &book->ipv6, list)
 	{
-		ip = shl_dlist_entry(iter, struct ip_addr, list);
 		if (filter && ip->quality < book->best_quality)
 			continue;
 		add_ip_to_interface(&head, ip);
@@ -312,9 +306,8 @@ char *issue_network_get_all_ip(struct addr_book *book, bool filter)
 	out = malloc(BUF_SIZE);
 	s = out;
 	remaining = BUF_SIZE - 1;
-	shl_dlist_for_each(iter, &head)
+	shl_dlist_for_each_entry(iface, &head, list)
 	{
-		iface = shl_dlist_entry(iter, struct interface, list);
 		len = snprintf(s, remaining, "%s: ", iface->name);
 		s += len;
 		remaining -= len;

--- a/src/misc/issue_network.c
+++ b/src/misc/issue_network.c
@@ -192,19 +192,17 @@ struct addr_book *issue_network_gen_book(void)
 void issue_network_free_book(struct addr_book *book)
 {
 	struct ip_addr *ip;
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 
 	if (!book)
 		return;
 
-	shl_dlist_for_each_safe(iter, tmp, &book->ipv4)
+	shl_dlist_for_each_entry_safe(ip, tmp, &book->ipv4, list)
 	{
-		ip = shl_dlist_entry(iter, struct ip_addr, list);
 		free(ip);
 	}
-	shl_dlist_for_each_safe(iter, tmp, &book->ipv6)
+	shl_dlist_for_each_entry_safe(ip, tmp, &book->ipv6, list)
 	{
-		ip = shl_dlist_entry(iter, struct ip_addr, list);
 		free(ip);
 	}
 	free(book);
@@ -275,7 +273,7 @@ static void add_ip_to_interface(struct shl_dlist *ifaces, struct ip_addr *ip)
  */
 char *issue_network_get_all_ip(struct addr_book *book, bool filter)
 {
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 	struct ip_addr *ip;
 	struct shl_dlist head;
 	struct interface *iface;
@@ -326,10 +324,9 @@ char *issue_network_get_all_ip(struct addr_book *book, bool filter)
 	}
 	*s = '\0';
 
-	shl_dlist_for_each_safe(iter, tmp, &head)
+	shl_dlist_for_each_entry_safe(iface, tmp, &head, list)
 	{
-		iface = shl_dlist_entry(iter, struct interface, list);
-		shl_dlist_unlink(iter);
+		shl_dlist_unlink(&iface->list);
 		free(iface);
 	}
 	return out;

--- a/src/misc/issue_network.c
+++ b/src/misc/issue_network.c
@@ -27,7 +27,7 @@ enum rating {
 };
 
 struct ip_addr {
-	struct shl_dlist list;
+	struct dlist list;
 	char addr[INET6_ADDRSTRLEN];
 	int quality;
 	char interface[IFNAMSIZ];
@@ -35,8 +35,8 @@ struct ip_addr {
 };
 
 struct addr_book {
-	struct shl_dlist ipv4;
-	struct shl_dlist ipv6;
+	struct dlist ipv4;
+	struct dlist ipv6;
 	int best_quality;
 };
 
@@ -118,9 +118,9 @@ static void parse_netlink_message(struct addr_book *book, struct nlmsghdr *nlh)
 		book->best_quality = ip->quality;
 
 	if (ifa->ifa_family == AF_INET6)
-		shl_dlist_link_tail(&book->ipv6, &ip->list);
+		dlist_link_tail(&book->ipv6, &ip->list);
 	else
-		shl_dlist_link_tail(&book->ipv4, &ip->list);
+		dlist_link_tail(&book->ipv4, &ip->list);
 }
 
 struct addr_book *issue_network_gen_book(void)
@@ -144,8 +144,8 @@ struct addr_book *issue_network_gen_book(void)
 	if (!book)
 		return NULL;
 
-	shl_dlist_init(&book->ipv4);
-	shl_dlist_init(&book->ipv6);
+	dlist_init(&book->ipv4);
+	dlist_init(&book->ipv6);
 
 	nl_fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
 	if (nl_fd < 0)
@@ -192,16 +192,16 @@ struct addr_book *issue_network_gen_book(void)
 void issue_network_free_book(struct addr_book *book)
 {
 	struct ip_addr *ip;
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 
 	if (!book)
 		return;
 
-	shl_dlist_for_each_entry_safe(ip, tmp, &book->ipv4, list)
+	dlist_for_each_entry_safe(ip, tmp, &book->ipv4, list)
 	{
 		free(ip);
 	}
-	shl_dlist_for_each_entry_safe(ip, tmp, &book->ipv6, list)
+	dlist_for_each_entry_safe(ip, tmp, &book->ipv6, list)
 	{
 		free(ip);
 	}
@@ -212,10 +212,10 @@ const char *issue_network_get_best_ip(struct addr_book *book, const char *interf
 {
 	struct ip_addr *ip;
 	struct ip_addr *best = NULL;
-	struct shl_dlist *head = ipv6 ? &book->ipv6 : &book->ipv4;
+	struct dlist *head = ipv6 ? &book->ipv6 : &book->ipv4;
 	bool filter = (interface && *interface);
 
-	shl_dlist_for_each_entry(ip, head, list)
+	dlist_for_each_entry(ip, head, list)
 	{
 		if (filter && strcmp(ip->interface, interface))
 			continue;
@@ -235,17 +235,17 @@ const char *issue_network_get_best_ip(struct addr_book *book, const char *interf
 #define MAX_ADDR_PER_IFACE 32
 
 struct interface {
-	struct shl_dlist list;
+	struct dlist list;
 	char name[IFNAMSIZ];
 	int n_addrs;
 	struct ip_addr *ips[MAX_ADDR_PER_IFACE];
 };
 
-static struct interface *get_interface(struct shl_dlist *ifaces, const char *name)
+static struct interface *get_interface(struct dlist *ifaces, const char *name)
 {
 	struct interface *iface;
 
-	shl_dlist_for_each_entry(iface, ifaces, list)
+	dlist_for_each_entry(iface, ifaces, list)
 	{
 		if (strcmp(iface->name, name) == 0)
 			return iface;
@@ -254,11 +254,11 @@ static struct interface *get_interface(struct shl_dlist *ifaces, const char *nam
 	if (!iface)
 		return NULL;
 	strncpy(iface->name, name, IFNAMSIZ);
-	shl_dlist_link_tail(ifaces, &iface->list);
+	dlist_link_tail(ifaces, &iface->list);
 	return iface;
 }
 
-static void add_ip_to_interface(struct shl_dlist *ifaces, struct ip_addr *ip)
+static void add_ip_to_interface(struct dlist *ifaces, struct ip_addr *ip)
 {
 	struct interface *iface;
 
@@ -273,28 +273,28 @@ static void add_ip_to_interface(struct shl_dlist *ifaces, struct ip_addr *ip)
  */
 char *issue_network_get_all_ip(struct addr_book *book, bool filter)
 {
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 	struct ip_addr *ip;
-	struct shl_dlist head;
+	struct dlist head;
 	struct interface *iface;
 	size_t remaining;
 	size_t len;
 	char *out;
 	char *s;
 
-	shl_dlist_init(&head);
+	dlist_init(&head);
 
 	/* Treat RAT_SITE as good as RAT_UNIVERSE, like agetty does */
 	if (book->best_quality == RAT_UNIVERSE)
 		book->best_quality = RAT_SITE;
 
-	shl_dlist_for_each_entry(ip, &book->ipv4, list)
+	dlist_for_each_entry(ip, &book->ipv4, list)
 	{
 		if (filter && ip->quality < book->best_quality)
 			continue;
 		add_ip_to_interface(&head, ip);
 	}
-	shl_dlist_for_each_entry(ip, &book->ipv6, list)
+	dlist_for_each_entry(ip, &book->ipv6, list)
 	{
 		if (filter && ip->quality < book->best_quality)
 			continue;
@@ -304,7 +304,7 @@ char *issue_network_get_all_ip(struct addr_book *book, bool filter)
 	out = malloc(BUF_SIZE);
 	s = out;
 	remaining = BUF_SIZE - 1;
-	shl_dlist_for_each_entry(iface, &head, list)
+	dlist_for_each_entry(iface, &head, list)
 	{
 		len = snprintf(s, remaining, "%s: ", iface->name);
 		s += len;
@@ -324,9 +324,9 @@ char *issue_network_get_all_ip(struct addr_book *book, bool filter)
 	}
 	*s = '\0';
 
-	shl_dlist_for_each_entry_safe(iface, tmp, &head, list)
+	dlist_for_each_entry_safe(iface, tmp, &head, list)
 	{
-		shl_dlist_unlink(&iface->list);
+		dlist_unlink(&iface->list);
 		free(iface);
 	}
 	return out;

--- a/src/render/gltex.c
+++ b/src/render/gltex.c
@@ -250,7 +250,7 @@ static void gltex_unset(struct kmscon_text *txt)
 {
 	struct gltex *gt = txt->data;
 	int ret;
-	struct dlist *iter;
+	struct dlist *tmp;
 	struct atlas *atlas;
 	bool gl = true;
 
@@ -262,10 +262,9 @@ static void gltex_unset(struct kmscon_text *txt)
 
 	shl_hashtable_free(gt->glyphs);
 
-	while (!dlist_empty(&gt->atlases)) {
-		iter = gt->atlases.next;
-		dlist_unlink(iter);
-		atlas = dlist_entry(iter, struct atlas, list);
+	dlist_for_each_entry_safe(atlas, tmp, &gt->atlases, list)
+	{
+		dlist_unlink(&atlas->list);
 
 		free(atlas->cache_pos);
 		free(atlas->cache_texpos);
@@ -294,11 +293,9 @@ static struct atlas *get_atlas(struct kmscon_text *txt, unsigned int num)
 	GLenum err;
 
 	/* check whether the last added atlas has still room for one glyph */
-	if (!dlist_empty(&gt->atlases)) {
-		atlas = dlist_entry(gt->atlases.next, struct atlas, list);
-		if (atlas->fill + num <= atlas->count)
-			return atlas;
-	}
+	atlas = dlist_first(&gt->atlases, struct atlas, list);
+	if (atlas && atlas->fill + num <= atlas->count)
+		return atlas;
 
 	/* all atlases are full so we have to create a new atlas */
 	atlas = malloc(sizeof(*atlas));

--- a/src/render/gltex.c
+++ b/src/render/gltex.c
@@ -59,7 +59,7 @@
 #define LOG_SUBSYSTEM "text_gltex"
 
 struct atlas {
-	struct shl_dlist list;
+	struct dlist list;
 
 	GLuint tex;
 	unsigned int height;
@@ -94,7 +94,7 @@ struct gltex {
 	unsigned int max_tex_size;
 	bool previous_overflow;
 
-	struct shl_dlist atlases;
+	struct dlist atlases;
 
 	GLfloat advance_x;
 	GLfloat advance_y;
@@ -191,7 +191,7 @@ static int gltex_set(struct kmscon_text *txt)
 		return ret;
 
 	memset(gt, 0, sizeof(*gt));
-	shl_dlist_init(&gt->atlases);
+	dlist_init(&gt->atlases);
 
 	ret = shl_hashtable_new(&gt->glyphs, shl_direct_hash, shl_direct_equal, free_glyph);
 	if (ret)
@@ -250,7 +250,7 @@ static void gltex_unset(struct kmscon_text *txt)
 {
 	struct gltex *gt = txt->data;
 	int ret;
-	struct shl_dlist *iter;
+	struct dlist *iter;
 	struct atlas *atlas;
 	bool gl = true;
 
@@ -262,10 +262,10 @@ static void gltex_unset(struct kmscon_text *txt)
 
 	shl_hashtable_free(gt->glyphs);
 
-	while (!shl_dlist_empty(&gt->atlases)) {
+	while (!dlist_empty(&gt->atlases)) {
 		iter = gt->atlases.next;
-		shl_dlist_unlink(iter);
-		atlas = shl_dlist_entry(iter, struct atlas, list);
+		dlist_unlink(iter);
+		atlas = dlist_entry(iter, struct atlas, list);
 
 		free(atlas->cache_pos);
 		free(atlas->cache_texpos);
@@ -294,8 +294,8 @@ static struct atlas *get_atlas(struct kmscon_text *txt, unsigned int num)
 	GLenum err;
 
 	/* check whether the last added atlas has still room for one glyph */
-	if (!shl_dlist_empty(&gt->atlases)) {
-		atlas = shl_dlist_entry(gt->atlases.next, struct atlas, list);
+	if (!dlist_empty(&gt->atlases)) {
+		atlas = dlist_entry(gt->atlases.next, struct atlas, list);
 		if (atlas->fill + num <= atlas->count)
 			return atlas;
 	}
@@ -371,7 +371,7 @@ try_next:
 	atlas->advance_htex = 1.0 / atlas->width * FONT_WIDTH(txt);
 	atlas->advance_vtex = 1.0 / atlas->height * FONT_HEIGHT(txt);
 
-	shl_dlist_link(&gt->atlases, &atlas->list);
+	dlist_link(&gt->atlases, &atlas->list);
 	return atlas;
 
 err_mem:
@@ -498,7 +498,7 @@ static int gltex_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr)
 	if (ret)
 		return ret;
 
-	shl_dlist_for_each_entry(atlas, &gt->atlases, list)
+	dlist_for_each_entry(atlas, &gt->atlases, list)
 	{
 		atlas->cache_num = 0;
 	}
@@ -717,7 +717,7 @@ static int gltex_render(struct kmscon_text *txt)
 	glActiveTexture(GL_TEXTURE0);
 	glUniform1i(gt->uni_atlas, 0);
 
-	shl_dlist_for_each_entry(atlas, &gt->atlases, list)
+	dlist_for_each_entry(atlas, &gt->atlases, list)
 	{
 		if (!atlas->cache_num)
 			continue;

--- a/src/render/gltex.c
+++ b/src/render/gltex.c
@@ -492,17 +492,14 @@ static int gltex_prepare(struct kmscon_text *txt, struct tsm_screen_attr *attr)
 {
 	struct gltex *gt = txt->data;
 	struct atlas *atlas;
-	struct shl_dlist *iter;
 	int ret;
 
 	ret = display_use(txt->disp);
 	if (ret)
 		return ret;
 
-	shl_dlist_for_each(iter, &gt->atlases)
+	shl_dlist_for_each_entry(atlas, &gt->atlases, list)
 	{
-		atlas = shl_dlist_entry(iter, struct atlas, list);
-
 		atlas->cache_num = 0;
 	}
 	gt->attr = *attr;
@@ -698,7 +695,6 @@ static int gltex_render(struct kmscon_text *txt)
 {
 	struct gltex *gt = txt->data;
 	struct atlas *atlas;
-	struct shl_dlist *iter;
 	float mat[16];
 
 	gl_clear_error();
@@ -721,9 +717,8 @@ static int gltex_render(struct kmscon_text *txt)
 	glActiveTexture(GL_TEXTURE0);
 	glUniform1i(gt->uni_atlas, 0);
 
-	shl_dlist_for_each(iter, &gt->atlases)
+	shl_dlist_for_each_entry(atlas, &gt->atlases, list)
 	{
-		atlas = shl_dlist_entry(iter, struct atlas, list);
 		if (!atlas->cache_num)
 			continue;
 

--- a/src/seat.c
+++ b/src/seat.c
@@ -185,16 +185,14 @@ static int seat_go_foreground(struct kmscon_seat *seat)
 		}
 	}
 
-	shl_dlist_for_each(iter, &seat->videos)
+	shl_dlist_for_each_entry(vid, &seat->videos, list)
 	{
-		vid = shl_dlist_entry(iter, struct kmscon_video, list);
 		if (!vid->awake)
 			video_wake_up(vid->video);
 	}
 
-	shl_dlist_for_each(iter, &seat->displays)
+	shl_dlist_for_each_entry(d, &seat->displays, list)
 	{
-		d = shl_dlist_entry(iter, struct kmscon_display, list);
 		activate_display(d);
 	}
 
@@ -203,7 +201,6 @@ static int seat_go_foreground(struct kmscon_seat *seat)
 
 static int seat_go_background(struct kmscon_seat *seat)
 {
-	struct shl_dlist *iter;
 	struct kmscon_video *vid;
 
 	if (!seat->foreground)
@@ -211,9 +208,8 @@ static int seat_go_background(struct kmscon_seat *seat)
 	if (!seat->awake)
 		return -EBUSY;
 
-	shl_dlist_for_each(iter, &seat->videos)
+	shl_dlist_for_each_entry(vid, &seat->videos, list)
 	{
-		vid = shl_dlist_entry(iter, struct kmscon_video, list);
 		video_sleep(vid->video);
 	}
 
@@ -324,12 +320,10 @@ static void seat_new_display(void *data, struct display *disp)
 
 static struct kmscon_display *seat_get_display(struct kmscon_seat *seat, struct display *disp)
 {
-	struct shl_dlist *iter;
 	struct kmscon_display *d;
 
-	shl_dlist_for_each(iter, &seat->displays)
+	shl_dlist_for_each_entry(d, &seat->displays, list)
 	{
-		d = shl_dlist_entry(iter, struct kmscon_display, list);
 		if (d->disp == disp)
 			return d;
 	}
@@ -369,7 +363,6 @@ static void seat_remove_display(void *data, struct display *disp)
 
 static void seat_refresh_display(void *data, struct display *disp)
 {
-	struct shl_dlist *iter;
 	struct kmscon_session *s;
 	struct kmscon_display *d;
 	struct kmscon_seat *seat = data;
@@ -381,9 +374,8 @@ static void seat_refresh_display(void *data, struct display *disp)
 		return;
 
 	if (d->activated) {
-		shl_dlist_for_each(iter, &seat->sessions)
+		shl_dlist_for_each_entry(s, &seat->sessions, list)
 		{
-			s = shl_dlist_entry(iter, struct kmscon_session, list);
 			terminal_refresh_displays(s->term);
 		}
 	}
@@ -472,7 +464,6 @@ static void seat_trigger_reboot(struct kmscon_seat *seat)
 static void seat_dpms_timeout(struct ev_timer *timer, uint64_t num, void *data)
 {
 	struct kmscon_seat *seat = data;
-	struct shl_dlist *iter;
 	struct kmscon_display *d;
 	int ret;
 
@@ -482,10 +473,8 @@ static void seat_dpms_timeout(struct ev_timer *timer, uint64_t num, void *data)
 	log_debug("DPMS: blanking screen due to inactivity");
 
 	/* Turn off all displays */
-	shl_dlist_for_each(iter, &seat->displays)
+	shl_dlist_for_each_entry(d, &seat->displays, list)
 	{
-		d = shl_dlist_entry(iter, struct kmscon_display, list);
-
 		/* Only set DPMS on activated displays */
 		if (!d->activated)
 			continue;
@@ -501,7 +490,6 @@ static void seat_dpms_timeout(struct ev_timer *timer, uint64_t num, void *data)
 
 static void seat_dpms_reset_timer(struct kmscon_seat *seat)
 {
-	struct shl_dlist *iter;
 	struct kmscon_display *d;
 	struct itimerspec spec;
 	int ret;
@@ -512,10 +500,8 @@ static void seat_dpms_reset_timer(struct kmscon_seat *seat)
 	/* If screen is blanked, unblank it */
 	if (seat->dpms_blanked) {
 		log_debug("DPMS: unblanking screen");
-		shl_dlist_for_each(iter, &seat->displays)
+		shl_dlist_for_each_entry(d, &seat->displays, list)
 		{
-			d = shl_dlist_entry(iter, struct kmscon_display, list);
-
 			/* Only set DPMS on activated displays */
 			if (!d->activated)
 				continue;
@@ -1083,7 +1069,6 @@ struct conf_ctx *kmscon_seat_get_conf(struct kmscon_seat *seat)
 static struct kmscon_session *kmscon_seat_new_session(struct kmscon_seat *seat)
 {
 	struct kmscon_session *sess;
-	struct shl_dlist *iter;
 	struct kmscon_display *d;
 
 	if (!seat)
@@ -1122,9 +1107,8 @@ static struct kmscon_session *kmscon_seat_new_session(struct kmscon_seat *seat)
 
 	++seat->session_count;
 
-	shl_dlist_for_each(iter, &seat->displays)
+	shl_dlist_for_each_entry(d, &seat->displays, list)
 	{
-		d = shl_dlist_entry(iter, struct kmscon_display, list);
 		terminal_add_display(sess->term, d->disp);
 	}
 	return sess;

--- a/src/seat.c
+++ b/src/seat.c
@@ -125,7 +125,7 @@ static void kmscon_session_unregister(struct kmscon_session *sess);
 static void activate_display(struct kmscon_display *d)
 {
 	int ret;
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 	struct kmscon_session *s;
 	struct kmscon_seat *seat = d->seat;
 
@@ -147,9 +147,8 @@ static void activate_display(struct kmscon_display *d)
 		/* Reset DPMS timer when display becomes active */
 		seat_dpms_reset_timer(seat);
 
-		shl_dlist_for_each_safe(iter, tmp, &seat->sessions)
+		shl_dlist_for_each_entry_safe(s, tmp, &seat->sessions, list)
 		{
-			s = shl_dlist_entry(iter, struct kmscon_session, list);
 			terminal_add_display(s->term, d->disp);
 		}
 		if (seat->current_sess)
@@ -159,7 +158,7 @@ static void activate_display(struct kmscon_display *d)
 
 static int seat_go_foreground(struct kmscon_seat *seat)
 {
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 	struct kmscon_video *vid;
 	struct kmscon_display *d;
 	int ret;
@@ -171,9 +170,8 @@ static int seat_go_foreground(struct kmscon_seat *seat)
 
 	seat->foreground = true;
 
-	shl_dlist_for_each_safe(iter, tmp, &seat->videos)
+	shl_dlist_for_each_entry_safe(vid, tmp, &seat->videos, list)
 	{
-		vid = shl_dlist_entry(iter, struct kmscon_video, list);
 		if (!vid->video) {
 			ret = seat_video_init(vid);
 			if (ret) {
@@ -332,7 +330,7 @@ static struct kmscon_display *seat_get_display(struct kmscon_seat *seat, struct 
 
 static void _seat_remove_display(struct kmscon_seat *seat, struct kmscon_display *d)
 {
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 	struct kmscon_session *s;
 
 	log_debug("remove display %s from seat %s", display_name(d->disp), seat->name);
@@ -340,9 +338,8 @@ static void _seat_remove_display(struct kmscon_seat *seat, struct kmscon_display
 	shl_dlist_unlink(&d->list);
 
 	if (d->activated) {
-		shl_dlist_for_each_safe(iter, tmp, &seat->sessions)
+		shl_dlist_for_each_entry_safe(s, tmp, &seat->sessions, list)
 		{
-			s = shl_dlist_entry(iter, struct kmscon_session, list);
 			terminal_rm_display(s->term, d->disp);
 		}
 	}
@@ -1003,7 +1000,7 @@ static void kmscon_seat_remove_video(struct kmscon_seat *seat, void *data)
 {
 	struct kmscon_video *vid = data;
 	struct kmscon_display *d;
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 
 	if (!seat || !vid)
 		return;
@@ -1014,9 +1011,8 @@ static void kmscon_seat_remove_video(struct kmscon_seat *seat, void *data)
 	shl_dlist_unlink(&vid->list);
 
 	if (vid->video) {
-		shl_dlist_for_each_safe(iter, tmp, &seat->displays)
+		shl_dlist_for_each_entry_safe(d, tmp, &seat->displays, list)
 		{
-			d = shl_dlist_entry(iter, struct kmscon_display, list);
 			if (display_video(d->disp) == vid->video)
 				_seat_remove_display(seat, d);
 		}

--- a/src/seat.c
+++ b/src/seat.c
@@ -51,7 +51,7 @@
 #define LOG_SUBSYSTEM "seat"
 
 struct kmscon_session {
-	struct shl_dlist list;
+	struct dlist list;
 	struct kmscon_seat *seat;
 
 	bool foreground;
@@ -61,14 +61,14 @@ struct kmscon_session {
 };
 
 struct kmscon_display {
-	struct shl_dlist list;
+	struct dlist list;
 	struct kmscon_seat *seat;
 	struct display *disp;
 	bool activated;
 };
 
 struct kmscon_video {
-	struct shl_dlist list;
+	struct dlist list;
 	struct kmscon_seat *seat;
 	struct video *video;
 	struct uterm_monitor_dev *udev;
@@ -89,11 +89,11 @@ struct kmscon_seat {
 	char *name;
 	struct input *input;
 	struct uterm_vt *vt;
-	struct shl_dlist displays;
-	struct shl_dlist videos;
+	struct dlist displays;
+	struct dlist videos;
 
 	size_t session_count;
-	struct shl_dlist sessions;
+	struct dlist sessions;
 
 	bool awake;
 	bool foreground;
@@ -125,7 +125,7 @@ static void kmscon_session_unregister(struct kmscon_session *sess);
 static void activate_display(struct kmscon_display *d)
 {
 	int ret;
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 	struct kmscon_session *s;
 	struct kmscon_seat *seat = d->seat;
 
@@ -147,7 +147,7 @@ static void activate_display(struct kmscon_display *d)
 		/* Reset DPMS timer when display becomes active */
 		seat_dpms_reset_timer(seat);
 
-		shl_dlist_for_each_entry_safe(s, tmp, &seat->sessions, list)
+		dlist_for_each_entry_safe(s, tmp, &seat->sessions, list)
 		{
 			terminal_add_display(s->term, d->disp);
 		}
@@ -158,7 +158,7 @@ static void activate_display(struct kmscon_display *d)
 
 static int seat_go_foreground(struct kmscon_seat *seat)
 {
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 	struct kmscon_video *vid;
 	struct kmscon_display *d;
 	int ret;
@@ -170,26 +170,26 @@ static int seat_go_foreground(struct kmscon_seat *seat)
 
 	seat->foreground = true;
 
-	shl_dlist_for_each_entry_safe(vid, tmp, &seat->videos, list)
+	dlist_for_each_entry_safe(vid, tmp, &seat->videos, list)
 	{
 		if (!vid->video) {
 			ret = seat_video_init(vid);
 			if (ret) {
 				uterm_monitor_set_dev_data(vid->udev, NULL);
-				shl_dlist_unlink(&vid->list);
+				dlist_unlink(&vid->list);
 				free(vid->node);
 				free(vid);
 			}
 		}
 	}
 
-	shl_dlist_for_each_entry(vid, &seat->videos, list)
+	dlist_for_each_entry(vid, &seat->videos, list)
 	{
 		if (!vid->awake)
 			video_wake_up(vid->video);
 	}
 
-	shl_dlist_for_each_entry(d, &seat->displays, list)
+	dlist_for_each_entry(d, &seat->displays, list)
 	{
 		activate_display(d);
 	}
@@ -206,7 +206,7 @@ static int seat_go_background(struct kmscon_seat *seat)
 	if (!seat->awake)
 		return -EBUSY;
 
-	shl_dlist_for_each_entry(vid, &seat->videos, list)
+	dlist_for_each_entry(vid, &seat->videos, list)
 	{
 		video_sleep(vid->video);
 	}
@@ -274,9 +274,9 @@ static void seat_next(struct kmscon_seat *seat)
 	struct kmscon_session *next = NULL;
 
 	if (seat->current_sess)
-		next = shl_dlist_next(seat->current_sess, &seat->sessions, list);
+		next = dlist_next(seat->current_sess, &seat->sessions, list);
 	if (!next)
-		next = shl_dlist_first(&seat->sessions, struct kmscon_session, list);
+		next = dlist_first(&seat->sessions, struct kmscon_session, list);
 	if (next && next == seat->current_sess)
 		next = NULL;
 
@@ -288,9 +288,9 @@ static void seat_prev(struct kmscon_seat *seat)
 	struct kmscon_session *prev = NULL;
 
 	if (seat->current_sess)
-		prev = shl_dlist_prev(seat->current_sess, &seat->sessions, list);
+		prev = dlist_prev(seat->current_sess, &seat->sessions, list);
 	if (!prev)
-		prev = shl_dlist_last(&seat->sessions, struct kmscon_session, list);
+		prev = dlist_last(&seat->sessions, struct kmscon_session, list);
 	if (prev && prev == seat->current_sess)
 		prev = NULL;
 
@@ -312,7 +312,7 @@ static void seat_new_display(void *data, struct display *disp)
 	d->seat = seat;
 
 	display_ref(d->disp);
-	shl_dlist_link(&seat->displays, &d->list);
+	dlist_link(&seat->displays, &d->list);
 	activate_display(d);
 }
 
@@ -320,7 +320,7 @@ static struct kmscon_display *seat_get_display(struct kmscon_seat *seat, struct 
 {
 	struct kmscon_display *d;
 
-	shl_dlist_for_each_entry(d, &seat->displays, list)
+	dlist_for_each_entry(d, &seat->displays, list)
 	{
 		if (d->disp == disp)
 			return d;
@@ -330,15 +330,15 @@ static struct kmscon_display *seat_get_display(struct kmscon_seat *seat, struct 
 
 static void _seat_remove_display(struct kmscon_seat *seat, struct kmscon_display *d)
 {
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 	struct kmscon_session *s;
 
 	log_debug("remove display %s from seat %s", display_name(d->disp), seat->name);
 
-	shl_dlist_unlink(&d->list);
+	dlist_unlink(&d->list);
 
 	if (d->activated) {
-		shl_dlist_for_each_entry_safe(s, tmp, &seat->sessions, list)
+		dlist_for_each_entry_safe(s, tmp, &seat->sessions, list)
 		{
 			terminal_rm_display(s->term, d->disp);
 		}
@@ -371,7 +371,7 @@ static void seat_refresh_display(void *data, struct display *disp)
 		return;
 
 	if (d->activated) {
-		shl_dlist_for_each_entry(s, &seat->sessions, list)
+		dlist_for_each_entry(s, &seat->sessions, list)
 		{
 			terminal_refresh_displays(s->term);
 		}
@@ -470,7 +470,7 @@ static void seat_dpms_timeout(struct ev_timer *timer, uint64_t num, void *data)
 	log_debug("DPMS: blanking screen due to inactivity");
 
 	/* Turn off all displays */
-	shl_dlist_for_each_entry(d, &seat->displays, list)
+	dlist_for_each_entry(d, &seat->displays, list)
 	{
 		/* Only set DPMS on activated displays */
 		if (!d->activated)
@@ -497,7 +497,7 @@ static void seat_dpms_reset_timer(struct kmscon_seat *seat)
 	/* If screen is blanked, unblank it */
 	if (seat->dpms_blanked) {
 		log_debug("DPMS: unblanking screen");
-		shl_dlist_for_each_entry(d, &seat->displays, list)
+		dlist_for_each_entry(d, &seat->displays, list)
 		{
 			/* Only set DPMS on activated displays */
 			if (!d->activated)
@@ -702,9 +702,9 @@ int kmscon_seat_new(struct kmscon_seat **out, struct conf_ctx *main_conf,
 	seat->eloop = eloop;
 	seat->cb = cb;
 	seat->data = data;
-	shl_dlist_init(&seat->displays);
-	shl_dlist_init(&seat->videos);
-	shl_dlist_init(&seat->sessions);
+	dlist_init(&seat->displays);
+	dlist_init(&seat->videos);
+	dlist_init(&seat->sessions);
 
 	ret = input_new(&seat->input, seat->eloop);
 	if (ret)
@@ -828,12 +828,12 @@ void kmscon_seat_free(struct kmscon_seat *seat)
 	if (ret)
 		log_warning("destroying seat %s while still awake: %d", seat->name, ret);
 
-	while (!shl_dlist_empty(&seat->sessions)) {
-		s = shl_dlist_entry(seat->sessions.next, struct kmscon_session, list);
+	while (!dlist_empty(&seat->sessions)) {
+		s = dlist_entry(seat->sessions.next, struct kmscon_session, list);
 		kmscon_session_unregister(s);
 	}
-	while (!shl_dlist_empty(&seat->videos)) {
-		vid = shl_dlist_entry(seat->videos.next, struct kmscon_video, list);
+	while (!dlist_empty(&seat->videos)) {
+		vid = dlist_entry(seat->videos.next, struct kmscon_video, list);
 		kmscon_seat_remove_video(seat, vid);
 	}
 
@@ -985,7 +985,7 @@ static int kmscon_seat_add_video(struct kmscon_seat *seat, enum uterm_monitor_de
 		if (ret)
 			goto err_node;
 	}
-	shl_dlist_link(&seat->videos, &vid->list);
+	dlist_link(&seat->videos, &vid->list);
 	return 0;
 
 err_node:
@@ -1000,7 +1000,7 @@ static void kmscon_seat_remove_video(struct kmscon_seat *seat, void *data)
 {
 	struct kmscon_video *vid = data;
 	struct kmscon_display *d;
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 
 	if (!seat || !vid)
 		return;
@@ -1008,10 +1008,10 @@ static void kmscon_seat_remove_video(struct kmscon_seat *seat, void *data)
 	log_debug("free video device %s on seat %s", vid->node, seat->name);
 
 	uterm_monitor_set_dev_data(vid->udev, NULL);
-	shl_dlist_unlink(&vid->list);
+	dlist_unlink(&vid->list);
 
 	if (vid->video) {
-		shl_dlist_for_each_entry_safe(d, tmp, &seat->displays, list)
+		dlist_for_each_entry_safe(d, tmp, &seat->displays, list)
 		{
 			if (display_video(d->disp) == vid->video)
 				_seat_remove_display(seat, d);
@@ -1097,13 +1097,13 @@ static struct kmscon_session *kmscon_seat_new_session(struct kmscon_seat *seat)
 
 	/* register new sessions next to the current one */
 	if (seat->current_sess)
-		shl_dlist_link(&seat->current_sess->list, &sess->list);
+		dlist_link(&seat->current_sess->list, &sess->list);
 	else
-		shl_dlist_link_tail(&seat->sessions, &sess->list);
+		dlist_link_tail(&seat->sessions, &sess->list);
 
 	++seat->session_count;
 
-	shl_dlist_for_each_entry(d, &seat->displays, list)
+	dlist_for_each_entry(d, &seat->displays, list)
 	{
 		terminal_add_display(sess->term, d->disp);
 	}
@@ -1126,7 +1126,7 @@ static void kmscon_session_unregister(struct kmscon_session *sess)
 		seat_next(seat);
 	}
 
-	shl_dlist_unlink(&sess->list);
+	dlist_unlink(&sess->list);
 	--seat->session_count;
 	sess->seat = NULL;
 

--- a/src/seat.c
+++ b/src/seat.c
@@ -817,6 +817,7 @@ void kmscon_seat_free(struct kmscon_seat *seat)
 {
 	struct kmscon_session *s;
 	struct kmscon_video *vid;
+	struct dlist *tmp;
 	int ret;
 
 	if (!seat)
@@ -828,12 +829,12 @@ void kmscon_seat_free(struct kmscon_seat *seat)
 	if (ret)
 		log_warning("destroying seat %s while still awake: %d", seat->name, ret);
 
-	while (!dlist_empty(&seat->sessions)) {
-		s = dlist_entry(seat->sessions.next, struct kmscon_session, list);
+	dlist_for_each_entry_safe(s, tmp, &seat->sessions, list)
+	{
 		kmscon_session_unregister(s);
 	}
-	while (!dlist_empty(&seat->videos)) {
-		vid = dlist_entry(seat->videos.next, struct kmscon_video, list);
+	dlist_for_each_entry_safe(vid, tmp, &seat->videos, list)
+	{
 		kmscon_seat_remove_video(seat, vid);
 	}
 

--- a/src/shl/dlist.h
+++ b/src/shl/dlist.h
@@ -46,21 +46,20 @@
 
 /* double linked list */
 
-struct shl_dlist {
-	struct shl_dlist *next;
-	struct shl_dlist *prev;
+struct dlist {
+	struct dlist *next;
+	struct dlist *prev;
 };
 
 #define SHL_DLIST_INIT(head) {&(head), &(head)}
 
-static inline void shl_dlist_init(struct shl_dlist *list)
+static inline void dlist_init(struct dlist *list)
 {
 	list->next = list;
 	list->prev = list;
 }
 
-static inline void shl_dlist__link(struct shl_dlist *prev, struct shl_dlist *next,
-				   struct shl_dlist *n)
+static inline void dlist__link(struct dlist *prev, struct dlist *next, struct dlist *n)
 {
 	next->prev = n;
 	n->next = next;
@@ -68,66 +67,64 @@ static inline void shl_dlist__link(struct shl_dlist *prev, struct shl_dlist *nex
 	prev->next = n;
 }
 
-static inline void shl_dlist_link(struct shl_dlist *head, struct shl_dlist *n)
+static inline void dlist_link(struct dlist *head, struct dlist *n)
 {
-	return shl_dlist__link(head, head->next, n);
+	return dlist__link(head, head->next, n);
 }
 
-static inline void shl_dlist_link_tail(struct shl_dlist *head, struct shl_dlist *n)
+static inline void dlist_link_tail(struct dlist *head, struct dlist *n)
 {
-	return shl_dlist__link(head->prev, head, n);
+	return dlist__link(head->prev, head, n);
 }
 
-static inline void shl_dlist__unlink(struct shl_dlist *prev, struct shl_dlist *next)
+static inline void dlist__unlink(struct dlist *prev, struct dlist *next)
 {
 	next->prev = prev;
 	prev->next = next;
 }
 
-static inline void shl_dlist_unlink(struct shl_dlist *e)
+static inline void dlist_unlink(struct dlist *e)
 {
-	shl_dlist__unlink(e->prev, e->next);
+	dlist__unlink(e->prev, e->next);
 	e->prev = NULL;
 	e->next = NULL;
 }
 
-static inline bool shl_dlist_empty(struct shl_dlist *head)
+static inline bool dlist_empty(struct dlist *head)
 {
 	return head->next == head;
 }
 
-#define shl_dlist_entry(ptr, type, member) shl_offsetof((ptr), type, member)
+#define dlist_entry(ptr, type, member) shl_offsetof((ptr), type, member)
 
-#define shl_dlist_first(head, type, member) shl_dlist_entry((head)->next, type, member)
+#define dlist_first(head, type, member) dlist_entry((head)->next, type, member)
 
-#define shl_dlist_last(head, type, member) shl_dlist_entry((head)->prev, type, member)
+#define dlist_last(head, type, member) dlist_entry((head)->prev, type, member)
 
-#define shl_dlist_next(iter, head, member)                                                         \
-	((iter)->member.next == (head)                                                             \
-		 ? NULL                                                                            \
-		 : shl_dlist_entry((iter)->member.next, typeof(*iter), list))
+#define dlist_next(iter, head, member)                                                             \
+	((iter)->member.next == (head) ? NULL                                                      \
+				       : dlist_entry((iter)->member.next, typeof(*iter), list))
 
-#define shl_dlist_prev(iter, head, member)                                                         \
-	((iter)->member.prev == (head)                                                             \
-		 ? NULL                                                                            \
-		 : shl_dlist_entry((iter)->member.prev, typeof(*iter), list))
+#define dlist_prev(iter, head, member)                                                             \
+	((iter)->member.prev == (head) ? NULL                                                      \
+				       : dlist_entry((iter)->member.prev, typeof(*iter), list))
 
-#define shl_dlist_for_each_entry(iter, head, member)                                               \
-	for (iter = shl_dlist_entry((head)->next, typeof(*iter), member); &iter->member != (head); \
-	     iter = shl_dlist_entry(iter->member.next, typeof(*iter), member))
+#define dlist_for_each_entry(iter, head, member)                                                   \
+	for (iter = dlist_entry((head)->next, typeof(*iter), member); &iter->member != (head);     \
+	     iter = dlist_entry(iter->member.next, typeof(*iter), member))
 
-#define shl_dlist_for_each_entry_safe(iter, tmp, head, member)                                     \
-	for (iter = shl_dlist_entry((head)->next, typeof(*iter), member), tmp = iter->member.next; \
+#define dlist_for_each_entry_safe(iter, tmp, head, member)                                         \
+	for (iter = dlist_entry((head)->next, typeof(*iter), member), tmp = iter->member.next;     \
 	     &iter->member != (head);                                                              \
-	     iter = shl_dlist_entry(tmp, typeof(*iter), member), tmp = iter->member.next)
+	     iter = dlist_entry(tmp, typeof(*iter), member), tmp = iter->member.next)
 
-#define shl_dlist_for_each_entry_reverse(iter, head, member)                                       \
-	for (iter = shl_dlist_entry((head)->prev, typeof(*iter), member); &iter->member != (head); \
-	     iter = shl_dlist_entry(iter->member.prev, typeof(*iter), member))
+#define dlist_for_each_entry_reverse(iter, head, member)                                           \
+	for (iter = dlist_entry((head)->prev, typeof(*iter), member); &iter->member != (head);     \
+	     iter = dlist_entry(iter->member.prev, typeof(*iter), member))
 
-#define shl_dlist_for_each_entry_reverse_safe(iter, tmp, head, member)                             \
-	for (iter = shl_dlist_entry((head)->prev, typeof(*iter), member), tmp = iter->member.prev; \
+#define dlist_for_each_entry_reverse_safe(iter, tmp, head, member)                                 \
+	for (iter = dlist_entry((head)->prev, typeof(*iter), member), tmp = iter->member.prev;     \
 	     &iter->member != (head);                                                              \
-	     iter = shl_dlist_entry(tmp, typeof(*iter), member), tmp = iter->member.prev)
+	     iter = dlist_entry(tmp, typeof(*iter), member), tmp = iter->member.prev)
 
 #endif /* SHL_DLIST_H */

--- a/src/shl/dlist.h
+++ b/src/shl/dlist.h
@@ -121,20 +121,13 @@ static inline bool shl_dlist_empty(struct shl_dlist *head)
 	     &iter->member != (head);                                                              \
 	     iter = shl_dlist_entry(tmp, typeof(*iter), member), tmp = iter->member.next)
 
-#define shl_dlist_for_each_but_one(iter, start, head)                                              \
-	for (iter = ((start)->next == (head)) ? (start)->next->next : (start)->next;               \
-	     iter != (start);                                                                      \
-	     iter = (iter->next == (head) && (start) != (head)) ? iter->next->next : iter->next)
+#define shl_dlist_for_each_entry_reverse(iter, head, member)                                       \
+	for (iter = shl_dlist_entry((head)->prev, typeof(*iter), member); &iter->member != (head); \
+	     iter = shl_dlist_entry(iter->member.prev, typeof(*iter), member))
 
-#define shl_dlist_for_each_reverse(iter, head)                                                     \
-	for (iter = (head)->prev; iter != (head); iter = iter->prev)
-
-#define shl_dlist_for_each_reverse_but_one(iter, start, head)                                      \
-	for (iter = ((start)->prev == (head)) ? (start)->prev->prev : (start)->prev;               \
-	     iter != (start);                                                                      \
-	     iter = (iter->prev == (head) && (start) != (head)) ? iter->prev->prev : iter->prev)
-
-#define shl_dlist_for_each_reverse_safe(iter, tmp, head)                                           \
-	for (iter = (head)->prev, tmp = iter->prev; iter != (head); iter = tmp, tmp = iter->prev)
+#define shl_dlist_for_each_entry_reverse_safe(iter, tmp, head, member)                             \
+	for (iter = shl_dlist_entry((head)->prev, typeof(*iter), member), tmp = iter->member.prev; \
+	     &iter->member != (head);                                                              \
+	     iter = shl_dlist_entry(tmp, typeof(*iter), member), tmp = iter->member.prev)
 
 #endif /* SHL_DLIST_H */

--- a/src/shl/dlist.h
+++ b/src/shl/dlist.h
@@ -112,7 +112,9 @@ static inline bool shl_dlist_empty(struct shl_dlist *head)
 		 ? NULL                                                                            \
 		 : shl_dlist_entry((iter)->member.prev, typeof(*iter), list))
 
-#define shl_dlist_for_each(iter, head) for (iter = (head)->next; iter != (head); iter = iter->next)
+#define shl_dlist_for_each_entry(iter, head, member)                                               \
+	for (iter = shl_dlist_entry((head)->next, typeof(*iter), member); &iter->member != (head); \
+	     iter = shl_dlist_entry(iter->member.next, typeof(*iter), member))
 
 #define shl_dlist_for_each_but_one(iter, start, head)                                              \
 	for (iter = ((start)->next == (head)) ? (start)->next->next : (start)->next;               \

--- a/src/shl/dlist.h
+++ b/src/shl/dlist.h
@@ -116,13 +116,15 @@ static inline bool shl_dlist_empty(struct shl_dlist *head)
 	for (iter = shl_dlist_entry((head)->next, typeof(*iter), member); &iter->member != (head); \
 	     iter = shl_dlist_entry(iter->member.next, typeof(*iter), member))
 
+#define shl_dlist_for_each_entry_safe(iter, tmp, head, member)                                     \
+	for (iter = shl_dlist_entry((head)->next, typeof(*iter), member), tmp = iter->member.next; \
+	     &iter->member != (head);                                                              \
+	     iter = shl_dlist_entry(tmp, typeof(*iter), member), tmp = iter->member.next)
+
 #define shl_dlist_for_each_but_one(iter, start, head)                                              \
 	for (iter = ((start)->next == (head)) ? (start)->next->next : (start)->next;               \
 	     iter != (start);                                                                      \
 	     iter = (iter->next == (head) && (start) != (head)) ? iter->next->next : iter->next)
-
-#define shl_dlist_for_each_safe(iter, tmp, head)                                                   \
-	for (iter = (head)->next, tmp = iter->next; iter != (head); iter = tmp, tmp = iter->next)
 
 #define shl_dlist_for_each_reverse(iter, head)                                                     \
 	for (iter = (head)->prev; iter != (head); iter = iter->prev)

--- a/src/shl/eloop.c
+++ b/src/shl/eloop.c
@@ -2139,6 +2139,17 @@ void ev_eloop_rm_counter(struct ev_counter *cnt)
  * eloop description to see some drawbacks when nesting eloop objects with the
  * same shared signal sources.
  */
+static struct ev_signal_shared *ev_loop_get_signal(struct ev_eloop *loop, int signum)
+{
+	struct ev_signal_shared *sig;
+
+	shl_dlist_for_each_entry(sig, &loop->sig_list, list)
+	{
+		if (sig->signum == signum)
+			return sig;
+	}
+	return NULL;
+}
 
 /**
  * ev_eloop_register_signal_cb:
@@ -2156,20 +2167,13 @@ SHL_EXPORT
 int ev_eloop_register_signal_cb(struct ev_eloop *loop, int signum, ev_signal_shared_cb cb,
 				void *data)
 {
-	struct ev_signal_shared *sig = NULL;
+	struct ev_signal_shared *sig;
 	int ret;
-	struct shl_dlist *iter;
 
 	if (!loop || signum < 0 || !cb)
 		return -EINVAL;
 
-	shl_dlist_for_each(iter, &loop->sig_list)
-	{
-		sig = shl_dlist_entry(iter, struct ev_signal_shared, list);
-		if (sig->signum == signum)
-			break;
-		sig = NULL;
-	}
+	sig = ev_loop_get_signal(loop, signum);
 
 	if (!sig) {
 		ret = signal_new(&sig, loop, signum);
@@ -2203,14 +2207,12 @@ void ev_eloop_unregister_signal_cb(struct ev_eloop *loop, int signum, ev_signal_
 				   void *data)
 {
 	struct ev_signal_shared *sig;
-	struct shl_dlist *iter;
 
 	if (!loop)
 		return;
 
-	shl_dlist_for_each(iter, &loop->sig_list)
+	shl_dlist_for_each_entry(sig, &loop->sig_list, list)
 	{
-		sig = shl_dlist_entry(iter, struct ev_signal_shared, list);
 		if (sig->signum == signum) {
 			shl_hook_rm_cast(sig->hook, cb, data);
 			if (!shl_hook_num(sig->hook))

--- a/src/shl/eloop.c
+++ b/src/shl/eloop.c
@@ -203,7 +203,7 @@ struct ev_eloop {
 	struct ev_fd *fd;
 	int idle_fd;
 
-	struct shl_dlist sig_list;
+	struct dlist sig_list;
 	struct shl_hook *chlds;
 	struct shl_hook *idlers;
 	struct shl_hook *pres;
@@ -290,7 +290,7 @@ struct ev_counter {
  * are called if the signal is caught.
  */
 struct ev_signal_shared {
-	struct shl_dlist list;
+	struct dlist list;
 
 	struct ev_fd *fd;
 	int signum;
@@ -406,7 +406,7 @@ static int signal_new(struct ev_signal_shared **out, struct ev_eloop *loop, int 
 		goto err_sig;
 
 	pthread_sigmask(SIG_BLOCK, &mask, NULL);
-	shl_dlist_link(&loop->sig_list, &sig->list);
+	dlist_link(&loop->sig_list, &sig->list);
 
 	*out = sig;
 	return 0;
@@ -436,7 +436,7 @@ static void signal_free(struct ev_signal_shared *sig)
 	if (!sig)
 		return;
 
-	shl_dlist_unlink(&sig->list);
+	dlist_unlink(&sig->list);
 	fd = sig->fd->fd;
 	ev_eloop_rm_fd(sig->fd);
 	close(fd);
@@ -578,7 +578,7 @@ int ev_eloop_new(struct ev_eloop **out)
 
 	memset(loop, 0, sizeof(*loop));
 	loop->ref = 1;
-	shl_dlist_init(&loop->sig_list);
+	dlist_init(&loop->sig_list);
 
 	loop->cur_fds_size = 32;
 	loop->cur_fds = malloc(sizeof(struct epoll_event) * loop->cur_fds_size);
@@ -703,7 +703,7 @@ void ev_eloop_unref(struct ev_eloop *loop)
 		ev_eloop_unregister_signal_cb(loop, SIGCHLD, sig_child, loop);
 
 	while (loop->sig_list.next != &loop->sig_list) {
-		sig = shl_dlist_entry(loop->sig_list.next, struct ev_signal_shared, list);
+		sig = dlist_entry(loop->sig_list.next, struct ev_signal_shared, list);
 		signal_free(sig);
 	}
 
@@ -2143,7 +2143,7 @@ static struct ev_signal_shared *ev_loop_get_signal(struct ev_eloop *loop, int si
 {
 	struct ev_signal_shared *sig;
 
-	shl_dlist_for_each_entry(sig, &loop->sig_list, list)
+	dlist_for_each_entry(sig, &loop->sig_list, list)
 	{
 		if (sig->signum == signum)
 			return sig;
@@ -2211,7 +2211,7 @@ void ev_eloop_unregister_signal_cb(struct ev_eloop *loop, int signum, ev_signal_
 	if (!loop)
 		return;
 
-	shl_dlist_for_each_entry(sig, &loop->sig_list, list)
+	dlist_for_each_entry(sig, &loop->sig_list, list)
 	{
 		if (sig->signum == signum) {
 			shl_hook_rm_cast(sig->hook, cb, data);

--- a/src/shl/hook.h
+++ b/src/shl/hook.h
@@ -152,19 +152,17 @@ static inline int shl_hook_add_single(struct shl_hook *hook, shl_hook_cb cb, voi
 
 static inline void shl_hook_rm(struct shl_hook *hook, shl_hook_cb cb, void *data)
 {
-	struct shl_dlist *iter;
 	struct shl_hook_entry *entry;
 
 	if (!hook || !cb)
 		return;
 
-	shl_dlist_for_each_reverse(iter, &hook->entries)
+	shl_dlist_for_each_entry_reverse(entry, &hook->entries, list)
 	{
-		entry = shl_dlist_entry(iter, struct shl_hook_entry, list);
 		if (entry->cb == cb && entry->data == data) {
 			/* if *_call() is running we must not disturb it */
-			if (hook->cur_entry == iter)
-				hook->cur_entry = iter->next;
+			if (hook->cur_entry == &entry->list)
+				hook->cur_entry = entry->list.next;
 			shl_dlist_unlink(&entry->list);
 			free(entry);
 			hook->num--;
@@ -175,19 +173,18 @@ static inline void shl_hook_rm(struct shl_hook *hook, shl_hook_cb cb, void *data
 
 static inline void shl_hook_rm_all(struct shl_hook *hook, shl_hook_cb cb, void *data)
 {
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 	struct shl_hook_entry *entry;
 
 	if (!hook || !cb)
 		return;
 
-	shl_dlist_for_each_reverse_safe(iter, tmp, &hook->entries)
+	shl_dlist_for_each_entry_reverse_safe(entry, tmp, &hook->entries, list)
 	{
-		entry = shl_dlist_entry(iter, struct shl_hook_entry, list);
 		if (entry->cb == cb && entry->data == data) {
 			/* if *_call() is running we must not disturb it */
-			if (hook->cur_entry == iter)
-				hook->cur_entry = iter->next;
+			if (hook->cur_entry == &entry->list)
+				hook->cur_entry = entry->list.next;
 			shl_dlist_unlink(&entry->list);
 			free(entry);
 			hook->num--;

--- a/src/shl/hook.h
+++ b/src/shl/hook.h
@@ -51,7 +51,7 @@ typedef void (*shl_hook_cb)(void *parent, void *arg, void *data);
 #define shl_hook_rm_all_cast(hook, cb, data) shl_hook_rm_all((hook), (shl_hook_cb)(cb), (data))
 
 struct shl_hook_entry {
-	struct shl_dlist list;
+	struct dlist list;
 	shl_hook_cb cb;
 	void *data;
 	bool oneshot;
@@ -59,8 +59,8 @@ struct shl_hook_entry {
 
 struct shl_hook {
 	unsigned int num;
-	struct shl_dlist entries;
-	struct shl_dlist *cur_entry;
+	struct dlist entries;
+	struct dlist *cur_entry;
 	bool dead;
 };
 
@@ -75,7 +75,7 @@ static inline int shl_hook_new(struct shl_hook **out)
 	if (!hook)
 		return -ENOMEM;
 	memset(hook, 0, sizeof(*hook));
-	shl_dlist_init(&hook->entries);
+	dlist_init(&hook->entries);
 
 	*out = hook;
 	return 0;
@@ -93,9 +93,9 @@ static inline void shl_hook_free(struct shl_hook *hook)
 		return;
 	}
 
-	while (!shl_dlist_empty(&hook->entries)) {
-		entry = shl_dlist_entry(hook->entries.prev, struct shl_hook_entry, list);
-		shl_dlist_unlink(&entry->list);
+	while (!dlist_empty(&hook->entries)) {
+		entry = dlist_entry(hook->entries.prev, struct shl_hook_entry, list);
+		dlist_unlink(&entry->list);
 		free(entry);
 	}
 
@@ -125,7 +125,7 @@ static inline int shl_hook_add(struct shl_hook *hook, shl_hook_cb cb, void *data
 	entry->data = data;
 	entry->oneshot = oneshot;
 
-	shl_dlist_link_tail(&hook->entries, &entry->list);
+	dlist_link_tail(&hook->entries, &entry->list);
 	hook->num++;
 	return 0;
 }
@@ -141,7 +141,7 @@ static inline int shl_hook_add_single(struct shl_hook *hook, shl_hook_cb cb, voi
 	if (!hook || !cb)
 		return -EINVAL;
 
-	shl_dlist_for_each_entry(entry, &hook->entries, list)
+	dlist_for_each_entry(entry, &hook->entries, list)
 	{
 		if (entry->cb == cb && entry->data == data)
 			return 0;
@@ -157,13 +157,13 @@ static inline void shl_hook_rm(struct shl_hook *hook, shl_hook_cb cb, void *data
 	if (!hook || !cb)
 		return;
 
-	shl_dlist_for_each_entry_reverse(entry, &hook->entries, list)
+	dlist_for_each_entry_reverse(entry, &hook->entries, list)
 	{
 		if (entry->cb == cb && entry->data == data) {
 			/* if *_call() is running we must not disturb it */
 			if (hook->cur_entry == &entry->list)
 				hook->cur_entry = entry->list.next;
-			shl_dlist_unlink(&entry->list);
+			dlist_unlink(&entry->list);
 			free(entry);
 			hook->num--;
 			return;
@@ -173,19 +173,19 @@ static inline void shl_hook_rm(struct shl_hook *hook, shl_hook_cb cb, void *data
 
 static inline void shl_hook_rm_all(struct shl_hook *hook, shl_hook_cb cb, void *data)
 {
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 	struct shl_hook_entry *entry;
 
 	if (!hook || !cb)
 		return;
 
-	shl_dlist_for_each_entry_reverse_safe(entry, tmp, &hook->entries, list)
+	dlist_for_each_entry_reverse_safe(entry, tmp, &hook->entries, list)
 	{
 		if (entry->cb == cb && entry->data == data) {
 			/* if *_call() is running we must not disturb it */
 			if (hook->cur_entry == &entry->list)
 				hook->cur_entry = entry->list.next;
-			shl_dlist_unlink(&entry->list);
+			dlist_unlink(&entry->list);
 			free(entry);
 			hook->num--;
 		}
@@ -201,12 +201,12 @@ static inline void shl_hook_call(struct shl_hook *hook, void *parent, void *arg)
 		return;
 
 	for (hook->cur_entry = hook->entries.next; hook->cur_entry != &hook->entries;) {
-		entry = shl_dlist_entry(hook->cur_entry, struct shl_hook_entry, list);
+		entry = dlist_entry(hook->cur_entry, struct shl_hook_entry, list);
 		hook->cur_entry = entry->list.next;
 		oneshot = entry->oneshot;
 
 		if (oneshot)
-			shl_dlist_unlink(&entry->list);
+			dlist_unlink(&entry->list);
 
 		entry->cb(parent, arg, entry->data);
 

--- a/src/shl/hook.h
+++ b/src/shl/hook.h
@@ -137,14 +137,12 @@ static inline int shl_hook_add_single(struct shl_hook *hook, shl_hook_cb cb, voi
 				      bool oneshot)
 {
 	struct shl_hook_entry *entry;
-	struct shl_dlist *iter;
 
 	if (!hook || !cb)
 		return -EINVAL;
 
-	shl_dlist_for_each(iter, &hook->entries)
+	shl_dlist_for_each_entry(entry, &hook->entries, list)
 	{
-		entry = shl_dlist_entry(iter, struct shl_hook_entry, list);
 		if (entry->cb == cb && entry->data == data)
 			return 0;
 	}

--- a/src/shl/lru.h
+++ b/src/shl/lru.h
@@ -34,11 +34,11 @@ struct shl_lru {
 	unsigned int max_size;
 	unsigned int size;
 	struct htable tbl;
-	struct shl_dlist list;
+	struct dlist list;
 };
 
 struct shl_lru_entry {
-	struct shl_dlist list;
+	struct dlist list;
 	uint64_t key;
 	void *value;
 };
@@ -64,7 +64,7 @@ static inline struct shl_lru *shl_lru_new(unsigned int max_size)
 
 	lru->max_size = max_size;
 	lru->size = 0;
-	shl_dlist_init(&lru->list);
+	dlist_init(&lru->list);
 	htable_init(&lru->tbl, shl_lru_rehash, lru);
 
 	return lru;
@@ -100,8 +100,8 @@ static inline void *shl_lru_get(struct shl_lru *lru, uint64_t key)
 	     entry = htable_nextval(&lru->tbl, &i, key)) {
 		if (key == entry->key) {
 			/* Put this entry at the top of the list */
-			shl_dlist_unlink(&entry->list);
-			shl_dlist_link(&lru->list, &entry->list);
+			dlist_unlink(&entry->list);
+			dlist_link(&lru->list, &entry->list);
 			return entry->value;
 		}
 	}
@@ -113,13 +113,13 @@ static inline int shl_lru_evict(struct shl_lru *lru)
 	struct shl_lru_entry *last, *entry;
 	struct htable_iter i;
 
-	last = shl_dlist_last(&lru->list, struct shl_lru_entry, list);
+	last = dlist_last(&lru->list, struct shl_lru_entry, list);
 
 	for (entry = htable_firstval(&lru->tbl, &i, last->key); entry;
 	     entry = htable_nextval(&lru->tbl, &i, last->key)) {
 		if (last == entry) {
 			htable_delval(&lru->tbl, &i);
-			shl_dlist_unlink(&last->list);
+			dlist_unlink(&last->list);
 			free(entry->value);
 			free(entry);
 			lru->size--;
@@ -150,7 +150,7 @@ static inline int shl_lru_insert(struct shl_lru *lru, uint64_t key, void *value)
 		free(entry);
 		return -ENOMEM;
 	}
-	shl_dlist_link(&lru->list, &entry->list);
+	dlist_link(&lru->list, &entry->list);
 	lru->size++;
 	return 0;
 }

--- a/src/shl/module.c
+++ b/src/shl/module.c
@@ -246,11 +246,12 @@ void kmscon_load_modules(void)
 void kmscon_unload_modules(void)
 {
 	struct shl_module *module;
+	struct dlist *tmp;
 
 	log_debug("unloading modules");
 
-	while (!dlist_empty(&module_list)) {
-		module = dlist_entry(module_list.prev, struct shl_module, list);
+	dlist_for_each_entry_safe(module, tmp, &module_list, list)
+	{
 		dlist_unlink(&module->list);
 		shl_module_unload(module);
 		shl_module_unref(module);

--- a/src/shl/module.c
+++ b/src/shl/module.c
@@ -39,7 +39,7 @@
 
 #define LOG_SUBSYSTEM "module"
 
-static struct shl_dlist module_list = SHL_DLIST_INIT(module_list);
+static struct dlist module_list = SHL_DLIST_INIT(module_list);
 
 int shl_module_open(struct shl_module **out, const char *file)
 {
@@ -181,7 +181,7 @@ void kmscon_load_modules(void)
 
 	log_debug("loading global modules from %s", BUILD_MODULE_DIR);
 
-	if (!shl_dlist_empty(&module_list)) {
+	if (!dlist_empty(&module_list)) {
 		log_error("trying to load global modules twice");
 		return;
 	}
@@ -237,7 +237,7 @@ void kmscon_load_modules(void)
 			continue;
 		}
 
-		shl_dlist_link(&module_list, &mod->list);
+		dlist_link(&module_list, &mod->list);
 	}
 
 	closedir(ent);
@@ -249,9 +249,9 @@ void kmscon_unload_modules(void)
 
 	log_debug("unloading modules");
 
-	while (!shl_dlist_empty(&module_list)) {
-		module = shl_dlist_entry(module_list.prev, struct shl_module, list);
-		shl_dlist_unlink(&module->list);
+	while (!dlist_empty(&module_list)) {
+		module = dlist_entry(module_list.prev, struct shl_module, list);
+		dlist_unlink(&module->list);
 		shl_module_unload(module);
 		shl_module_unref(module);
 	}

--- a/src/shl/module_interface.h
+++ b/src/shl/module_interface.h
@@ -49,7 +49,7 @@ struct shl_module_info {
 
 struct shl_module {
 	struct shl_module_info info;
-	struct shl_dlist list;
+	struct dlist list;
 	unsigned long ref;
 	bool loaded;
 	void *handle;

--- a/src/shl/register.h
+++ b/src/shl/register.h
@@ -136,15 +136,13 @@ err_free:
 
 static inline void shl_register_free(struct shl_register *reg)
 {
-	struct shl_dlist *iter;
 	struct shl_register_record *record;
 
 	if (!reg)
 		return;
 
-	shl_dlist_for_each(iter, &reg->records)
+	shl_dlist_for_each_entry(record, &reg->records, list)
 	{
-		record = shl_dlist_entry(iter, struct shl_register_record, list);
 		shl_dlist_unlink(&record->list);
 		shl_register_record_unref(record);
 	}
@@ -156,7 +154,6 @@ static inline void shl_register_free(struct shl_register *reg)
 static inline int shl_register_add_cb(struct shl_register *reg, const char *name, void *data,
 				      shl_register_destroy_cb destroy)
 {
-	struct shl_dlist *iter;
 	struct shl_register_record *record;
 	int ret;
 
@@ -167,9 +164,8 @@ static inline int shl_register_add_cb(struct shl_register *reg, const char *name
 	if (ret)
 		return -EFAULT;
 
-	shl_dlist_for_each(iter, &reg->records)
+	shl_dlist_for_each_entry(record, &reg->records, list)
 	{
-		record = shl_dlist_entry(iter, struct shl_register_record, list);
 		if (!strcmp(record->name, name)) {
 			ret = -EALREADY;
 			goto out_unlock;
@@ -218,7 +214,6 @@ static inline int shl_register_add(struct shl_register *reg, const char *name, v
 
 static inline void shl_register_remove(struct shl_register *reg, const char *name)
 {
-	struct shl_dlist *iter;
 	struct shl_register_record *record;
 	int ret;
 
@@ -229,9 +224,8 @@ static inline void shl_register_remove(struct shl_register *reg, const char *nam
 	if (ret)
 		return;
 
-	shl_dlist_for_each(iter, &reg->records)
+	shl_dlist_for_each_entry(record, &reg->records, list)
 	{
-		record = shl_dlist_entry(iter, struct shl_register_record, list);
 		if (strcmp(record->name, name))
 			continue;
 
@@ -246,7 +240,6 @@ static inline void shl_register_remove(struct shl_register *reg, const char *nam
 static inline struct shl_register_record *shl_register_find(struct shl_register *reg,
 							    const char *name)
 {
-	struct shl_dlist *iter;
 	struct shl_register_record *record, *res;
 	int ret;
 
@@ -258,9 +251,8 @@ static inline struct shl_register_record *shl_register_find(struct shl_register 
 		return NULL;
 
 	res = NULL;
-	shl_dlist_for_each(iter, &reg->records)
+	shl_dlist_for_each_entry(record, &reg->records, list)
 	{
-		record = shl_dlist_entry(iter, struct shl_register_record, list);
 		if (!strcmp(record->name, name)) {
 			res = record;
 			shl_register_record_ref(res);

--- a/src/shl/register.h
+++ b/src/shl/register.h
@@ -48,7 +48,7 @@
 typedef void (*shl_register_destroy_cb)(void *data);
 
 struct shl_register_record {
-	struct shl_dlist list;
+	struct dlist list;
 
 	pthread_mutex_t mutex;
 	unsigned long ref;
@@ -59,7 +59,7 @@ struct shl_register_record {
 
 struct shl_register {
 	pthread_mutex_t mutex;
-	struct shl_dlist records;
+	struct dlist records;
 };
 
 #define SHL_REGISTER_INIT(name)                                                                    \
@@ -118,7 +118,7 @@ static inline int shl_register_new(struct shl_register **out)
 	if (!reg)
 		return -ENOMEM;
 	memset(reg, 0, sizeof(*reg));
-	shl_dlist_init(&reg->records);
+	dlist_init(&reg->records);
 
 	ret = pthread_mutex_init(&reg->mutex, NULL);
 	if (ret) {
@@ -141,9 +141,9 @@ static inline void shl_register_free(struct shl_register *reg)
 	if (!reg)
 		return;
 
-	shl_dlist_for_each_entry(record, &reg->records, list)
+	dlist_for_each_entry(record, &reg->records, list)
 	{
-		shl_dlist_unlink(&record->list);
+		dlist_unlink(&record->list);
 		shl_register_record_unref(record);
 	}
 
@@ -164,7 +164,7 @@ static inline int shl_register_add_cb(struct shl_register *reg, const char *name
 	if (ret)
 		return -EFAULT;
 
-	shl_dlist_for_each_entry(record, &reg->records, list)
+	dlist_for_each_entry(record, &reg->records, list)
 	{
 		if (!strcmp(record->name, name)) {
 			ret = -EALREADY;
@@ -194,7 +194,7 @@ static inline int shl_register_add_cb(struct shl_register *reg, const char *name
 		goto err_mutex;
 	}
 
-	shl_dlist_link_tail(&reg->records, &record->list);
+	dlist_link_tail(&reg->records, &record->list);
 	ret = 0;
 	goto out_unlock;
 
@@ -224,12 +224,12 @@ static inline void shl_register_remove(struct shl_register *reg, const char *nam
 	if (ret)
 		return;
 
-	shl_dlist_for_each_entry(record, &reg->records, list)
+	dlist_for_each_entry(record, &reg->records, list)
 	{
 		if (strcmp(record->name, name))
 			continue;
 
-		shl_dlist_unlink(&record->list);
+		dlist_unlink(&record->list);
 		shl_register_record_unref(record);
 		break;
 	}
@@ -251,7 +251,7 @@ static inline struct shl_register_record *shl_register_find(struct shl_register 
 		return NULL;
 
 	res = NULL;
-	shl_dlist_for_each_entry(record, &reg->records, list)
+	dlist_for_each_entry(record, &reg->records, list)
 	{
 		if (!strcmp(record->name, name)) {
 			res = record;
@@ -276,10 +276,10 @@ static inline struct shl_register_record *shl_register_first(struct shl_register
 	if (ret)
 		return NULL;
 
-	if (shl_dlist_empty(&reg->records)) {
+	if (dlist_empty(&reg->records)) {
 		res = NULL;
 	} else {
-		res = shl_dlist_entry(reg->records.next, struct shl_register_record, list);
+		res = dlist_entry(reg->records.next, struct shl_register_record, list);
 		shl_register_record_ref(res);
 	}
 
@@ -299,10 +299,10 @@ static inline struct shl_register_record *shl_register_last(struct shl_register 
 	if (ret)
 		return NULL;
 
-	if (shl_dlist_empty(&reg->records)) {
+	if (dlist_empty(&reg->records)) {
 		res = NULL;
 	} else {
-		res = shl_dlist_entry(reg->records.prev, struct shl_register_record, list);
+		res = dlist_entry(reg->records.prev, struct shl_register_record, list);
 		shl_register_record_ref(res);
 	}
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -54,7 +54,7 @@
 #define LOG_SUBSYSTEM "terminal"
 
 struct screen {
-	struct shl_dlist list;
+	struct dlist list;
 	struct kmscon_terminal *term;
 	struct display *disp;
 	struct kmscon_text *txt;
@@ -87,7 +87,7 @@ struct kmscon_terminal {
 	struct kmscon_conf_t *conf;
 	struct kmscon_session *session;
 
-	struct shl_dlist screens;
+	struct dlist screens;
 	unsigned int cols;
 	unsigned int rows;
 
@@ -348,7 +348,7 @@ static void redraw_all(struct kmscon_terminal *term)
 	if (!term->awake)
 		return;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		redraw_screen(scr);
 	}
@@ -358,7 +358,7 @@ static bool has_kms_display(struct kmscon_terminal *term)
 {
 	struct screen *scr;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		if (display_is_drm(scr->disp))
 			return true;
@@ -380,7 +380,7 @@ static void update_pointer_max_all(struct kmscon_terminal *term)
 	if (!term->awake)
 		return;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		if (!scr->enabled)
 			continue;
@@ -502,7 +502,7 @@ static bool terminal_update_size_clone(struct kmscon_terminal *term)
 	unsigned int min_cols = UINT_MAX;
 	unsigned int min_rows = UINT_MAX;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		unsigned int cols, rows;
 		cols = kmscon_text_get_cols(scr->txt, term->font->width);
@@ -535,7 +535,7 @@ static bool terminal_update_size_largest(struct kmscon_terminal *term)
 	unsigned int rows, cols, cells;
 	unsigned int max_cells = 0;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		rows = kmscon_text_get_rows(scr->txt, term->font->height);
 		cols = kmscon_text_get_cols(scr->txt, term->font->width);
@@ -546,7 +546,7 @@ static bool terminal_update_size_largest(struct kmscon_terminal *term)
 			term->rows = rows;
 		}
 	}
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		rows = kmscon_text_get_rows(scr->txt, term->font->height);
 		cols = kmscon_text_get_cols(scr->txt, term->font->width);
@@ -606,7 +606,7 @@ static bool terminal_update_size_scaled(struct kmscon_terminal *term)
 
 	terminal_update_size_clone(term);
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		unsigned int scaled_height;
 		unsigned int h, w;
@@ -623,7 +623,7 @@ static bool terminal_update_size_scaled(struct kmscon_terminal *term)
 			kmscon_text_set(scr->txt, term->font);
 		refresh_hw_cursor(scr);
 	}
-	return !shl_dlist_empty(&term->screens);
+	return !dlist_empty(&term->screens);
 }
 
 static bool terminal_update_size(struct kmscon_terminal *term)
@@ -641,7 +641,7 @@ static bool terminal_update_size(struct kmscon_terminal *term)
 	if (!ret)
 		return false;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		if (scr->enabled)
 			kmscon_text_resize(scr->txt, term->cols, term->rows);
@@ -675,7 +675,7 @@ static int font_set(struct kmscon_terminal *term)
 
 	term->cols = 0;
 	term->rows = 0;
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		ret = kmscon_text_set(scr->txt, font);
 		if (ret)
@@ -698,7 +698,7 @@ static void rotate_cw_all(struct kmscon_terminal *term)
 {
 	struct screen *scr;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		rotate_cw_screen(scr);
 	}
@@ -721,7 +721,7 @@ static void rotate_ccw_all(struct kmscon_terminal *term)
 {
 	struct screen *scr;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		rotate_ccw_screen(scr);
 	}
@@ -736,7 +736,7 @@ int terminal_add_display(struct kmscon_terminal *term, struct display *disp)
 	const char *be;
 	bool opengl;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		if (scr->disp == disp)
 			return 0;
@@ -776,7 +776,7 @@ int terminal_add_display(struct kmscon_terminal *term, struct display *disp)
 		goto err_text;
 	}
 
-	shl_dlist_link(&term->screens, &scr->list);
+	dlist_link(&term->screens, &scr->list);
 
 	log_notice("Display [%s] with backend [%s] text renderer [%s] font engine [%s]\n",
 		   display_name(disp), display_backend_name(disp), scr->txt->ops->name,
@@ -810,7 +810,7 @@ static void free_screen(struct screen *scr, bool update)
 	log_debug("destroying terminal screen %p", scr);
 	if (scr->hw_cursor)
 		display_destroy_cursor(scr->disp);
-	shl_dlist_unlink(&scr->list);
+	dlist_unlink(&scr->list);
 	kmscon_text_unref(scr->txt);
 	display_unregister_pageflip(scr->disp, display_pageflip, scr);
 	display_unref(scr->disp);
@@ -827,7 +827,7 @@ void terminal_rm_display(struct kmscon_terminal *term, struct display *disp)
 {
 	struct screen *scr;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		if (scr->disp == disp) {
 			log_debug("removed display %p from terminal %p", disp, term);
@@ -1065,7 +1065,7 @@ static void hw_cursor_show(struct kmscon_terminal *term, int32_t x, int32_t y)
 	int fw = term->font->width ? term->font->width : 1;
 	int fh = term->font->height ? term->font->height : 1;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		int32_t sx, sy;
 
@@ -1089,7 +1089,7 @@ static void hw_cursor_hide(struct kmscon_terminal *term)
 {
 	struct screen *scr;
 
-	shl_dlist_for_each_entry(scr, &term->screens, list)
+	dlist_for_each_entry(scr, &term->screens, list)
 	{
 		if (scr->hw_cursor)
 			display_hide_cursor(scr->disp);
@@ -1152,11 +1152,11 @@ static void pointer_event(struct input *input, struct input_pointer_event *ev, v
 
 static void rm_all_screens(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
+	struct dlist *iter;
 	struct screen *scr;
 
 	while ((iter = term->screens.next) != &term->screens) {
-		scr = shl_dlist_entry(iter, struct screen, list);
+		scr = dlist_entry(iter, struct screen, list);
 		free_screen(scr, false);
 	}
 
@@ -1221,7 +1221,7 @@ void terminal_refresh_displays(struct kmscon_terminal *term)
 void terminal_activate(struct kmscon_terminal *term)
 {
 	// Don't open pty yet if there are no screens.
-	if (shl_dlist_empty(&term->screens))
+	if (dlist_empty(&term->screens))
 		return;
 
 	term->awake = true;
@@ -1328,7 +1328,7 @@ struct kmscon_terminal *terminal_new(struct kmscon_session *session, unsigned in
 	term->session = session;
 	term->eloop = eloop;
 	term->input = input;
-	shl_dlist_init(&term->screens);
+	dlist_init(&term->screens);
 
 	term->conf_ctx = conf_ctx;
 	term->conf = conf_ctx_get_mem(term->conf_ctx);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -343,27 +343,23 @@ static void redraw_screen(struct screen *scr)
 
 static void redraw_all(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 
 	if (!term->awake)
 		return;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		redraw_screen(scr);
 	}
 }
 
 static bool has_kms_display(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		if (display_is_drm(scr->disp))
 			return true;
 	}
@@ -376,7 +372,6 @@ static bool has_kms_display(struct kmscon_terminal *term)
  */
 static void update_pointer_max_all(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 	unsigned int max_x = INT_MAX;
 	unsigned int max_y = INT_MAX;
@@ -385,9 +380,8 @@ static void update_pointer_max_all(struct kmscon_terminal *term)
 	if (!term->awake)
 		return;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		if (!scr->enabled)
 			continue;
 
@@ -408,21 +402,6 @@ static void update_pointer_max_all(struct kmscon_terminal *term)
 	}
 	if (max_x < INT_MAX && max_y < INT_MAX)
 		input_set_pointer_max(term->input, max_x, max_y);
-}
-
-static void redraw_all_text(struct kmscon_terminal *term)
-{
-	struct shl_dlist *iter;
-	struct screen *scr;
-
-	if (!term->awake)
-		return;
-
-	shl_dlist_for_each(iter, &term->screens)
-	{
-		scr = shl_dlist_entry(iter, struct screen, list);
-		redraw_screen(scr);
-	}
 }
 
 static void display_pageflip(void *unused, void *unused2, void *data)
@@ -519,15 +498,13 @@ static void mouse_event(struct tsm_vte *vte, enum tsm_mouse_track_mode track_mod
  */
 static bool terminal_update_size_clone(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 	unsigned int min_cols = UINT_MAX;
 	unsigned int min_rows = UINT_MAX;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
 		unsigned int cols, rows;
-		scr = shl_dlist_entry(iter, struct screen, list);
 		cols = kmscon_text_get_cols(scr->txt, term->font->width);
 		if (cols && cols < min_cols)
 			min_cols = cols;
@@ -554,14 +531,12 @@ static bool terminal_update_size_clone(struct kmscon_terminal *term)
  */
 static bool terminal_update_size_largest(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 	unsigned int rows, cols, cells;
 	unsigned int max_cells = 0;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		rows = kmscon_text_get_rows(scr->txt, term->font->height);
 		cols = kmscon_text_get_cols(scr->txt, term->font->width);
 		cells = rows * cols;
@@ -571,9 +546,8 @@ static bool terminal_update_size_largest(struct kmscon_terminal *term)
 			term->rows = rows;
 		}
 	}
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		rows = kmscon_text_get_rows(scr->txt, term->font->height);
 		cols = kmscon_text_get_cols(scr->txt, term->font->width);
 		if (rows != term->rows || cols != term->cols)
@@ -627,18 +601,16 @@ retry:
  */
 static bool terminal_update_size_scaled(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 	unsigned int height = term->font->height;
 
 	terminal_update_size_clone(term);
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
 		unsigned int scaled_height;
 		unsigned int h, w;
 
-		scr = shl_dlist_entry(iter, struct screen, list);
 		scr->scaled = false;
 
 		h = (kmscon_text_get_cols(scr->txt, term->font->width) * height) / term->cols;
@@ -651,12 +623,11 @@ static bool terminal_update_size_scaled(struct kmscon_terminal *term)
 			kmscon_text_set(scr->txt, term->font);
 		refresh_hw_cursor(scr);
 	}
-	return true;
+	return !shl_dlist_empty(&term->screens);
 }
 
 static bool terminal_update_size(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 	bool ret;
 
@@ -670,9 +641,8 @@ static bool terminal_update_size(struct kmscon_terminal *term)
 	if (!ret)
 		return false;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		if (scr->enabled)
 			kmscon_text_resize(scr->txt, term->cols, term->rows);
 	}
@@ -693,7 +663,6 @@ static int font_set(struct kmscon_terminal *term)
 {
 	int ret;
 	struct kmscon_font *font;
-	struct shl_dlist *iter;
 	struct screen *scr;
 
 	ret = kmscon_font_find(&font, term->conf->font_name, term->font_size,
@@ -706,10 +675,8 @@ static int font_set(struct kmscon_terminal *term)
 
 	term->cols = 0;
 	term->rows = 0;
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
-
 		ret = kmscon_text_set(scr->txt, font);
 		if (ret)
 			log_warning("cannot change text-renderer font: %d", ret);
@@ -729,12 +696,10 @@ static void rotate_cw_screen(struct screen *scr)
 
 static void rotate_cw_all(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		rotate_cw_screen(scr);
 	}
 	terminal_update_size_notify(term);
@@ -754,12 +719,10 @@ static void rotate_ccw_screen(struct screen *scr)
 
 static void rotate_ccw_all(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		rotate_ccw_screen(scr);
 	}
 	terminal_update_size_notify(term);
@@ -768,15 +731,13 @@ static void rotate_ccw_all(struct kmscon_terminal *term)
 
 int terminal_add_display(struct kmscon_terminal *term, struct display *disp)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 	int ret;
 	const char *be;
 	bool opengl;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		if (scr->disp == disp)
 			return 0;
 	}
@@ -864,21 +825,16 @@ static void free_screen(struct screen *scr, bool update)
 
 void terminal_rm_display(struct kmscon_terminal *term, struct display *disp)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
-		if (scr->disp == disp)
-			break;
+		if (scr->disp == disp) {
+			log_debug("removed display %p from terminal %p", disp, term);
+			free_screen(scr, true);
+			return;
+		}
 	}
-
-	if (iter == &term->screens)
-		return;
-
-	log_debug("removed display %p from terminal %p", disp, term);
-	free_screen(scr, true);
 }
 
 static void zoom_in(struct kmscon_terminal *term)
@@ -1105,16 +1061,14 @@ static void text_show_cursor(struct kmscon_text *txt, int32_t x, int32_t y)
 
 static void hw_cursor_show(struct kmscon_terminal *term, int32_t x, int32_t y)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 	int fw = term->font->width ? term->font->width : 1;
 	int fh = term->font->height ? term->font->height : 1;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
 		int32_t sx, sy;
 
-		scr = shl_dlist_entry(iter, struct screen, list);
 		if (scr->hw_cursor) {
 			if (!scr->scaled)
 				text_show_cursor(scr->txt, x, y);
@@ -1133,12 +1087,10 @@ static void hw_cursor_show(struct kmscon_terminal *term, int32_t x, int32_t y)
 
 static void hw_cursor_hide(struct kmscon_terminal *term)
 {
-	struct shl_dlist *iter;
 	struct screen *scr;
 
-	shl_dlist_for_each(iter, &term->screens)
+	shl_dlist_for_each_entry(scr, &term->screens, list)
 	{
-		scr = shl_dlist_entry(iter, struct screen, list);
 		if (scr->hw_cursor)
 			display_hide_cursor(scr->disp);
 	}
@@ -1263,7 +1215,7 @@ void terminal_refresh_displays(struct kmscon_terminal *term)
 {
 	if (term->pointer.visible)
 		hw_cursor_show(term, term->pointer.x, term->pointer.y);
-	redraw_all_text(term);
+	redraw_all(term);
 }
 
 void terminal_activate(struct kmscon_terminal *term)

--- a/src/uterm/monitor.c
+++ b/src/uterm/monitor.c
@@ -604,7 +604,7 @@ void uterm_monitor_ref(struct uterm_monitor *mon)
 SHL_EXPORT
 void uterm_monitor_unref(struct uterm_monitor *mon)
 {
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 	struct uterm_monitor_dev *dev;
 
 	if (!mon || !mon->ref || --mon->ref)
@@ -615,9 +615,8 @@ void uterm_monitor_unref(struct uterm_monitor *mon)
 	udev_unref(mon->udev);
 	ev_eloop_unref(mon->eloop);
 
-	shl_dlist_for_each_safe(iter, tmp, &mon->devices)
+	shl_dlist_for_each_entry_safe(dev, tmp, &mon->devices, list)
 	{
-		dev = shl_dlist_entry(iter, struct uterm_monitor_dev, list);
 		mon_free_dev(dev);
 	}
 

--- a/src/uterm/monitor.c
+++ b/src/uterm/monitor.c
@@ -48,7 +48,7 @@
 #define LOG_SUBSYSTEM "monitor"
 
 struct uterm_monitor_dev {
-	struct shl_dlist list;
+	struct dlist list;
 	struct uterm_monitor *mon;
 	unsigned int type;
 	unsigned int flags;
@@ -67,7 +67,7 @@ struct uterm_monitor {
 	struct ev_fd *umon_fd;
 
 	char *seat_name;
-	struct shl_dlist devices;
+	struct dlist devices;
 };
 
 static void mon_new_dev(struct uterm_monitor *mon, unsigned int type, unsigned int flags,
@@ -87,7 +87,7 @@ static void mon_new_dev(struct uterm_monitor *mon, unsigned int type, unsigned i
 	if (!dev->node)
 		goto err_free;
 
-	shl_dlist_link(&mon->devices, &dev->list);
+	dlist_link(&mon->devices, &dev->list);
 
 	mon->cb.new_dev(node, type, flags, mon->data, dev);
 
@@ -102,7 +102,7 @@ static void mon_free_dev(struct uterm_monitor_dev *dev)
 {
 	log_debug("free device %s on %s", dev->node, dev->mon->seat_name);
 
-	shl_dlist_unlink(&dev->list);
+	dlist_unlink(&dev->list);
 
 	dev->mon->cb.free_dev(dev->mon->data, dev->type, dev->data);
 
@@ -120,7 +120,7 @@ static struct uterm_monitor_dev *monitor_find_dev(struct uterm_monitor *mon,
 	if (!node)
 		return NULL;
 
-	shl_dlist_for_each_entry(sdev, &mon->devices, list)
+	dlist_for_each_entry(sdev, &mon->devices, list)
 	{
 		if (!strcmp(node, sdev->node))
 			return sdev;
@@ -505,7 +505,7 @@ int uterm_monitor_new(struct uterm_monitor **out, struct ev_eloop *eloop,
 	mon->eloop = eloop;
 	mon->cb = *cb;
 	mon->data = data;
-	shl_dlist_init(&mon->devices);
+	dlist_init(&mon->devices);
 
 	mon->udev = udev_new();
 	if (!mon->udev) {
@@ -604,7 +604,7 @@ void uterm_monitor_ref(struct uterm_monitor *mon)
 SHL_EXPORT
 void uterm_monitor_unref(struct uterm_monitor *mon)
 {
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 	struct uterm_monitor_dev *dev;
 
 	if (!mon || !mon->ref || --mon->ref)
@@ -615,7 +615,7 @@ void uterm_monitor_unref(struct uterm_monitor *mon)
 	udev_unref(mon->udev);
 	ev_eloop_unref(mon->eloop);
 
-	shl_dlist_for_each_entry_safe(dev, tmp, &mon->devices, list)
+	dlist_for_each_entry_safe(dev, tmp, &mon->devices, list)
 	{
 		mon_free_dev(dev);
 	}

--- a/src/uterm/monitor.c
+++ b/src/uterm/monitor.c
@@ -114,16 +114,14 @@ static struct uterm_monitor_dev *monitor_find_dev(struct uterm_monitor *mon,
 						  struct udev_device *dev)
 {
 	const char *node;
-	struct shl_dlist *iter;
 	struct uterm_monitor_dev *sdev;
 
 	node = udev_device_get_devnode(dev);
 	if (!node)
 		return NULL;
 
-	shl_dlist_for_each(iter, &mon->devices)
+	shl_dlist_for_each_entry(sdev, &mon->devices, list)
 	{
-		sdev = shl_dlist_entry(iter, struct uterm_monitor_dev, list);
 		if (!strcmp(node, sdev->node))
 			return sdev;
 	}

--- a/src/video/drm2d_video.c
+++ b/src/video/drm2d_video.c
@@ -251,7 +251,7 @@ static void show_displays(struct video *video)
 	if (!video_is_awake(video))
 		return;
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		if (!display_is_online(disp))
 			continue;

--- a/src/video/drm2d_video.c
+++ b/src/video/drm2d_video.c
@@ -41,6 +41,7 @@
 #include <xf86drmMode.h>
 #include "drm2d_internal.h"
 #include "drm_shared_internal.h"
+#include "shl/dlist.h"
 #include "shl/log.h"
 #include "video.h"
 #include "video_internal.h"
@@ -243,21 +244,18 @@ static const struct display_ops drm2d_display_ops = {
 
 static void show_displays(struct video *video)
 {
-	struct display *iter;
+	struct display *disp;
 	struct drm2d_display *d2d;
 	struct drm2d_rb *rb;
-	struct shl_dlist *i;
 
 	if (!video_is_awake(video))
 		return;
 
-	shl_dlist_for_each(i, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		iter = shl_dlist_entry(i, struct display, list);
-
-		if (!display_is_online(iter))
+		if (!display_is_online(disp))
 			continue;
-		if (iter->dpms != DPMS_ON)
+		if (disp->dpms != DPMS_ON)
 			continue;
 
 		/* We use double-buffering so there might be no free back-buffer
@@ -266,10 +264,10 @@ static void show_displays(struct video *video)
 		 * tearing but that's acceptable as this is only called during
 		 * wakeup/sleep. */
 
-		d2d = iter->data;
+		d2d = disp->data;
 		rb = &d2d->rb[d2d->current_rb];
 		memset(rb->map, 0, rb->size);
-		drm_display_wait_pflip(iter);
+		drm_display_wait_pflip(disp);
 	}
 }
 

--- a/src/video/drm3d_video.c
+++ b/src/video/drm3d_video.c
@@ -46,6 +46,7 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include "drm_shared_internal.h"
+#include "shl/dlist.h"
 #include "shl/log.h"
 #include "shl/misc.h"
 #include "video.h"
@@ -443,28 +444,25 @@ static const struct display_ops drm_display_ops = {
 static void show_displays(struct video *video)
 {
 	int ret;
-	struct display *iter;
-	struct shl_dlist *i;
+	struct display *disp;
 
 	if (!video_is_awake(video))
 		return;
 
-	shl_dlist_for_each(i, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		iter = shl_dlist_entry(i, struct display, list);
-
-		if (!display_is_online(iter))
+		if (!display_is_online(disp))
 			continue;
-		if (iter->dpms != DPMS_ON)
+		if (disp->dpms != DPMS_ON)
 			continue;
 
-		ret = drm3d_display_use(iter);
+		ret = drm3d_display_use(disp);
 		if (ret)
 			continue;
 
 		glClearColor(0, 0, 0, 1);
 		glClear(GL_COLOR_BUFFER_BIT);
-		display_swap(iter);
+		display_swap(disp);
 	}
 }
 

--- a/src/video/drm3d_video.c
+++ b/src/video/drm3d_video.c
@@ -449,7 +449,7 @@ static void show_displays(struct video *video)
 	if (!video_is_awake(video))
 		return;
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		if (!display_is_online(disp))
 			continue;

--- a/src/video/drm_shared.c
+++ b/src/video/drm_shared.c
@@ -1437,7 +1437,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 	struct display *disp;
 	struct drm_display *ddrm;
 	int ret, i, dpms;
-	struct shl_dlist *iter, *tmp;
+	struct shl_dlist *tmp;
 	bool needs_modeset = modeset;
 	bool found = false;
 
@@ -1501,9 +1501,8 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 
 	drmModeFreeResources(res);
 
-	shl_dlist_for_each_safe(iter, tmp, &video->displays)
+	shl_dlist_for_each_entry_safe(disp, tmp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		if (!(disp->flags & DISPLAY_AVAILABLE))
 			display_unbind(disp);
 	}

--- a/src/video/drm_shared.c
+++ b/src/video/drm_shared.c
@@ -144,13 +144,11 @@ static int set_drm_object_property(drmModeAtomicReq *req, struct drm_object *obj
 
 static bool is_crtc_in_use(struct video *video, uint32_t crtc_id)
 {
-	struct shl_dlist *iter;
 	struct display *disp;
 	struct drm_display *ddrm;
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		ddrm = disp->data;
 		if (ddrm->crtc.id == crtc_id)
 			return true;
@@ -855,7 +853,6 @@ int drm_display_wait_pflip(struct display *disp)
 static int perform_modeset(struct video *video)
 {
 	drmModeAtomicReq *req;
-	struct shl_dlist *iter;
 	struct drm_video *vdrm = video->data;
 	struct display *disp;
 	struct drm_display *ddrm;
@@ -872,9 +869,8 @@ static int perform_modeset(struct video *video)
 
 	modeset_clear_cursor(req, vdrm->fd);
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		ddrm = disp->data;
 
 		drm_display_wait_pflip(disp);
@@ -901,9 +897,8 @@ static int perform_modeset(struct video *video)
 		goto err_commit;
 	}
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		display_ref(disp);
 	}
 	refs_taken = true;
@@ -918,11 +913,10 @@ err_commit:
 	drmModeAtomicFree(req);
 
 	i = 0;
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
 		if (i++ >= num_prepared)
 			break;
-		disp = shl_dlist_entry(iter, struct display, list);
 		ddrm = disp->data;
 		ddrm->done_modeset(disp, ret);
 		if (ret) {
@@ -937,14 +931,12 @@ err_commit:
 static int legacy_modeset(struct video *video)
 {
 	struct drm_video *vdrm = video->data;
-	struct shl_dlist *iter;
 	struct display *disp;
 	struct drm_display *ddrm;
 	int ret;
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		ddrm = disp->data;
 
 		drm_display_wait_pflip(disp);
@@ -975,7 +967,6 @@ static int legacy_modeset(struct video *video)
 
 static int try_modeset(struct video *video)
 {
-	struct shl_dlist *iter;
 	struct display *disp;
 	struct drm_display *ddrm;
 	struct drm_video *vdrm = video->data;
@@ -993,9 +984,8 @@ static int try_modeset(struct video *video)
 		return ret;
 
 	/* Retry with default mode for all display */
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		ddrm = disp->data;
 		ddrm->previous_mode = ddrm->current_mode;
 		ddrm->current_mode = &ddrm->default_mode;
@@ -1005,9 +995,8 @@ static int try_modeset(struct video *video)
 	else
 		ret = perform_modeset(video);
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		ddrm = disp->data;
 		if (ret)
 			ddrm->current_mode = ddrm->previous_mode;
@@ -1109,13 +1098,11 @@ static void display_event(int fd, unsigned int frame, unsigned int sec, unsigned
 			  unsigned int crtc_id, void *data)
 {
 	struct video *video = data;
-	struct shl_dlist *iter;
 	struct display *disp;
 	struct drm_display *ddrm;
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		ddrm = disp->data;
 		if (ddrm->crtc.id == crtc_id) {
 			if (disp->flags & DISPLAY_VSYNC)
@@ -1154,11 +1141,9 @@ static void do_pflips(struct ev_eloop *eloop, void *unused, void *data)
 {
 	struct video *video = data;
 	struct display *disp;
-	struct shl_dlist *iter;
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		if ((disp->flags & DISPLAY_PFLIP))
 			drm_display_pflip(disp);
 	}
@@ -1169,7 +1154,6 @@ static void io_event(struct ev_fd *fd, int mask, void *data)
 	struct video *video = data;
 	struct drm_video *vdrm = video->data;
 	struct display *disp;
-	struct shl_dlist *iter;
 	int ret;
 
 	/* TODO: forward HUP to caller */
@@ -1187,9 +1171,8 @@ static void io_event(struct ev_fd *fd, int mask, void *data)
 	if (ret)
 		return;
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		if ((disp->flags & DISPLAY_PFLIP))
 			drm_display_pflip(disp);
 	}
@@ -1200,15 +1183,13 @@ static void vt_timeout(struct ev_timer *timer, uint64_t exp, void *data)
 	struct video *video = data;
 	struct drm_video *vdrm = video->data;
 	struct display *disp;
-	struct shl_dlist *iter;
 	int r;
 
 	r = drm_video_wake_up(video);
 	if (!r) {
 		ev_timer_update(vdrm->vt_timer, NULL);
-		shl_dlist_for_each(iter, &video->displays)
+		shl_dlist_for_each_entry(disp, &video->displays, list)
 		{
-			disp = shl_dlist_entry(iter, struct display, list);
 			disp->video->cb->refresh_disp(disp->video->cb_data, disp);
 		}
 	}
@@ -1458,6 +1439,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 	int ret, i, dpms;
 	struct shl_dlist *iter, *tmp;
 	bool needs_modeset = modeset;
+	bool found = false;
 
 	if (!video_is_awake(video) || !video_need_hotplug(video))
 		return 0;
@@ -1470,9 +1452,8 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 		return -EACCES;
 	}
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		disp->flags &= ~DISPLAY_AVAILABLE;
 	}
 
@@ -1485,9 +1466,8 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 			continue;
 		}
 
-		shl_dlist_for_each(iter, &video->displays)
+		shl_dlist_for_each_entry(disp, &video->displays, list)
 		{
-			disp = shl_dlist_entry(iter, struct display, list);
 			ddrm = disp->data;
 
 			if (ddrm->connector.id != res->connectors[i])
@@ -1497,6 +1477,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 
 			if (!display_is_online(disp)) {
 				needs_modeset = true;
+				found = true;
 				break;
 			}
 
@@ -1507,10 +1488,11 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 					drm_display_set_dpms(disp, disp->dpms);
 				}
 			}
+			found = true;
 			break;
 		}
 
-		if (iter == &video->displays) {
+		if (!found) {
 			needs_modeset = true;
 			bind_display(video, res, conn);
 		}
@@ -1536,9 +1518,8 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 		if (ret)
 			return ret;
 	}
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		disp = shl_dlist_entry(iter, struct display, list);
 		display_ready(disp);
 	}
 
@@ -1567,14 +1548,12 @@ int drm_video_wake_up(struct video *video)
 void drm_video_sleep(struct video *video)
 {
 	struct drm_video *vdrm = video->data;
-	struct shl_dlist *iter;
 	struct display *disp;
 	drmModeAtomicReq *req;
 
 	if (vdrm->master && !vdrm->legacy) {
-		shl_dlist_for_each(iter, &video->displays)
+		shl_dlist_for_each_entry(disp, &video->displays, list)
 		{
-			disp = shl_dlist_entry(iter, struct display, list);
 			drm_display_wait_pflip(disp);
 		}
 

--- a/src/video/drm_shared.c
+++ b/src/video/drm_shared.c
@@ -147,7 +147,7 @@ static bool is_crtc_in_use(struct video *video, uint32_t crtc_id)
 	struct display *disp;
 	struct drm_display *ddrm;
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		ddrm = disp->data;
 		if (ddrm->crtc.id == crtc_id)
@@ -869,7 +869,7 @@ static int perform_modeset(struct video *video)
 
 	modeset_clear_cursor(req, vdrm->fd);
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		ddrm = disp->data;
 
@@ -897,7 +897,7 @@ static int perform_modeset(struct video *video)
 		goto err_commit;
 	}
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		display_ref(disp);
 	}
@@ -913,7 +913,7 @@ err_commit:
 	drmModeAtomicFree(req);
 
 	i = 0;
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		if (i++ >= num_prepared)
 			break;
@@ -935,7 +935,7 @@ static int legacy_modeset(struct video *video)
 	struct drm_display *ddrm;
 	int ret;
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		ddrm = disp->data;
 
@@ -980,11 +980,11 @@ static int try_modeset(struct video *video)
 	if (ret != -EAGAIN)
 		return ret;
 
-	if (shl_dlist_empty(&video->displays))
+	if (dlist_empty(&video->displays))
 		return ret;
 
 	/* Retry with default mode for all display */
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		ddrm = disp->data;
 		ddrm->previous_mode = ddrm->current_mode;
@@ -995,7 +995,7 @@ static int try_modeset(struct video *video)
 	else
 		ret = perform_modeset(video);
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		ddrm = disp->data;
 		if (ret)
@@ -1101,7 +1101,7 @@ static void display_event(int fd, unsigned int frame, unsigned int sec, unsigned
 	struct display *disp;
 	struct drm_display *ddrm;
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		ddrm = disp->data;
 		if (ddrm->crtc.id == crtc_id) {
@@ -1142,7 +1142,7 @@ static void do_pflips(struct ev_eloop *eloop, void *unused, void *data)
 	struct video *video = data;
 	struct display *disp;
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		if ((disp->flags & DISPLAY_PFLIP))
 			drm_display_pflip(disp);
@@ -1171,7 +1171,7 @@ static void io_event(struct ev_fd *fd, int mask, void *data)
 	if (ret)
 		return;
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		if ((disp->flags & DISPLAY_PFLIP))
 			drm_display_pflip(disp);
@@ -1188,7 +1188,7 @@ static void vt_timeout(struct ev_timer *timer, uint64_t exp, void *data)
 	r = drm_video_wake_up(video);
 	if (!r) {
 		ev_timer_update(vdrm->vt_timer, NULL);
-		shl_dlist_for_each_entry(disp, &video->displays, list)
+		dlist_for_each_entry(disp, &video->displays, list)
 		{
 			disp->video->cb->refresh_disp(disp->video->cb_data, disp);
 		}
@@ -1437,7 +1437,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 	struct display *disp;
 	struct drm_display *ddrm;
 	int ret, i, dpms;
-	struct shl_dlist *tmp;
+	struct dlist *tmp;
 	bool needs_modeset = modeset;
 	bool found = false;
 
@@ -1452,7 +1452,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 		return -EACCES;
 	}
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		disp->flags &= ~DISPLAY_AVAILABLE;
 	}
@@ -1466,7 +1466,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 			continue;
 		}
 
-		shl_dlist_for_each_entry(disp, &video->displays, list)
+		dlist_for_each_entry(disp, &video->displays, list)
 		{
 			ddrm = disp->data;
 
@@ -1501,12 +1501,12 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 
 	drmModeFreeResources(res);
 
-	shl_dlist_for_each_entry_safe(disp, tmp, &video->displays, list)
+	dlist_for_each_entry_safe(disp, tmp, &video->displays, list)
 	{
 		if (!(disp->flags & DISPLAY_AVAILABLE))
 			display_unbind(disp);
 	}
-	if (shl_dlist_empty(&video->displays)) {
+	if (dlist_empty(&video->displays)) {
 		// If there are no display available, drop drm master
 		drop_drm_master(vdrm);
 		goto finish_hotplug;
@@ -1517,7 +1517,7 @@ int drm_video_hotplug(struct video *video, bool read_dpms, bool modeset)
 		if (ret)
 			return ret;
 	}
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		display_ready(disp);
 	}
@@ -1551,7 +1551,7 @@ void drm_video_sleep(struct video *video)
 	drmModeAtomicReq *req;
 
 	if (vdrm->master && !vdrm->legacy) {
-		shl_dlist_for_each_entry(disp, &video->displays, list)
+		dlist_for_each_entry(disp, &video->displays, list)
 		{
 			drm_display_wait_pflip(disp);
 		}

--- a/src/video/fbdev_video.c
+++ b/src/video/fbdev_video.c
@@ -504,7 +504,7 @@ static void fb_video_sleep(struct video *video)
 {
 	struct display *disp;
 
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		if (!display_is_online(disp))
 			continue;
@@ -519,7 +519,7 @@ static int fb_video_wake_up(struct video *video)
 	int ret;
 
 	video->flags |= VIDEO_AWAKE;
-	shl_dlist_for_each_entry(disp, &video->displays, list)
+	dlist_for_each_entry(disp, &video->displays, list)
 	{
 		if (!display_is_online(disp)) {
 			ret = display_activate_force(disp, false);

--- a/src/video/fbdev_video.c
+++ b/src/video/fbdev_video.c
@@ -37,6 +37,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #include "fbdev_internal.h"
+#include "shl/dlist.h"
 #include "shl/log.h"
 #include "video.h"
 #include "video_internal.h"
@@ -501,43 +502,37 @@ static void fb_video_destroy(struct video *video)
 
 static void fb_video_sleep(struct video *video)
 {
-	struct display *iter;
-	struct shl_dlist *i;
+	struct display *disp;
 
-	shl_dlist_for_each(i, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		iter = shl_dlist_entry(i, struct display, list);
-
-		if (!display_is_online(iter))
+		if (!display_is_online(disp))
 			continue;
 
-		display_deactivate_force(iter, true);
+		display_deactivate_force(disp, true);
 	}
 }
 
 static int fb_video_wake_up(struct video *video)
 {
-	struct display *iter;
-	struct shl_dlist *i;
+	struct display *disp;
 	int ret;
 
 	video->flags |= VIDEO_AWAKE;
-	shl_dlist_for_each(i, &video->displays)
+	shl_dlist_for_each_entry(disp, &video->displays, list)
 	{
-		iter = shl_dlist_entry(i, struct display, list);
-
-		if (!display_is_online(iter)) {
-			ret = display_activate_force(iter, false);
+		if (!display_is_online(disp)) {
+			ret = display_activate_force(disp, false);
 			if (ret)
 				return ret;
 		}
 
-		ret = display_activate_force(iter, true);
+		ret = display_activate_force(disp, true);
 		if (ret)
 			return ret;
 
-		if (iter->dpms != DPMS_UNKNOWN)
-			display_set_dpms(iter, iter->dpms);
+		if (disp->dpms != DPMS_UNKNOWN)
+			display_set_dpms(disp, disp->dpms);
 	}
 
 	return 0;

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -138,7 +138,7 @@ int display_bind(struct display *disp)
 	if (!disp || !disp->video)
 		return -EINVAL;
 
-	shl_dlist_link_tail(&disp->video->displays, &disp->list);
+	dlist_link_tail(&disp->video->displays, &disp->list);
 	display_ref(disp);
 
 	return 0;
@@ -161,7 +161,7 @@ void display_unbind(struct display *disp)
 		return;
 	if (disp->flags & DISPLAY_INUSE)
 		disp->video->cb->remove_disp(disp->video->cb_data, disp);
-	shl_dlist_unlink(&disp->list);
+	dlist_unlink(&disp->list);
 	display_unref(disp);
 }
 
@@ -450,7 +450,7 @@ int video_new(struct video **out, struct ev_eloop *eloop, int fd, const char *ba
 	video->cb_data = data;
 
 	video->eloop = eloop;
-	shl_dlist_init(&video->displays);
+	dlist_init(&video->displays);
 
 	ret = video->ops->init(video, fd);
 	if (ret)
@@ -490,8 +490,8 @@ void video_unref(struct video *video)
 
 	log_info("free device %p", video);
 
-	while (!shl_dlist_empty(&video->displays)) {
-		disp = shl_dlist_entry(video->displays.prev, struct display, list);
+	while (!dlist_empty(&video->displays)) {
+		disp = dlist_entry(video->displays.prev, struct display, list);
 		display_unbind(disp);
 	}
 

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -484,14 +484,15 @@ SHL_EXPORT
 void video_unref(struct video *video)
 {
 	struct display *disp;
+	struct dlist *tmp;
 
 	if (!video || !video->ref || --video->ref)
 		return;
 
 	log_info("free device %p", video);
 
-	while (!dlist_empty(&video->displays)) {
-		disp = dlist_entry(video->displays.prev, struct display, list);
+	dlist_for_each_entry_safe(disp, tmp, &video->displays, list)
+	{
 		display_unbind(disp);
 	}
 

--- a/src/video/video_internal.h
+++ b/src/video/video_internal.h
@@ -84,7 +84,7 @@ struct video_ops {
 
 struct display {
 	char *name;
-	struct shl_dlist list;
+	struct dlist list;
 	unsigned long ref;
 	unsigned int flags;
 	unsigned int width;
@@ -123,7 +123,7 @@ struct video {
 	struct ev_eloop *eloop;
 	struct shl_register_record *record;
 
-	struct shl_dlist displays;
+	struct dlist displays;
 	struct video_cb *cb;
 	void *cb_data;
 

--- a/tests/test_output.c
+++ b/tests/test_output.c
@@ -67,23 +67,19 @@ struct {
 
 static int blit_outputs(struct video *video)
 {
-	struct shl_dlist *iter;
 	struct display *display;
 	int ret;
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(display, &video->displays, list)
 	{
-		display = shl_dlist_entry(iter, struct display, list);
 		log_notice("Activating display %s...", display_name(display));
 		ret = display_set_dpms(display, DPMS_ON);
 		if (ret)
 			log_err("Cannot set DPMS to ON: %d", ret);
 	}
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(display, &video->displays, list)
 	{
-		display = shl_dlist_entry(iter, struct display, list);
-
 		if (display_get_state(display) != DISPLAY_ACTIVE)
 			continue;
 
@@ -99,7 +95,7 @@ static int blit_outputs(struct video *video)
 			continue;
 		}
 
-		log_notice("Successfully set screen on display %p", iter);
+		log_notice("Successfully set screen on display %p", display);
 	}
 
 	log_notice("Waiting 5 seconds...");
@@ -111,14 +107,12 @@ static int blit_outputs(struct video *video)
 
 static int list_outputs(struct video *video)
 {
-	struct shl_dlist *iter;
 	struct display *display;
 
 	log_notice("List of Outputs:");
 
-	shl_dlist_for_each(iter, &video->displays)
+	shl_dlist_for_each_entry(display, &video->displays, list)
 	{
-		display = shl_dlist_entry(iter, struct display, list);
 		log_notice(" display %s active %d", display->name, display_get_state(display));
 	}
 	log_notice("End of Output list");

--- a/tests/test_output.c
+++ b/tests/test_output.c
@@ -70,7 +70,7 @@ static int blit_outputs(struct video *video)
 	struct display *display;
 	int ret;
 
-	shl_dlist_for_each_entry(display, &video->displays, list)
+	dlist_for_each_entry(display, &video->displays, list)
 	{
 		log_notice("Activating display %s...", display_name(display));
 		ret = display_set_dpms(display, DPMS_ON);
@@ -78,7 +78,7 @@ static int blit_outputs(struct video *video)
 			log_err("Cannot set DPMS to ON: %d", ret);
 	}
 
-	shl_dlist_for_each_entry(display, &video->displays, list)
+	dlist_for_each_entry(display, &video->displays, list)
 	{
 		if (display_get_state(display) != DISPLAY_ACTIVE)
 			continue;
@@ -111,7 +111,7 @@ static int list_outputs(struct video *video)
 
 	log_notice("List of Outputs:");
 
-	shl_dlist_for_each_entry(display, &video->displays, list)
+	dlist_for_each_entry(display, &video->displays, list)
 	{
 		log_notice(" display %s active %d", display->name, display_get_state(display));
 	}


### PR DESCRIPTION
Rename dlist macros, and use dlist_for_each_entry() to simplify list traversal.